### PR TITLE
add focus window method with some minor clang-format changes

### DIFF
--- a/include/polyscope/options.h
+++ b/include/polyscope/options.h
@@ -54,6 +54,9 @@ extern bool openImGuiWindowForUserCallback;
 // If true, the user callback will be invoked for nested calls to polyscope::show(), otherwise not (default: false)
 extern bool invokeUserCallbackForNestedShow;
 
+// If true, focus the Polyscope window when shown (default: false)
+extern bool giveFocusOnShow;
+
 // === Scene options
 
 // Behavior of the ground plane

--- a/include/polyscope/render/engine.h
+++ b/include/polyscope/render/engine.h
@@ -345,6 +345,7 @@ public:
 
   // === Windowing and framework things
   virtual void makeContextCurrent() = 0;
+  virtual void focusWindow() = 0;
   virtual void showWindow() = 0;
   virtual void hideWindow() = 0;
   virtual void updateWindowSize(bool force = false) = 0;
@@ -413,7 +414,7 @@ public:
   virtual void applyTransparencySettings() = 0;
   void addSlicePlane(std::string uniquePostfix);
   void removeSlicePlane(std::string uniquePostfix);
-  bool slicePlanesEnabled(); // true if there is at least one slice plane in the scene
+  bool slicePlanesEnabled();                     // true if there is at least one slice plane in the scene
   virtual void setFrontFaceCCW(bool newVal) = 0; // true if CCW triangles are considered front-facing; false otherwise
   bool getFrontFaceCCW();
 

--- a/include/polyscope/render/mock_opengl/mock_gl_engine.h
+++ b/include/polyscope/render/mock_opengl/mock_gl_engine.h
@@ -218,6 +218,7 @@ public:
 
   // === Windowing and framework things
   void makeContextCurrent() override;
+  void focusWindow() override;
   void showWindow() override;
   void hideWindow() override;
   void updateWindowSize(bool force = false) override;
@@ -259,11 +260,10 @@ public:
 
   // Transparency
   virtual void applyTransparencySettings() override;
- 
+
   virtual void setFrontFaceCCW(bool newVal) override;
 
 protected:
-  
   // Helpers
   virtual void createSlicePlaneFliterRule(std::string name) override;
 

--- a/include/polyscope/render/opengl/gl_engine.h
+++ b/include/polyscope/render/opengl/gl_engine.h
@@ -265,6 +265,7 @@ public:
 
   // === Windowing and framework things
   void makeContextCurrent() override;
+  void focusWindow() override;
   void showWindow() override;
   void hideWindow() override;
   void updateWindowSize(bool force = false) override;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -19,6 +19,7 @@ bool automaticallyComputeSceneExtents = true;
 bool buildGui = true;
 bool openImGuiWindowForUserCallback = true;
 bool invokeUserCallbackForNestedShow = false;
+bool giveFocusOnShow = false;
 
 bool screenshotTransparency = true;
 std::string screenshotExtension = ".png";
@@ -29,8 +30,8 @@ std::string screenshotExtension = ".png";
 bool groundPlaneEnabled = true;
 GroundPlaneMode groundPlaneMode = GroundPlaneMode::TileReflection;
 ScaledValue<float> groundPlaneHeightFactor = 0;
-int shadowBlurIters = 2; 
-float shadowDarkness = 0.25; 
+int shadowBlurIters = 2;
+float shadowDarkness = 0.25;
 
 // Rendering options
 

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -155,6 +155,7 @@ void pushContext(std::function<void()> callbackFunction, bool drawDefaultUI) {
 
   // Make sure the window is visible
   render::engine->showWindow();
+  render::engine->focusWindow();
 
   // Re-enter main loop until the context has been popped
   size_t currentContextStackSize = contextStack.size();
@@ -1015,7 +1016,7 @@ void updateStructureExtents() {
 
   // If we got a degenerate bounding box, perturb it slightly
   if (minBbox == maxBbox) {
-    double offsetScale = (state::lengthScale == 0) ? 1e-5 : state::lengthScale*1e-5;
+    double offsetScale = (state::lengthScale == 0) ? 1e-5 : state::lengthScale * 1e-5;
     glm::vec3 offset{offsetScale, offsetScale, offsetScale};
     minBbox = minBbox - offset / 2.f;
     maxBbox = maxBbox + offset / 2.f;

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -155,7 +155,10 @@ void pushContext(std::function<void()> callbackFunction, bool drawDefaultUI) {
 
   // Make sure the window is visible
   render::engine->showWindow();
-  render::engine->focusWindow();
+
+  if (options::giveFocusOnShow) {
+    render::engine->focusWindow();
+  }
 
   // Re-enter main loop until the context has been popped
   size_t currentContextStackSize = contextStack.size();

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -156,10 +156,6 @@ void pushContext(std::function<void()> callbackFunction, bool drawDefaultUI) {
   // Make sure the window is visible
   render::engine->showWindow();
 
-  if (options::giveFocusOnShow) {
-    render::engine->focusWindow();
-  }
-
   // Re-enter main loop until the context has been popped
   size_t currentContextStackSize = contextStack.size();
   while (contextStack.size() >= currentContextStackSize) {
@@ -726,6 +722,11 @@ void show(size_t forFrames) {
       forFrames--;
     }
   };
+
+  if (options::giveFocusOnShow) {
+    render::engine->focusWindow();
+  }
+
   pushContext(checkFrames);
 
   if (options::usePrefsFile) {

--- a/src/render/mock_opengl/mock_gl_engine.cpp
+++ b/src/render/mock_opengl/mock_gl_engine.cpp
@@ -1202,6 +1202,8 @@ void MockGLEngine::checkError(bool fatal) { checkGLError(fatal); }
 
 void MockGLEngine::makeContextCurrent() {}
 
+void MockGLEngine::focusWindow() {}
+
 void MockGLEngine::showWindow() {}
 
 void MockGLEngine::hideWindow() {}

--- a/src/render/opengl/gl_engine.cpp
+++ b/src/render/opengl/gl_engine.cpp
@@ -1771,6 +1771,8 @@ void GLEngine::checkError(bool fatal) { checkGLError(fatal); }
 
 void GLEngine::makeContextCurrent() { glfwMakeContextCurrent(mainWindow); }
 
+void GLEngine::focusWindow() { glfwFocusWindow(mainWindow); }
+
 void GLEngine::showWindow() { glfwShowWindow(mainWindow); }
 
 void GLEngine::hideWindow() {
@@ -1789,11 +1791,9 @@ void GLEngine::updateWindowSize(bool force) {
     requestRedraw();
 
     // prevent any division by zero for e.g. aspect ratio calcs
-    if (newBufferHeight == 0)
-      newBufferHeight = 1;
+    if (newBufferHeight == 0) newBufferHeight = 1;
 
-    if (newWindowHeight == 0)
-      newWindowHeight = 1;
+    if (newWindowHeight == 0) newWindowHeight = 1;
 
     view::bufferWidth = newBufferWidth;
     view::bufferHeight = newBufferHeight;


### PR DESCRIPTION
When using Polyscope within Python on OSX, the window pops up behind the currently used windows and has to be focused in order to see it.  Add and use a `focusWindow` method so that it shows at the front when the windows is created.

* add a `focusWindow` method
* use `focusWindow` when a window is created

Also, there were some minor clang-format changes when editing these files.  I figured they should be included since the changes were made based on the config `.clang-format` file in this repository.