### PR TITLE
Add Backface Color option

### DIFF
--- a/include/polyscope/render/opengl/shaders/surface_mesh_shaders.h
+++ b/include/polyscope/render/opengl/shaders/surface_mesh_shaders.h
@@ -13,7 +13,7 @@ extern const ShaderStageSpecification FLEX_MESH_FRAG_SHADER;
 // Rules specific to meshes 
 extern const ShaderReplacementRule MESH_WIREFRAME;
 extern const ShaderReplacementRule MESH_BACKFACE_NORMAL_FLIP;
-extern const ShaderReplacementRule MESH_BACKFACE_DARKEN;
+extern const ShaderReplacementRule MESH_BACKFACE_DIFFERENT;
 extern const ShaderReplacementRule MESH_PROPAGATE_VALUE;
 extern const ShaderReplacementRule MESH_PROPAGATE_VALUE2;
 extern const ShaderReplacementRule MESH_PROPAGATE_COLOR;

--- a/include/polyscope/render/opengl/shaders/surface_mesh_shaders.h
+++ b/include/polyscope/render/opengl/shaders/surface_mesh_shaders.h
@@ -14,6 +14,7 @@ extern const ShaderStageSpecification FLEX_MESH_FRAG_SHADER;
 extern const ShaderReplacementRule MESH_WIREFRAME;
 extern const ShaderReplacementRule MESH_BACKFACE_NORMAL_FLIP;
 extern const ShaderReplacementRule MESH_BACKFACE_DIFFERENT;
+extern const ShaderReplacementRule MESH_BACKFACE_DARKEN;
 extern const ShaderReplacementRule MESH_PROPAGATE_VALUE;
 extern const ShaderReplacementRule MESH_PROPAGATE_VALUE2;
 extern const ShaderReplacementRule MESH_PROPAGATE_COLOR;

--- a/include/polyscope/surface_mesh.h
+++ b/include/polyscope/surface_mesh.h
@@ -293,6 +293,9 @@ public:
   SurfaceMesh* setMaterial(std::string name);
   std::string getMaterial();
 
+  // Backface color
+  SurfaceMesh* setBackfaceColor(glm::vec3 val);
+  glm::vec3 getBackfaceColor();
 
   // Width of the edges. Scaled such that 1 is a reasonable weight for visible edges, but values  1 can be used for
   // bigger edges. Use 0. to disable.
@@ -317,6 +320,7 @@ private:
   PersistentValue<std::string> material;
   PersistentValue<float> edgeWidth;
   PersistentValue<BackFacePolicy> backFacePolicy;
+  PersistentValue<glm::vec3> backFaceColor;
 
   // Do setup work related to drawing, including allocating openGL data
   void prepare();

--- a/include/polyscope/surface_mesh.h
+++ b/include/polyscope/surface_mesh.h
@@ -294,8 +294,8 @@ public:
   std::string getMaterial();
 
   // Backface color
-  SurfaceMesh* setBackfaceColor(glm::vec3 val);
-  glm::vec3 getBackfaceColor();
+  SurfaceMesh* setBackFaceColor(glm::vec3 val);
+  glm::vec3 getBackFaceColor();
 
   // Width of the edges. Scaled such that 1 is a reasonable weight for visible edges, but values  1 can be used for
   // bigger edges. Use 0. to disable.

--- a/include/polyscope/types.h
+++ b/include/polyscope/types.h
@@ -8,7 +8,7 @@ namespace polyscope {
 enum class BackgroundView { None = 0 };
 enum class TransparencyMode { None = 0, Simple, Pretty };
 enum class GroundPlaneMode { None, Tile, TileReflection, ShadowOnly };
-enum class BackFacePolicy { Identical, Different, Cull };
+enum class BackFacePolicy { Identical, Different, Custom, Cull };
 enum class ShadeStyle { FLAT = 0, SMOOTH };
 
 enum class MeshElement { VERTEX = 0, FACE, EDGE, HALFEDGE, CORNER };

--- a/src/render/mock_opengl/mock_gl_engine.cpp
+++ b/src/render/mock_opengl/mock_gl_engine.cpp
@@ -1421,7 +1421,7 @@ void MockGLEngine::populateDefaultShadersAndRules() {
   // mesh things
   registeredShaderRules.insert({"MESH_WIREFRAME", MESH_WIREFRAME});
   registeredShaderRules.insert({"MESH_BACKFACE_NORMAL_FLIP", MESH_BACKFACE_NORMAL_FLIP});
-  registeredShaderRules.insert({"MESH_BACKFACE_DARKEN", MESH_BACKFACE_DARKEN});
+  registeredShaderRules.insert({"MESH_BACKFACE_DARKEN", MESH_BACKFACE_DIFFERENT});
   registeredShaderRules.insert({"MESH_PROPAGATE_VALUE", MESH_PROPAGATE_VALUE});
   registeredShaderRules.insert({"MESH_PROPAGATE_VALUE2", MESH_PROPAGATE_VALUE2});
   registeredShaderRules.insert({"MESH_PROPAGATE_COLOR", MESH_PROPAGATE_COLOR});

--- a/src/render/mock_opengl/mock_gl_engine.cpp
+++ b/src/render/mock_opengl/mock_gl_engine.cpp
@@ -1421,7 +1421,7 @@ void MockGLEngine::populateDefaultShadersAndRules() {
   // mesh things
   registeredShaderRules.insert({"MESH_WIREFRAME", MESH_WIREFRAME});
   registeredShaderRules.insert({"MESH_BACKFACE_NORMAL_FLIP", MESH_BACKFACE_NORMAL_FLIP});
-  registeredShaderRules.insert({"MESH_BACKFACE_DARKEN", MESH_BACKFACE_DIFFERENT});
+  registeredShaderRules.insert({"MESH_BACKFACE_DIFFERENT", MESH_BACKFACE_DIFFERENT});
   registeredShaderRules.insert({"MESH_PROPAGATE_VALUE", MESH_PROPAGATE_VALUE});
   registeredShaderRules.insert({"MESH_PROPAGATE_VALUE2", MESH_PROPAGATE_VALUE2});
   registeredShaderRules.insert({"MESH_PROPAGATE_COLOR", MESH_PROPAGATE_COLOR});

--- a/src/render/mock_opengl/mock_gl_engine.cpp
+++ b/src/render/mock_opengl/mock_gl_engine.cpp
@@ -1422,6 +1422,7 @@ void MockGLEngine::populateDefaultShadersAndRules() {
   registeredShaderRules.insert({"MESH_WIREFRAME", MESH_WIREFRAME});
   registeredShaderRules.insert({"MESH_BACKFACE_NORMAL_FLIP", MESH_BACKFACE_NORMAL_FLIP});
   registeredShaderRules.insert({"MESH_BACKFACE_DIFFERENT", MESH_BACKFACE_DIFFERENT});
+  registeredShaderRules.insert({"MESH_BACKFACE_DARKEN", MESH_BACKFACE_DARKEN});
   registeredShaderRules.insert({"MESH_PROPAGATE_VALUE", MESH_PROPAGATE_VALUE});
   registeredShaderRules.insert({"MESH_PROPAGATE_VALUE2", MESH_PROPAGATE_VALUE2});
   registeredShaderRules.insert({"MESH_PROPAGATE_COLOR", MESH_PROPAGATE_COLOR});

--- a/src/render/opengl/gl_engine.cpp
+++ b/src/render/opengl/gl_engine.cpp
@@ -2071,7 +2071,7 @@ void GLEngine::populateDefaultShadersAndRules() {
   // mesh things
   registeredShaderRules.insert({"MESH_WIREFRAME", MESH_WIREFRAME});
   registeredShaderRules.insert({"MESH_BACKFACE_NORMAL_FLIP", MESH_BACKFACE_NORMAL_FLIP});
-  registeredShaderRules.insert({"MESH_BACKFACE_DARKEN", MESH_BACKFACE_DARKEN});
+  registeredShaderRules.insert({"MESH_BACKFACE_DIFFERENT", MESH_BACKFACE_DIFFERENT});
   registeredShaderRules.insert({"MESH_PROPAGATE_VALUE", MESH_PROPAGATE_VALUE});
   registeredShaderRules.insert({"MESH_PROPAGATE_VALUE2", MESH_PROPAGATE_VALUE2});
   registeredShaderRules.insert({"MESH_PROPAGATE_COLOR", MESH_PROPAGATE_COLOR});

--- a/src/render/opengl/gl_engine.cpp
+++ b/src/render/opengl/gl_engine.cpp
@@ -2072,6 +2072,7 @@ void GLEngine::populateDefaultShadersAndRules() {
   registeredShaderRules.insert({"MESH_WIREFRAME", MESH_WIREFRAME});
   registeredShaderRules.insert({"MESH_BACKFACE_NORMAL_FLIP", MESH_BACKFACE_NORMAL_FLIP});
   registeredShaderRules.insert({"MESH_BACKFACE_DIFFERENT", MESH_BACKFACE_DIFFERENT});
+  registeredShaderRules.insert({"MESH_BACKFACE_DARKEN", MESH_BACKFACE_DARKEN});
   registeredShaderRules.insert({"MESH_PROPAGATE_VALUE", MESH_PROPAGATE_VALUE});
   registeredShaderRules.insert({"MESH_PROPAGATE_VALUE2", MESH_PROPAGATE_VALUE2});
   registeredShaderRules.insert({"MESH_PROPAGATE_COLOR", MESH_PROPAGATE_COLOR});

--- a/src/render/opengl/shaders/surface_mesh_shaders.cpp
+++ b/src/render/opengl/shaders/surface_mesh_shaders.cpp
@@ -329,6 +329,21 @@ const ShaderReplacementRule MESH_BACKFACE_NORMAL_FLIP (
     /* textures */ {}
 );
 
+const ShaderReplacementRule MESH_BACKFACE_DARKEN (
+    /* rule name */ "MESH_BACKFACE_DARKEN",
+    { /* replacement sources */
+      {"PERTURB_LIT_COLOR", R"(
+        if(!gl_FrontFacing) {
+          litColor *= .7;
+        }
+        )"}
+    },
+    /* uniforms */ {},
+    /* attributes */ {},
+    /* textures */ {}
+);
+
+
 const ShaderReplacementRule MESH_BACKFACE_DIFFERENT (
     /* rule name */ "MESH_BACKFACE_DIFFERENT",
     { /* replacement sources */

--- a/src/render/opengl/shaders/surface_mesh_shaders.cpp
+++ b/src/render/opengl/shaders/surface_mesh_shaders.cpp
@@ -329,16 +329,22 @@ const ShaderReplacementRule MESH_BACKFACE_NORMAL_FLIP (
     /* textures */ {}
 );
 
-const ShaderReplacementRule MESH_BACKFACE_DARKEN (
-    /* rule name */ "MESH_BACKFACE_DARKEN",
+const ShaderReplacementRule MESH_BACKFACE_DIFFERENT (
+    /* rule name */ "MESH_BACKFACE_DIFFERENT",
     { /* replacement sources */
-      {"PERTURB_LIT_COLOR", R"(
+      {"FRAG_DECLARATIONS", R"(
+          uniform vec3 u_backfaceColor;
+        )"},
+      {"GENERATE_SHADE_COLOR", R"(
         if(!gl_FrontFacing) {
-          litColor *= .7;
+          albedoColor = u_backfaceColor;
         }
-        )"}
+  )"}
     },
-    /* uniforms */ {},
+    /* uniforms */ 
+    {
+      {"u_backfaceColor", DataType::Vector3Float}
+    },
     /* attributes */ {},
     /* textures */ {}
 );

--- a/src/surface_mesh.cpp
+++ b/src/surface_mesh.cpp
@@ -887,15 +887,7 @@ void SurfaceMesh::buildCustomUI() {
   }
 }
 
-SurfaceMesh* SurfaceMesh::setBackfaceColor(glm::vec3 val){
-  backFaceColor.set(val);
-  requestRedraw();
-  return this;
-}
 
-glm::vec3 SurfaceMesh::getBackfaceColor(){
-  return backFaceColor.get();
-}
 
 void SurfaceMesh::buildCustomOptionsUI() {
   if (render::buildMaterialOptionsGui(material.get())) {
@@ -1123,6 +1115,16 @@ SurfaceMesh* SurfaceMesh::setSurfaceColor(glm::vec3 val) {
   return this;
 }
 glm::vec3 SurfaceMesh::getSurfaceColor() { return surfaceColor.get(); }
+
+SurfaceMesh* SurfaceMesh::setBackfaceColor(glm::vec3 val){
+  backFaceColor.set(val);
+  requestRedraw();
+  return this;
+}
+
+glm::vec3 SurfaceMesh::getBackfaceColor(){
+  return backFaceColor.get();
+}
 
 SurfaceMesh* SurfaceMesh::setEdgeColor(glm::vec3 val) {
   edgeColor = val;

--- a/src/surface_mesh.cpp
+++ b/src/surface_mesh.cpp
@@ -25,11 +25,11 @@ SurfaceMesh::SurfaceMesh(std::string name, const std::vector<glm::vec3>& vertexP
                          const std::vector<std::vector<size_t>>& faceIndices)
     : QuantityStructure<SurfaceMesh>(name, typeName()), vertices(vertexPositions), faces(faceIndices),
       shadeSmooth(uniquePrefix() + "shadeSmooth", false),
+      surfaceColor(uniquePrefix() + "surfaceColor", glm::vec3(0,0,0)) ,
       edgeColor(uniquePrefix() + "edgeColor", glm::vec3{0., 0., 0.}), material(uniquePrefix() + "material", "clay"),
       edgeWidth(uniquePrefix() + "edgeWidth", 0.),
       backFacePolicy(uniquePrefix() + "backFacePolicy", BackFacePolicy::Different),
-      backFaceColor(uniquePrefix() + "backFaceColor", glm::vec3(0,0,0)),
-      surfaceColor(uniquePrefix() + "surfaceColor", glm::vec3(0,0,0)) {
+      backFaceColor(uniquePrefix() + "backFaceColor", glm::vec3(0,0,0)) {
   glm::vec3 mainColor = getNextUniqueColor();
   surfaceColor.set(mainColor);
   backFaceColor.set(glm::vec3(1.f - mainColor.r,
@@ -1109,13 +1109,6 @@ SurfaceMesh* SurfaceMesh::setSmoothShade(bool isSmooth) {
 }
 bool SurfaceMesh::isSmoothShade() { return shadeSmooth.get(); }
 
-SurfaceMesh* SurfaceMesh::setSurfaceColor(glm::vec3 val) {
-  surfaceColor = val;
-  requestRedraw();
-  return this;
-}
-glm::vec3 SurfaceMesh::getSurfaceColor() { return surfaceColor.get(); }
-
 SurfaceMesh* SurfaceMesh::setBackfaceColor(glm::vec3 val){
   backFaceColor.set(val);
   requestRedraw();
@@ -1125,6 +1118,13 @@ SurfaceMesh* SurfaceMesh::setBackfaceColor(glm::vec3 val){
 glm::vec3 SurfaceMesh::getBackfaceColor(){
   return backFaceColor.get();
 }
+
+SurfaceMesh* SurfaceMesh::setSurfaceColor(glm::vec3 val) {
+  surfaceColor = val;
+  requestRedraw();
+  return this;
+}
+glm::vec3 SurfaceMesh::getSurfaceColor() { return surfaceColor.get(); }
 
 SurfaceMesh* SurfaceMesh::setEdgeColor(glm::vec3 val) {
   edgeColor = val;

--- a/src/surface_mesh.cpp
+++ b/src/surface_mesh.cpp
@@ -25,16 +25,15 @@ SurfaceMesh::SurfaceMesh(std::string name, const std::vector<glm::vec3>& vertexP
                          const std::vector<std::vector<size_t>>& faceIndices)
     : QuantityStructure<SurfaceMesh>(name, typeName()), vertices(vertexPositions), faces(faceIndices),
       shadeSmooth(uniquePrefix() + "shadeSmooth", false),
-      surfaceColor(uniquePrefix() + "surfaceColor", glm::vec3(0,0,0)) ,
+      surfaceColor(uniquePrefix() + "surfaceColor", getNextUniqueColor()),
       edgeColor(uniquePrefix() + "edgeColor", glm::vec3{0., 0., 0.}), material(uniquePrefix() + "material", "clay"),
       edgeWidth(uniquePrefix() + "edgeWidth", 0.),
       backFacePolicy(uniquePrefix() + "backFacePolicy", BackFacePolicy::Different),
-      backFaceColor(uniquePrefix() + "backFaceColor", glm::vec3(0,0,0)) {
-  glm::vec3 mainColor = getNextUniqueColor();
-  surfaceColor.set(mainColor);
-  backFaceColor.set(glm::vec3(1.f - mainColor.r,
-                              1.f - mainColor.g,
-                              1.f - mainColor.b));
+      backFaceColor(uniquePrefix() + "backFaceColor",
+                    glm::vec3(1.f - surfaceColor.get().r,
+                              1.f - surfaceColor.get().g,
+                              1.f - surfaceColor.get().b)) 
+{
   computeCounts();
   computeGeometryData();
 }

--- a/src/surface_mesh.cpp
+++ b/src/surface_mesh.cpp
@@ -11,14 +11,10 @@
 #include <unordered_map>
 #include <utility>
 
-using std::cout;
-using std::endl;
-
 namespace polyscope {
 
 // Initialize statics
 const std::string SurfaceMesh::structureTypeName = "Surface Mesh";
-
 
 
 SurfaceMesh::SurfaceMesh(std::string name, const std::vector<glm::vec3>& vertexPositions,
@@ -30,10 +26,7 @@ SurfaceMesh::SurfaceMesh(std::string name, const std::vector<glm::vec3>& vertexP
       edgeWidth(uniquePrefix() + "edgeWidth", 0.),
       backFacePolicy(uniquePrefix() + "backFacePolicy", BackFacePolicy::Different),
       backFaceColor(uniquePrefix() + "backFaceColor",
-                    glm::vec3(1.f - surfaceColor.get().r,
-                              1.f - surfaceColor.get().g,
-                              1.f - surfaceColor.get().b)) 
-{
+                    glm::vec3(1.f - surfaceColor.get().r, 1.f - surfaceColor.get().g, 1.f - surfaceColor.get().b)) {
   computeCounts();
   computeGeometryData();
 }
@@ -554,7 +547,7 @@ void SurfaceMesh::setSurfaceMeshUniforms(render::ShaderProgram& p) {
     p.setUniform("u_edgeWidth", getEdgeWidth() * render::engine->getCurrentPixelScaling());
     p.setUniform("u_edgeColor", getEdgeColor());
   }
-  if(backFacePolicy.get() == BackFacePolicy::Custom){
+  if (backFacePolicy.get() == BackFacePolicy::Custom) {
     p.setUniform("u_backfaceColor", getBackFaceColor());
   }
 }
@@ -887,12 +880,11 @@ void SurfaceMesh::buildCustomUI() {
     }
     ImGui::PopItemWidth();
   }
-  if(backFacePolicy.get() == BackFacePolicy::Custom){
-     if(ImGui::ColorEdit3("Backface Color", &backFaceColor.get()[0], ImGuiColorEditFlags_NoInputs))
-       setBackFaceColor(backFaceColor.get());
+  if (backFacePolicy.get() == BackFacePolicy::Custom) {
+    if (ImGui::ColorEdit3("Backface Color", &backFaceColor.get()[0], ImGuiColorEditFlags_NoInputs))
+      setBackFaceColor(backFaceColor.get());
   }
 }
-
 
 
 void SurfaceMesh::buildCustomOptionsUI() {
@@ -1117,15 +1109,13 @@ SurfaceMesh* SurfaceMesh::setSmoothShade(bool isSmooth) {
 }
 bool SurfaceMesh::isSmoothShade() { return shadeSmooth.get(); }
 
-SurfaceMesh* SurfaceMesh::setBackFaceColor(glm::vec3 val){
+SurfaceMesh* SurfaceMesh::setBackFaceColor(glm::vec3 val) {
   backFaceColor.set(val);
   requestRedraw();
   return this;
 }
 
-glm::vec3 SurfaceMesh::getBackFaceColor(){
-  return backFaceColor.get();
-}
+glm::vec3 SurfaceMesh::getBackFaceColor() { return backFaceColor.get(); }
 
 SurfaceMesh* SurfaceMesh::setSurfaceColor(glm::vec3 val) {
   surfaceColor = val;

--- a/src/surface_mesh.cpp
+++ b/src/surface_mesh.cpp
@@ -524,6 +524,9 @@ std::vector<std::string> SurfaceMesh::addSurfaceMeshRules(std::vector<std::strin
         initRules.push_back("MESH_WIREFRAME");
       }
       if (backFacePolicy.get() == BackFacePolicy::Different) {
+        initRules.push_back("MESH_BACKFACE_DARKEN");
+      }
+      if (backFacePolicy.get() == BackFacePolicy::Custom) {
         initRules.push_back("MESH_BACKFACE_DIFFERENT");
       }
     }
@@ -533,6 +536,10 @@ std::vector<std::string> SurfaceMesh::addSurfaceMeshRules(std::vector<std::strin
     }
 
     if (backFacePolicy.get() == BackFacePolicy::Different) {
+      initRules.push_back("MESH_BACKFACE_NORMAL_FLIP");
+    }
+
+    if (backFacePolicy.get() == BackFacePolicy::Custom) {
       initRules.push_back("MESH_BACKFACE_NORMAL_FLIP");
     }
 
@@ -548,8 +555,8 @@ void SurfaceMesh::setSurfaceMeshUniforms(render::ShaderProgram& p) {
     p.setUniform("u_edgeWidth", getEdgeWidth() * render::engine->getCurrentPixelScaling());
     p.setUniform("u_edgeColor", getEdgeColor());
   }
-  if(backFacePolicy.get() == BackFacePolicy::Different){
-    p.setUniform("u_backfaceColor", getBackfaceColor());
+  if(backFacePolicy.get() == BackFacePolicy::Custom){
+    p.setUniform("u_backfaceColor", getBackFaceColor());
   }
 }
 
@@ -881,9 +888,9 @@ void SurfaceMesh::buildCustomUI() {
     }
     ImGui::PopItemWidth();
   }
-  if(backFacePolicy.get() == BackFacePolicy::Different){
+  if(backFacePolicy.get() == BackFacePolicy::Custom){
      if(ImGui::ColorEdit3("Backface Color", &backFaceColor.get()[0], ImGuiColorEditFlags_NoInputs))
-       setBackfaceColor(backFaceColor.get());
+       setBackFaceColor(backFaceColor.get());
   }
 }
 
@@ -901,6 +908,8 @@ void SurfaceMesh::buildCustomOptionsUI() {
       setBackFacePolicy(BackFacePolicy::Identical);
     if (ImGui::MenuItem("different shading", NULL, backFacePolicy.get() == BackFacePolicy::Different))
       setBackFacePolicy(BackFacePolicy::Different);
+    if (ImGui::MenuItem("custom shading", NULL, backFacePolicy.get() == BackFacePolicy::Custom))
+      setBackFacePolicy(BackFacePolicy::Custom);
     if (ImGui::MenuItem("cull", NULL, backFacePolicy.get() == BackFacePolicy::Cull))
       setBackFacePolicy(BackFacePolicy::Cull);
     ImGui::EndMenu();
@@ -1109,13 +1118,13 @@ SurfaceMesh* SurfaceMesh::setSmoothShade(bool isSmooth) {
 }
 bool SurfaceMesh::isSmoothShade() { return shadeSmooth.get(); }
 
-SurfaceMesh* SurfaceMesh::setBackfaceColor(glm::vec3 val){
+SurfaceMesh* SurfaceMesh::setBackFaceColor(glm::vec3 val){
   backFaceColor.set(val);
   requestRedraw();
   return this;
 }
 
-glm::vec3 SurfaceMesh::getBackfaceColor(){
+glm::vec3 SurfaceMesh::getBackFaceColor(){
   return backFaceColor.get();
 }
 

--- a/test/src/basics_test.cpp
+++ b/test/src/basics_test.cpp
@@ -287,6 +287,8 @@ TEST_F(PolyscopeTest, SurfaceMeshBackface) {
   // Different appearance
   psMesh->setBackFacePolicy(polyscope::BackFacePolicy::Different);
   EXPECT_EQ(psMesh->getBackFacePolicy(), polyscope::BackFacePolicy::Different);
+  psMesh->setBackfaceColor(glm::vec3(1.f, 0.f, 0.f));
+  EXPECT_EQ(psMesh->getBackFaceColor(), glm::vec3(1.f, 0.f, 0.f));
   polyscope::show(3);
 
   // Cull backfacing

--- a/test/src/basics_test.cpp
+++ b/test/src/basics_test.cpp
@@ -287,8 +287,8 @@ TEST_F(PolyscopeTest, SurfaceMeshBackface) {
   // Different appearance
   psMesh->setBackFacePolicy(polyscope::BackFacePolicy::Different);
   EXPECT_EQ(psMesh->getBackFacePolicy(), polyscope::BackFacePolicy::Different);
-  psMesh->setBackfaceColor(glm::vec3(1.f, 0.f, 0.f));
-  EXPECT_EQ(psMesh->getBackfaceColor(), glm::vec3(1.f, 0.f, 0.f));
+  psMesh->setBackFaceColor(glm::vec3(1.f, 0.f, 0.f));
+  EXPECT_EQ(psMesh->getBackFaceColor(), glm::vec3(1.f, 0.f, 0.f));
   polyscope::show(3);
 
   // Cull backfacing

--- a/test/src/basics_test.cpp
+++ b/test/src/basics_test.cpp
@@ -278,7 +278,7 @@ TEST_F(PolyscopeTest, SurfaceMeshPick) {
 
 TEST_F(PolyscopeTest, SurfaceMeshBackface) {
   auto psMesh = registerTriangleMesh();
-  
+
   // Same appearance
   psMesh->setBackFacePolicy(polyscope::BackFacePolicy::Identical);
   EXPECT_EQ(psMesh->getBackFacePolicy(), polyscope::BackFacePolicy::Identical);
@@ -288,7 +288,7 @@ TEST_F(PolyscopeTest, SurfaceMeshBackface) {
   psMesh->setBackFacePolicy(polyscope::BackFacePolicy::Different);
   EXPECT_EQ(psMesh->getBackFacePolicy(), polyscope::BackFacePolicy::Different);
   psMesh->setBackfaceColor(glm::vec3(1.f, 0.f, 0.f));
-  EXPECT_EQ(psMesh->getBackFaceColor(), glm::vec3(1.f, 0.f, 0.f));
+  EXPECT_EQ(psMesh->getBackfaceColor(), glm::vec3(1.f, 0.f, 0.f));
   polyscope::show(3);
 
   // Cull backfacing
@@ -816,7 +816,7 @@ TEST_F(PolyscopeTest, VolumeMeshColorVertex) {
   std::vector<std::array<int, 8>> cells;
   std::tie(verts, cells) = getVolumeMeshData();
   polyscope::VolumeMesh* psVol = polyscope::registerVolumeMesh("vol", verts, cells);
-  
+
   std::vector<glm::vec3> vColors(verts.size(), glm::vec3{.2, .3, .4});
   auto q1 = psVol->addVertexColorQuantity("vcolor", vColors);
   q1->setEnabled(true);
@@ -829,7 +829,7 @@ TEST_F(PolyscopeTest, VolumeMeshColorCell) {
   std::vector<std::array<int, 8>> cells;
   std::tie(verts, cells) = getVolumeMeshData();
   polyscope::VolumeMesh* psVol = polyscope::registerVolumeMesh("vol", verts, cells);
-  
+
   std::vector<glm::vec3> cColors(cells.size(), glm::vec3{.2, .3, .4});
   auto q1 = psVol->addCellColorQuantity("ccolor", cColors);
   q1->setEnabled(true);
@@ -842,7 +842,7 @@ TEST_F(PolyscopeTest, VolumeMeshScalarVertex) {
   std::vector<std::array<int, 8>> cells;
   std::tie(verts, cells) = getVolumeMeshData();
   polyscope::VolumeMesh* psVol = polyscope::registerVolumeMesh("vol", verts, cells);
-  
+
   std::vector<float> vals(verts.size(), 0.44);
   auto q1 = psVol->addVertexScalarQuantity("vals", vals);
   q1->setEnabled(true);
@@ -855,7 +855,7 @@ TEST_F(PolyscopeTest, VolumeMeshScalarCell) {
   std::vector<std::array<int, 8>> cells;
   std::tie(verts, cells) = getVolumeMeshData();
   polyscope::VolumeMesh* psVol = polyscope::registerVolumeMesh("vol", verts, cells);
-  
+
   std::vector<float> vals(cells.size(), 0.44);
   auto q1 = psVol->addCellScalarQuantity("vals", vals);
   q1->setEnabled(true);
@@ -868,7 +868,7 @@ TEST_F(PolyscopeTest, VolumeMeshVertexVector) {
   std::vector<std::array<int, 8>> cells;
   std::tie(verts, cells) = getVolumeMeshData();
   polyscope::VolumeMesh* psVol = polyscope::registerVolumeMesh("vol", verts, cells);
-  
+
   std::vector<glm::vec3> vals(verts.size(), {1., 2., 3.});
   auto q1 = psVol->addVertexVectorQuantity("vals", vals);
   q1->setEnabled(true);
@@ -881,7 +881,7 @@ TEST_F(PolyscopeTest, VolumeMeshCellVector) {
   std::vector<std::array<int, 8>> cells;
   std::tie(verts, cells) = getVolumeMeshData();
   polyscope::VolumeMesh* psVol = polyscope::registerVolumeMesh("vol", verts, cells);
-  
+
   std::vector<glm::vec3> vals(cells.size(), {1., 2., 3.});
   auto q1 = psVol->addCellVectorQuantity("vals", vals);
   q1->setEnabled(true);


### PR DESCRIPTION
Resolves #52 
Culling and identical rendering for backfaces was already implemented, previously the "different" option would just render a slightly darker version of the same material, I changed that to a color option that defaults to the inverse of the first material color. 