### PR TITLE
Simple Solo Toggle for same type structures

### DIFF
--- a/include/polyscope/structure.h
+++ b/include/polyscope/structure.h
@@ -56,7 +56,8 @@ public:
   virtual Structure* setEnabled(bool newEnabled);
   bool isEnabled();
   virtual std::string typeName() = 0;
-
+  void solo();
+  
   // = Scene transform
   glm::mat4 objectTransform = glm::mat4(1.0);
   glm::mat4 getModelView();

--- a/include/polyscope/view.h
+++ b/include/polyscope/view.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <array>
+#include <string>
 
 #include "polyscope/camera_parameters.h"
 //#include "polyscope/gl/gl_utils.h"

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -39,6 +39,9 @@ void Structure::buildUI() {
     }
     if (ImGui::BeginPopup("OptionsPopup")) {
 
+      // Solo
+      if (ImGui::MenuItem("Solo toggle")) solo();
+      
       // Transform
       if (ImGui::BeginMenu("Transform")) {
         if (ImGui::MenuItem("Center")) centerBoundingBox();
@@ -106,6 +109,12 @@ std::string Structure::uniquePrefix() { return typeName() + "#" + name + "#"; }
 
 void Structure::remove() {
   removeStructure(typeName(), name);
+}
+
+void Structure::solo() {
+    for(auto &structure: polyscope::state::structures[this->typeName()])
+        structure.second->setEnabled(!structure.second->isEnabled());
+    this->setEnabled(true);
 }
 
 } // namespace polyscope


### PR DESCRIPTION
When you pile a bunch of structures, the solo toggle allows you to quickly check on specific structure by toggling  all other structures of the same type.

![solo](https://user-images.githubusercontent.com/700165/82032543-a88afe00-969b-11ea-8f2c-5a8a3577e325.gif)

(I could have saved the other structures state, turn them off and restore their state when needed but that would mean a new class member map which may not be necessary.. what do you think?)