### PR TITLE
Allow compilation with only mocked backend

### DIFF
--- a/include/polyscope/render/opengl/shaders/common.h
+++ b/include/polyscope/render/opengl/shaders/common.h
@@ -5,7 +5,9 @@
 // multiple shaders; it is combined at link time with all fragment
 // shaders compiled via the methods in the GLProgram class.
 
+#ifdef POLYSCOPE_BACKEND_OPENGL3_GLFW_ENABLED
 #include "polyscope/render/opengl/gl_engine.h"
+#endif
 
 namespace polyscope {
 namespace render {


### PR DESCRIPTION
## Problem

At the moment polyscope cannot be compiled without its `OPENGL3_GLFW` backend. This wouldn't really be an issue but in the documentation there is a note that the OpenGL backend can be disabled by building with 

```bash
cmake -DPOLYSCOPE_BACKEND_OPENGL3_GLFW=OFF ..
```
While cmake runs; the subsequent `make` call leads to an error:

```bash
payoto$ ~/code/polyscope/build$ cmake -DPOLYSCOPE_BACKEND_OPENGL3_GLFW=OFF ..
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
Polyscope backend openGL_mock enabled
-- Configuring done
-- Generating done
-- Build files have been written to: /home/payoto/code/polyscope/build
payoto$ ~/code/polyscope/build$ make -j 6
Scanning dependencies of target stb
Scanning dependencies of target imgui
[  1%] Building CXX object deps/stb/CMakeFiles/stb.dir/stb_impl.cpp.o
[  3%] Building CXX object deps/imgui/CMakeFiles/imgui.dir/imgui/imgui.cpp.o
[  3%] Building CXX object deps/imgui/CMakeFiles/imgui.dir/imgui/imgui_widgets.cpp.o
[  4%] Building CXX object deps/imgui/CMakeFiles/imgui.dir/imgui/imgui_draw.cpp.o
[  6%] Linking CXX static library libstb.a
[  6%] Built target stb
[  7%] Linking CXX static library libimgui.a
[  7%] Built target imgui
Scanning dependencies of target polyscope
[  9%] Building CXX object src/CMakeFiles/polyscope.dir/polyscope.cpp.o
[  9%] Building CXX object src/CMakeFiles/polyscope.dir/options.cpp.o
[ 10%] Building CXX object src/CMakeFiles/polyscope.dir/state.cpp.o
[ 13%] Building CXX object src/CMakeFiles/polyscope.dir/structure.cpp.o
[ 13%] Building CXX object src/CMakeFiles/polyscope.dir/utilities.cpp.o
[ 14%] Building CXX object src/CMakeFiles/polyscope.dir/view.cpp.o
[ 15%] Building CXX object src/CMakeFiles/polyscope.dir/screenshot.cpp.o
[ 17%] Building CXX object src/CMakeFiles/polyscope.dir/messages.cpp.o
[ 18%] Building CXX object src/CMakeFiles/polyscope.dir/pick.cpp.o
[ 19%] Building CXX object src/CMakeFiles/polyscope.dir/widget.cpp.o
[ 20%] Building CXX object src/CMakeFiles/polyscope.dir/render/engine.cpp.o
[ 21%] Building CXX object src/CMakeFiles/polyscope.dir/render/color_maps.cpp.o
[ 23%] Building CXX object src/CMakeFiles/polyscope.dir/render/ground_plane.cpp.o
[ 24%] Building CXX object src/CMakeFiles/polyscope.dir/render/materials.cpp.o
[ 25%] Building CXX object src/CMakeFiles/polyscope.dir/render/initialize_backend.cpp.o
[ 26%] Building CXX object src/CMakeFiles/polyscope.dir/render/shader_builder.cpp.o
[ 28%] Building CXX object src/CMakeFiles/polyscope.dir/file_helpers.cpp.o
[ 29%] Building CXX object src/CMakeFiles/polyscope.dir/disjoint_sets.cpp.o
[ 30%] Building CXX object src/CMakeFiles/polyscope.dir/camera_parameters.cpp.o
[ 31%] Building CXX object src/CMakeFiles/polyscope.dir/histogram.cpp.o
[ 32%] Building CXX object src/CMakeFiles/polyscope.dir/persistent_value.cpp.o
[ 34%] Building CXX object src/CMakeFiles/polyscope.dir/color_management.cpp.o
[ 35%] Building CXX object src/CMakeFiles/polyscope.dir/transformation_gizmo.cpp.o
[ 36%] Building CXX object src/CMakeFiles/polyscope.dir/slice_plane.cpp.o
[ 37%] Building CXX object src/CMakeFiles/polyscope.dir/point_cloud.cpp.o
[ 39%] Building CXX object src/CMakeFiles/polyscope.dir/point_cloud_color_quantity.cpp.o
[ 40%] Building CXX object src/CMakeFiles/polyscope.dir/point_cloud_scalar_quantity.cpp.o
[ 41%] Building CXX object src/CMakeFiles/polyscope.dir/point_cloud_vector_quantity.cpp.o
[ 42%] Building CXX object src/CMakeFiles/polyscope.dir/point_cloud_parameterization_quantity.cpp.o
[ 43%] Building CXX object src/CMakeFiles/polyscope.dir/surface_mesh.cpp.o
[ 45%] Building CXX object src/CMakeFiles/polyscope.dir/surface_mesh_io.cpp.o
[ 46%] Building CXX object src/CMakeFiles/polyscope.dir/surface_scalar_quantity.cpp.o
[ 47%] Building CXX object src/CMakeFiles/polyscope.dir/surface_color_quantity.cpp.o
[ 48%] Building CXX object src/CMakeFiles/polyscope.dir/surface_distance_quantity.cpp.o
[ 50%] Building CXX object src/CMakeFiles/polyscope.dir/surface_parameterization_quantity.cpp.o
[ 51%] Building CXX object src/CMakeFiles/polyscope.dir/surface_vector_quantity.cpp.o
[ 52%] Building CXX object src/CMakeFiles/polyscope.dir/surface_count_quantity.cpp.o
[ 53%] Building CXX object src/CMakeFiles/polyscope.dir/surface_graph_quantity.cpp.o
[ 54%] Building CXX object src/CMakeFiles/polyscope.dir/curve_network.cpp.o
[ 56%] Building CXX object src/CMakeFiles/polyscope.dir/curve_network_scalar_quantity.cpp.o
[ 57%] Building CXX object src/CMakeFiles/polyscope.dir/curve_network_color_quantity.cpp.o
[ 58%] Building CXX object src/CMakeFiles/polyscope.dir/curve_network_vector_quantity.cpp.o
[ 59%] Building CXX object src/CMakeFiles/polyscope.dir/volume_mesh.cpp.o
[ 60%] Building CXX object src/CMakeFiles/polyscope.dir/volume_mesh_color_quantity.cpp.o
[ 62%] Building CXX object src/CMakeFiles/polyscope.dir/volume_mesh_scalar_quantity.cpp.o
[ 63%] Building CXX object src/CMakeFiles/polyscope.dir/volume_mesh_vector_quantity.cpp.o
[ 64%] Building CXX object src/CMakeFiles/polyscope.dir/vector_artist.cpp.o
[ 65%] Building CXX object src/CMakeFiles/polyscope.dir/trace_vector_field.cpp.o
[ 67%] Building CXX object src/CMakeFiles/polyscope.dir/ribbon_artist.cpp.o
[ 68%] Building CXX object src/CMakeFiles/polyscope.dir/image_scalar_artist.cpp.o
[ 69%] Building CXX object src/CMakeFiles/polyscope.dir/render/bindata/bindata_font_lato_regular.cpp.o
[ 70%] Building CXX object src/CMakeFiles/polyscope.dir/render/bindata/bindata_font_cousine_regular.cpp.o
[ 71%] Building CXX object src/CMakeFiles/polyscope.dir/render/bindata/concrete_seamless.cpp.o
[ 73%] Building CXX object src/CMakeFiles/polyscope.dir/render/bindata/bindata_clay.cpp.o
[ 74%] Building CXX object src/CMakeFiles/polyscope.dir/render/bindata/bindata_wax.cpp.o
[ 75%] Building CXX object src/CMakeFiles/polyscope.dir/render/bindata/bindata_candy.cpp.o
[ 76%] Building CXX object src/CMakeFiles/polyscope.dir/render/bindata/bindata_flat.cpp.o
[ 78%] Building CXX object src/CMakeFiles/polyscope.dir/render/bindata/bindata_mud.cpp.o
[ 79%] Building CXX object src/CMakeFiles/polyscope.dir/render/bindata/bindata_ceramic.cpp.o
[ 80%] Building CXX object src/CMakeFiles/polyscope.dir/render/bindata/bindata_jade.cpp.o
[ 81%] Building CXX object src/CMakeFiles/polyscope.dir/render/bindata/bindata_normal.cpp.o
[ 82%] Building CXX object src/CMakeFiles/polyscope.dir/render/opengl/gl_engine.cpp.o
[ 84%] Building CXX object src/CMakeFiles/polyscope.dir/render/mock_opengl/mock_gl_engine.cpp.o
[ 85%] Building CXX object src/CMakeFiles/polyscope.dir/render/opengl/shaders/texture_draw_shaders.cpp.o
[ 86%] Building CXX object src/CMakeFiles/polyscope.dir/render/opengl/shaders/lighting_shaders.cpp.o
In file included from /home/payoto/code/polyscope/src/../include/polyscope/render/opengl/shaders/common.h:8,
                 from ~/polyscope/src/render/mock_opengl/mock_gl_engine.cpp:13:
~/polyscope/src/../include/polyscope/render/opengl/gl_engine.h:12:10: fatal error: glad/glad.h: No such file or directory
   12 | #include "glad/glad.h"
      |          ^~~~~~~~~~~~~
compilation terminated.
make[2]: *** [src/CMakeFiles/polyscope.dir/build.make:869: src/CMakeFiles/polyscope.dir/render/mock_opengl/mock_gl_engine.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:209: src/CMakeFiles/polyscope.dir/all] Error 2
make: *** [Makefile:84: all] Error 2

```

This is due to the mocked backend depending on glad. 

## The fix

This commit uses compiler flags to disable the `gl_engine` import in `shaders/common.h` as that header is included in `mock_gl_engine.cpp`. Running the test suite by building:

```bash
cd test
mkdir build && cd build
cmake -DCMAKE_BUILD_TYPE=Debug -DPOLYSCOPE_BACKEND_OPENGL3_GLFW=OFF ..
make -j4 && ./bin/polyscope-test --gtest_catch_exceptions=0
```

produces 69 passing tests.