### PR TITLE
catch exception as ref

### DIFF
--- a/deps/args/args/args.hxx
+++ b/deps/args/args/args.hxx
@@ -1562,7 +1562,7 @@ namespace args
                     {
                         parserCoroutine(coro.Parser());
                     }
-                    catch (args::SubparserError)
+                    catch (args::SubparserError&)
                     {
                     }
 #else


### PR DESCRIPTION
args is not a submodule.
IMHO should be const ref, but is fixed in the orignal lib as ref.
see commit 285168d on May 4, 2018