### PR TITLE
Fixed off-by-one error in permutation setters

### DIFF
--- a/include/polyscope/surface_mesh.ipp
+++ b/include/polyscope/surface_mesh.ipp
@@ -112,7 +112,7 @@ void SurfaceMesh::setVertexPermutation(const T& perm, size_t expectedSize) {
   if (vertexDataSize == 0) {
     // Find max element to set the data size
     for (size_t i : vertexPerm) {
-      vertexDataSize = std::max(vertexDataSize, i);
+      vertexDataSize = std::max(vertexDataSize, i+1);
     }
   }
 }
@@ -127,7 +127,7 @@ void SurfaceMesh::setFacePermutation(const T& perm, size_t expectedSize) {
   if (faceDataSize == 0) {
     // Find max element to set the data size
     for (size_t i : facePerm) {
-      faceDataSize = std::max(faceDataSize, i);
+      faceDataSize = std::max(faceDataSize, i+1);
     }
   }
 }
@@ -142,7 +142,7 @@ void SurfaceMesh::setEdgePermutation(const T& perm, size_t expectedSize) {
   if (edgeDataSize == 0) {
     // Find max element to set the data size
     for (size_t i : edgePerm) {
-      edgeDataSize = std::max(edgeDataSize, i);
+      edgeDataSize = std::max(edgeDataSize, i+1);
     }
   }
 }
@@ -157,7 +157,7 @@ void SurfaceMesh::setHalfedgePermutation(const T& perm, size_t expectedSize) {
   if (halfedgeDataSize == 0) {
     // Find max element to set the data size
     for (size_t i : halfedgePerm) {
-      halfedgeDataSize = std::max(halfedgeDataSize, i);
+      halfedgeDataSize = std::max(halfedgeDataSize, i+1);
     }
   }
 }
@@ -172,7 +172,7 @@ void SurfaceMesh::setCornerPermutation(const T& perm, size_t expectedSize) {
   if (cornerDataSize == 0) {
     // Find max element to set the data size
     for (size_t i : cornerPerm) {
-      cornerDataSize = std::max(cornerDataSize, i);
+      cornerDataSize = std::max(cornerDataSize, i+1);
     }
   }
 }


### PR DESCRIPTION
The size of the index space for a permutation should be the maximum
entry of the permutation plus one, since permutations are zero-indexed.