### PR TITLE
Adds check for bufferHeight being 0 on minimize.

### DIFF
--- a/src/render/opengl/gl_engine.cpp
+++ b/src/render/opengl/gl_engine.cpp
@@ -1755,6 +1755,14 @@ void GLEngine::updateWindowSize(bool force) {
       newWindowHeight != view::windowHeight || newWindowWidth != view::windowWidth) {
     // Basically a resize callback
     requestRedraw();
+
+    // prevent any division by zero for e.g. aspect ratio calcs
+    if (newBufferHeight == 0)
+      newBufferHeight = 1;
+
+    if (newWindowHeight == 0)
+      newWindowHeight = 1;
+
     view::bufferWidth = newBufferWidth;
     view::bufferHeight = newBufferHeight;
     view::windowWidth = newWindowWidth;


### PR DESCRIPTION
Hello 👋

I found a slight annoyance when using polyscope on windows where glm::perspective would crash when I minimize the viewport since it takes the aspect ratio.