### PR TITLE
add callback func to allow ImGui Font setting.

### DIFF
--- a/include/polyscope/polyscope.h
+++ b/include/polyscope/polyscope.h
@@ -116,6 +116,15 @@ bool redrawRequested();
 void pushContext(std::function<void()> callbackFunction, bool drawDefaultUI = true);
 void popContext();
 
+// These helpers are called internally by Polyscope to render and build the UI.
+// Normally, applications should not need to call them, but in advanced settings when making custom UIs, they may be
+// useful to manually build pieces of the interface.
+void buildPolyscopeGui();
+void buildStructureGui();
+void buildPickGui();
+void buildUserGuiAndInvokeCallback();
+
+
 // === Utility
 
 // Execute one iteration of the main loop

--- a/include/polyscope/polyscope.h
+++ b/include/polyscope/polyscope.h
@@ -60,6 +60,9 @@ extern std::vector<SlicePlane*> slicePlanes;
 // a callback function used to render a "user" gui
 extern std::function<void()> userCallback;
 
+// a callback function used to set ImGui specific settings (style, font, etc.)
+extern std::function<void()> userGuiCallback;
+
 // representative center for all registered structures
 glm::vec3 center();
 

--- a/include/polyscope/render/engine.h
+++ b/include/polyscope/render/engine.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <functional>
 
 #include "polyscope/render/color_maps.h"
 #include "polyscope/render/ground_plane.h"
@@ -356,7 +357,7 @@ public:
   virtual void setClipboardText(std::string text) = 0;
 
   // ImGui
-  virtual void initializeImGui() = 0;
+  virtual void initializeImGui(std::function<void()> callback) = 0;
   virtual void shutdownImGui() = 0;
   void setImGuiStyle();
   ImFontAtlas* getImGuiGlobalFontAtlas();

--- a/include/polyscope/render/mock_opengl/mock_gl_engine.h
+++ b/include/polyscope/render/mock_opengl/mock_gl_engine.h
@@ -229,7 +229,7 @@ public:
   void setClipboardText(std::string text) override;
 
   // ImGui
-  void initializeImGui() override;
+  void initializeImGui(std::function<void()> callback) override;
   void shutdownImGui() override;
   void ImGuiNewFrame() override;
   void ImGuiRender() override;

--- a/include/polyscope/render/opengl/gl_engine.h
+++ b/include/polyscope/render/opengl/gl_engine.h
@@ -276,7 +276,7 @@ public:
   void setClipboardText(std::string text) override;
 
   // ImGui
-  void initializeImGui() override;
+  void initializeImGui(std::function<void()> callback = nullptr) override;
   void shutdownImGui() override;
   void ImGuiNewFrame() override;
   void ImGuiRender() override;

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -123,7 +123,7 @@ void init(std::string backend) {
 
   // Initialie ImGUI
   IMGUI_CHECKVERSION();
-  render::engine->initializeImGui();
+  render::engine->initializeImGui(state::userGuiCallback);
   // push a fake context which will never be used (but dodges some invalidation issues)
   contextStack.push_back(ContextEntry{ImGui::GetCurrentContext(), nullptr, false});
 

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -415,6 +415,10 @@ void renderSceneToScreen() {
   }
 }
 
+auto lastMainLoopIterTime = std::chrono::steady_clock::now();
+
+} // namespace
+
 void buildPolyscopeGui() {
 
   // Create window
@@ -555,6 +559,25 @@ void buildStructureGui() {
   ImGui::End();
 }
 
+void buildPickGui() {
+  if (pick::haveSelection()) {
+
+    ImGui::SetNextWindowPos(ImVec2(view::windowWidth - (rightWindowsWidth + imguiStackMargin),
+                                   2 * imguiStackMargin + lastWindowHeightUser));
+    ImGui::SetNextWindowSize(ImVec2(rightWindowsWidth, 0.));
+
+    ImGui::Begin("Selection", nullptr);
+    std::pair<Structure*, size_t> selection = pick::getSelection();
+
+    ImGui::TextUnformatted((selection.first->typeName() + ": " + selection.first->name).c_str());
+    ImGui::Separator();
+    selection.first->buildPickUI(selection.second);
+
+    rightWindowsWidth = ImGui::GetWindowWidth();
+    ImGui::End();
+  }
+}
+
 void buildUserGuiAndInvokeCallback() {
 
   if (!options::invokeUserCallbackForNestedShow && contextStack.size() > 2) {
@@ -586,29 +609,6 @@ void buildUserGuiAndInvokeCallback() {
     lastWindowHeightUser = imguiStackMargin;
   }
 }
-
-void buildPickGui() {
-  if (pick::haveSelection()) {
-
-    ImGui::SetNextWindowPos(ImVec2(view::windowWidth - (rightWindowsWidth + imguiStackMargin),
-                                   2 * imguiStackMargin + lastWindowHeightUser));
-    ImGui::SetNextWindowSize(ImVec2(rightWindowsWidth, 0.));
-
-    ImGui::Begin("Selection", nullptr);
-    std::pair<Structure*, size_t> selection = pick::getSelection();
-
-    ImGui::TextUnformatted((selection.first->typeName() + ": " + selection.first->name).c_str());
-    ImGui::Separator();
-    selection.first->buildPickUI(selection.second);
-
-    rightWindowsWidth = ImGui::GetWindowWidth();
-    ImGui::End();
-  }
-}
-
-auto lastMainLoopIterTime = std::chrono::steady_clock::now();
-
-} // namespace
 
 void draw(bool withUI, bool withContextCallback) {
   processLazyProperties();

--- a/src/render/mock_opengl/mock_gl_engine.cpp
+++ b/src/render/mock_opengl/mock_gl_engine.cpp
@@ -1172,7 +1172,7 @@ void MockGLEngine::initialize() {
   populateDefaultShadersAndRules();
 }
 
-void MockGLEngine::initializeImGui() {
+void MockGLEngine::initializeImGui(std::function<void()> callback) {
   ImGui::CreateContext(); // must call once at start
   configureImGui();
 }

--- a/src/render/opengl/gl_engine.cpp
+++ b/src/render/opengl/gl_engine.cpp
@@ -1792,10 +1792,10 @@ void GLEngine::updateWindowSize(bool force) {
     requestRedraw();
 
     // prevent any division by zero for e.g. aspect ratio calcs
-    if (newBufferHeight == 0) 
+    if (newBufferHeight == 0)
       newBufferHeight = 1;
 
-    if (newWindowHeight == 0) 
+    if (newWindowHeight == 0)
       newWindowHeight = 1;
 
     view::bufferWidth = newBufferWidth;

--- a/src/render/opengl/gl_engine.cpp
+++ b/src/render/opengl/gl_engine.cpp
@@ -1792,9 +1792,11 @@ void GLEngine::updateWindowSize(bool force) {
     requestRedraw();
 
     // prevent any division by zero for e.g. aspect ratio calcs
-    if (newBufferHeight == 0) newBufferHeight = 1;
+    if (newBufferHeight == 0) 
+      newBufferHeight = 1;
 
-    if (newWindowHeight == 0) newWindowHeight = 1;
+    if (newWindowHeight == 0) 
+      newWindowHeight = 1;
 
     view::bufferWidth = newBufferWidth;
     view::bufferHeight = newBufferHeight;

--- a/src/render/opengl/gl_engine.cpp
+++ b/src/render/opengl/gl_engine.cpp
@@ -1719,7 +1719,7 @@ void GLEngine::initialize() {
 }
 
 
-void GLEngine::initializeImGui() {
+void GLEngine::initializeImGui(std::function<void()> callback) {
   bindDisplay();
 
   ImGui::CreateContext(); // must call once at start
@@ -1729,7 +1729,10 @@ void GLEngine::initializeImGui() {
   const char* glsl_version = "#version 150";
   ImGui_ImplOpenGL3_Init(glsl_version);
 
-  configureImGui();
+  if (!callback)
+    configureImGui();
+  else
+    callback();
 }
 
 void GLEngine::shutdownImGui() {
@@ -1789,11 +1792,9 @@ void GLEngine::updateWindowSize(bool force) {
     requestRedraw();
 
     // prevent any division by zero for e.g. aspect ratio calcs
-    if (newBufferHeight == 0)
-      newBufferHeight = 1;
+    if (newBufferHeight == 0) newBufferHeight = 1;
 
-    if (newWindowHeight == 0)
-      newWindowHeight = 1;
+    if (newWindowHeight == 0) newWindowHeight = 1;
 
     view::bufferWidth = newBufferWidth;
     view::bufferHeight = newBufferHeight;

--- a/src/render/opengl/gl_engine.cpp
+++ b/src/render/opengl/gl_engine.cpp
@@ -1731,8 +1731,10 @@ void GLEngine::initializeImGui(std::function<void()> callback) {
 
   if (!callback)
     configureImGui();
-  else
+  else {
     callback();
+    globalFontAtlas = ImGui::GetIO().Fonts;
+  }
 }
 
 void GLEngine::shutdownImGui() {

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -12,6 +12,7 @@ std::tuple<glm::vec3, glm::vec3> boundingBox =
     std::tuple<glm::vec3, glm::vec3>{glm::vec3{-1., -1., -1.}, glm::vec3{1., 1., 1.}};
 std::map<std::string, std::map<std::string, Structure*>> structures;
 std::function<void()> userCallback = nullptr;
+std::function<void()> userGuiCallback = nullptr;
 
 // Lists of things
 std::set<Widget*> widgets;


### PR DESCRIPTION
This PR tries to resolve issues described in: https://github.com/nmwsharp/polyscope/issues/133, https://github.com/nmwsharp/polyscope/issues/135.

add a callback function to the render::engine and its derivatives to allow external ImGui font setting when using `polyscope` as a library.

One issue that still exists is the `globalFontAtlas` variable cannot be set from the external function, though it looks that variable does not affect anything. But an additional step was added to make sure that variable is set after the font setting.