### PR TITLE
Implement engine::registerShaderRule

### DIFF
--- a/include/polyscope/render/engine.h
+++ b/include/polyscope/render/engine.h
@@ -394,6 +394,8 @@ public:
   requestShader(const std::string& programName, const std::vector<std::string>& customRules,
                 ShaderReplacementDefaults defaults = ShaderReplacementDefaults::SceneObject) = 0;
 
+  virtual void registerShaderRule(const std::string& name, const ShaderReplacementRule& rule) = 0;
+
   // === The frame buffers used in the rendering pipeline
   // The size of these buffers is always kept in sync with the screen size
   std::shared_ptr<FrameBuffer> displayBuffer, displayBufferAlt;

--- a/include/polyscope/render/mock_opengl/mock_gl_engine.h
+++ b/include/polyscope/render/mock_opengl/mock_gl_engine.h
@@ -259,11 +259,12 @@ public:
   requestShader(const std::string& programName, const std::vector<std::string>& customRules,
                 ShaderReplacementDefaults defaults = ShaderReplacementDefaults::SceneObject) override;
 
+  void registerShaderRule(const std::string& name, const ShaderReplacementRule& rule) override;
+
   // Transparency
   virtual void applyTransparencySettings() override;
 
 protected:
-  
   // Helpers
   virtual void createSlicePlaneFliterRule(std::string name) override;
 

--- a/include/polyscope/render/opengl/gl_engine.h
+++ b/include/polyscope/render/opengl/gl_engine.h
@@ -68,7 +68,6 @@ public:
 
   void setFilterMode(FilterMode newMode) override;
   void* getNativeHandle() override;
-  
   std::vector<float> getDataScalar() override;
   std::vector<glm::vec2> getDataVector2() override;
   std::vector<glm::vec3> getDataVector3() override;
@@ -310,7 +309,7 @@ public:
 
   // Add a shader programs/rules so that they can be requested above
   void registerShaderProgram(const std::string& name, const std::vector<ShaderStageSpecification>& stages);
-  void registerShaderRule(const std::string& name, const ShaderReplacementRule& rule);
+  void registerShaderRule(const std::string& name, const ShaderReplacementRule& rule) override;
 
   // Transparency
   virtual void applyTransparencySettings() override;
@@ -327,10 +326,8 @@ protected:
   std::unordered_map<std::string, std::pair<std::vector<ShaderStageSpecification>, DrawMode>> registeredShaderPrograms;
   std::unordered_map<std::string, ShaderReplacementRule> registeredShaderRules;
   void populateDefaultShadersAndRules();
-  
   std::shared_ptr<ShaderProgram> generateShaderProgram(const std::vector<ShaderStageSpecification>& stages,
                                                        DrawMode dm) override;
-
 };
 
 } // namespace backend_openGL3_glfw

--- a/src/render/mock_opengl/mock_gl_engine.cpp
+++ b/src/render/mock_opengl/mock_gl_engine.cpp
@@ -1461,6 +1461,10 @@ void MockGLEngine::populateDefaultShadersAndRules() {
   // clang-format on
 };
 
+void MockGLEngine::registerShaderRule(const std::string& name, const ShaderReplacementRule& rule) {
+  registeredShaderRules.insert({name, rule});
+}
+
 
 void MockGLEngine::createSlicePlaneFliterRule(std::string uniquePostfix) {
   using namespace backend_openGL3_glfw;
@@ -1486,4 +1490,3 @@ void initializeRenderEngine() {
 } // namespace polyscope
 
 #endif
-

--- a/src/render/opengl/gl_engine.cpp
+++ b/src/render/opengl/gl_engine.cpp
@@ -2028,6 +2028,10 @@ std::shared_ptr<ShaderProgram> GLEngine::requestShader(const std::string& progra
   return generateShaderProgram(updatedStages, dm);
 }
 
+void GLEngine::registerShaderRule(const std::string& name, const ShaderReplacementRule& rule) {
+  registeredShaderRules.insert({name, rule});
+}
+
 void GLEngine::populateDefaultShadersAndRules() {
   // Note: we use .insert({key, value}) rather than map[key] = value to support const members in the value.
 


### PR DESCRIPTION
I'm writing some custom shaders and needed to register some of my own shader rules, so I went ahead and implemented `registerShaderRule`. It seems to work, although it might be nice to have more validation (e.g. checking for name collisions).

BTW the new shader system is really nice! It was much easier to implement projective interpolation this time around