### PR TITLE
Fix bug in FaceCountQuantity

### DIFF
--- a/include/polyscope/surface_count_quantity.h
+++ b/include/polyscope/surface_count_quantity.h
@@ -29,15 +29,24 @@ public:
   const std::string descriptiveType; // ("vertex count", etc)
   std::shared_ptr<render::ShaderProgram> program;
 
-  // TODO use persistent/scaled quantities
-  float pointRadius = 0.003;
   float vizRangeLow, vizRangeHigh, dataRangeLow, dataRangeHigh;
-  std::string cMap = "coolwarm";
+
+  // set the radius of the points
+  SurfaceCountQuantity* setPointRadius(double newVal, bool isRelative = true);
+  double getPointRadius();
+
+  // Material
+  SurfaceCountQuantity* setColorMap(std::string name);
+  std::string getColorMap();
 
 protected:
   void initializeLimits();
   void setUniforms(render::ShaderProgram& p);
   void createProgram();
+
+private:
+  PersistentValue<ScaledValue<float>> pointRadius;
+  PersistentValue<std::string> colorMap;
 };
 
 // ========================================================

--- a/src/surface_count_quantity.cpp
+++ b/src/surface_count_quantity.cpp
@@ -237,6 +237,7 @@ SurfaceFaceCountQuantity::SurfaceFaceCountQuantity(std::string name, std::vector
     for (size_t j = 0; j < D; j++) {
       faceCenter += parent.vertices[face[j]];
     }
+    faceCenter /= static_cast<double>(D);
 
     entries.push_back(std::make_pair(faceCenter, t.second));
   }


### PR DESCRIPTION
The positions of the points in a FaceCountQuantity were not divided by the number of vertices in a face, causing the points to float above the surface instead of laying on top of it.

I also added getters and setters for controlling the radius and color map