### PR TITLE
Set custom object transform

### DIFF
--- a/include/polyscope/structure.h
+++ b/include/polyscope/structure.h
@@ -59,6 +59,7 @@ public:
 
   // = Scene transform
   glm::mat4 getModelView();
+  void setTransform(glm::mat4x4 transform);
   void centerBoundingBox();
   void rescaleToUnit();
   void resetTransform();
@@ -86,7 +87,7 @@ public:
 protected:
   // = State
   PersistentValue<bool> enabled;
-  
+
   PersistentValue<glm::mat4> objectTransform;
 
   // 0 for transparent, 1 for opaque, only has effect if engine transparency is set
@@ -94,7 +95,7 @@ protected:
 
   // Widget that wraps the transform
   TransformationGizmo transformGizmo;
-  
+
   PersistentValue<std::vector<std::string>> ignoredSlicePlaneNames;
 };
 

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -133,6 +133,12 @@ void Structure::buildCustomOptionsUI() {}
 
 void Structure::refresh() { requestRedraw(); }
 
+void Structure::setTransform(glm::mat4x4 transform)
+{
+  objectTransform = transform * objectTransform.get();
+  updateStructureExtents();
+}
+
 void Structure::resetTransform() {
   objectTransform = glm::mat4(1.0);
   updateStructureExtents();


### PR DESCRIPTION
Found it useful to set the transform manually on initialization without having to use the gizmo. Main reason was loading multiple meshes which were both origin centered