### PR TITLE
catch exceptions as const ref in demo_app

### DIFF
--- a/examples/demo-app/demo_app.cpp
+++ b/examples/demo-app/demo_app.cpp
@@ -349,10 +349,10 @@ int main(int argc, char** argv) {
   // Parse args
   try {
     parser.ParseCLI(argc, argv);
-  } catch (args::Help) {
+  } catch (const args::Help&) {
     std::cout << parser;
     return 0;
-  } catch (args::ParseError e) {
+  } catch (const args::ParseError& e) {
     std::cerr << e.what() << std::endl;
 
     std::cerr << parser;


### PR DESCRIPTION
Don't catch (polymorphic) exceptions as value. -> slicing
see also GCC warning: -Werror=catch-value