### PR TITLE
add function to update curve network geometry

### DIFF
--- a/include/polyscope/curve_network.h
+++ b/include/polyscope/curve_network.h
@@ -116,6 +116,9 @@ public:
   glm::vec3 baseColor;
   float radius = 0.001;
 
+  // === Mutate
+  void updateNodePositions(const std::vector<glm::vec3>& newPositions);
+
 private:
   // Drawing related things
   // if nullptr, prepare() (resp. preparePick()) needs to be called

--- a/src/curve_network.cpp
+++ b/src/curve_network.cpp
@@ -319,6 +319,18 @@ std::tuple<glm::vec3, glm::vec3> CurveNetwork::boundingBox() {
 
 std::string CurveNetwork::typeName() { return structureTypeName; }
 
+void CurveNetwork::updateNodePositions(const std::vector<glm::vec3>& newPositions)
+{
+	nodes = newPositions;
+
+	nodeProgram.reset();
+	edgeProgram.reset();
+
+  for (auto& q : quantities) {
+    q.second->geometryChanged();
+  }
+}
+
 // === Quantities
 
 CurveNetworkQuantity::CurveNetworkQuantity(std::string name_, CurveNetwork& curveNetwork_, bool dominates_)


### PR DESCRIPTION
add the method updateNodePositions in CurveNetwork
it is intended to work in the same way as SurfaceMesh::updateVertexPositions i.e. update geometry and reset gl programs to update the view