### PR TITLE
Adding the ability to use individual radii on point sets

### DIFF
--- a/include/polyscope/point_cloud_scalar_quantity.h
+++ b/include/polyscope/point_cloud_scalar_quantity.h
@@ -48,6 +48,7 @@ protected:
 
   // UI internals
   PersistentValue<std::string> cMap;
+  PersistentValue<bool> valueAsRadius;
 
 
   void createPointProgram();

--- a/src/curve_network.cpp
+++ b/src/curve_network.cpp
@@ -56,6 +56,9 @@ void CurveNetwork::setCurveNetworkNodeUniforms(render::ShaderProgram& p) {
   p.setUniform("u_invProjMatrix", glm::value_ptr(Pinv));
   p.setUniform("u_viewport", render::engine->getCurrentViewport());
   p.setUniform("u_pointRadius", getRadius());
+  if(p.hasUniform("u_valueAsRadius")) {
+    p.setUniform("u_valueAsRadius", (unsigned int)false);
+  }
 }
 
 void CurveNetwork::setCurveNetworkEdgeUniforms(render::ShaderProgram& p) {

--- a/src/point_cloud_scalar_quantity.cpp
+++ b/src/point_cloud_scalar_quantity.cpp
@@ -12,7 +12,8 @@ namespace polyscope {
 PointCloudScalarQuantity::PointCloudScalarQuantity(std::string name, const std::vector<double>& values_,
                                                    PointCloud& pointCloud_, DataType dataType_)
     : PointCloudQuantity(name, pointCloud_, true), dataType(dataType_),
-      cMap(uniquePrefix() + "#cmap", defaultColorMap(dataType))
+      cMap(uniquePrefix() + "#cmap", defaultColorMap(dataType)),
+      valueAsRadius(uniquePrefix() + "#valueAsRadius", false)
 
 {
   if (values_.size() != parent.points.size()) {
@@ -44,6 +45,7 @@ void PointCloudScalarQuantity::draw() {
   parent.setPointCloudUniforms(*pointProgram);
   pointProgram->setUniform("u_rangeLow", vizRange.first);
   pointProgram->setUniform("u_rangeHigh", vizRange.second);
+  pointProgram->setUniform("u_valueAsRadius", (unsigned int) valueAsRadius.get()) ;
 
   pointProgram->draw();
 }
@@ -68,6 +70,9 @@ PointCloudScalarQuantity* PointCloudScalarQuantity::resetMapRange() {
 
 void PointCloudScalarQuantity::buildCustomUI() {
   ImGui::SameLine();
+
+  // == Using as radius
+  ImGui::Checkbox("Use as radius", &valueAsRadius.get()) ;
 
   // == Options popup
   if (ImGui::Button("Options")) {

--- a/src/surface_count_quantity.cpp
+++ b/src/surface_count_quantity.cpp
@@ -66,6 +66,7 @@ void SurfaceCountQuantity::setUniforms(render::ShaderProgram& p) {
   p.setUniform("u_viewport", render::engine->getCurrentViewport());
 
   p.setUniform("u_pointRadius", pointRadius * state::lengthScale);
+  p.setUniform("u_valueAsRadius", (unsigned int)false);
   p.setUniform("u_rangeLow", vizRangeLow);
   p.setUniform("u_rangeHigh", vizRangeHigh);
 }


### PR DESCRIPTION
this is a quick hack to be able to use a scalar attribute on a point set to define the radii of the points. This was usefull to me to visualize sets of balls. In its current state it is not possible to use another scalar attribute for colors.

![image](https://user-images.githubusercontent.com/16121552/95763212-0c4b3e80-0caf-11eb-95c5-59ee8478d2aa.png)
