### PR TITLE
fix sphere and cylinder picking.

### DIFF
--- a/src/render/opengl/shaders/cylinder_shaders.cpp
+++ b/src/render/opengl/shaders/cylinder_shaders.cpp
@@ -384,9 +384,9 @@ const ShaderReplacementRule CYLINDER_PROPAGATE_PICK (
           in vec3 a_colorTailToGeom[];
           in vec3 a_colorTipToGeom[];
           in vec3 a_colorEdgeToGeom[];
-          out vec3 a_colorTailToFrag;
-          out vec3 a_colorTipToFrag;
-          out vec3 a_colorEdgeToFrag;
+          flat out vec3 a_colorTailToFrag;
+          flat out vec3 a_colorTipToFrag;
+          flat out vec3 a_colorEdgeToFrag;
         )"},
       {"GEOM_PER_EMIT", R"(
           a_colorTailToFrag = a_colorTailToGeom[0]; 
@@ -394,9 +394,9 @@ const ShaderReplacementRule CYLINDER_PROPAGATE_PICK (
           a_colorEdgeToFrag = a_colorEdgeToGeom[0]; 
         )"},
       {"FRAG_DECLARATIONS", R"(
-          in vec3 a_colorTailToFrag;
-          in vec3 a_colorTipToFrag;
-          in vec3 a_colorEdgeToFrag;
+          flat in vec3 a_colorTailToFrag;
+          flat in vec3 a_colorTipToFrag;
+          flat in vec3 a_colorEdgeToFrag;
           float length2(vec3 x);
         )"},
       {"GENERATE_SHADE_VALUE", R"(

--- a/src/render/opengl/shaders/sphere_shaders.cpp
+++ b/src/render/opengl/shaders/sphere_shaders.cpp
@@ -425,13 +425,13 @@ const ShaderReplacementRule SPHERE_PROPAGATE_COLOR (
         )"},
       {"GEOM_DECLARATIONS", R"(
           in vec3 a_colorToGeom[];
-          out vec3 a_colorToFrag;
+          flat out vec3 a_colorToFrag;
         )"},
       {"GEOM_PER_EMIT", R"(
           a_colorToFrag = a_colorToGeom[0]; 
         )"},
       {"FRAG_DECLARATIONS", R"(
-          in vec3 a_colorToFrag;
+          flat in vec3 a_colorToFrag;
         )"},
       {"GENERATE_SHADE_VALUE", R"(
           vec3 shadeColor = a_colorToFrag;


### PR DESCRIPTION
Encoded picking color pass by vertex attribute would be used by raster interpolation, make decoded picking id may not be the precise value passed in,
and this line of debug check may fail:
https://github.com/nmwsharp/polyscope/blob/master/include/polyscope/pick.ipp#L38
