### PR TITLE
Add corner scalar quantity, corner picker

### DIFF
--- a/include/polyscope/surface_mesh.h
+++ b/include/polyscope/surface_mesh.h
@@ -52,40 +52,40 @@ class SurfaceGraphQuantity;
 
 template <> // Specialize the quantity type
 struct QuantityTypeHelper<SurfaceMesh> {
-    typedef SurfaceMeshQuantity type;
+  typedef SurfaceMeshQuantity type;
 };
 
 
 // === The grand surface mesh class
 
 class SurfaceMesh : public QuantityStructure<SurfaceMesh> {
-  public:
-    typedef SurfaceMeshQuantity QuantityType;
+public:
+  typedef SurfaceMeshQuantity QuantityType;
 
-    // === Member functions ===
+  // === Member functions ===
 
-    // Construct a new surface mesh structure
-    SurfaceMesh(std::string name, const std::vector<glm::vec3>& vertexPositions,
-                const std::vector<std::vector<size_t>>& faceIndices);
+  // Construct a new surface mesh structure
+  SurfaceMesh(std::string name, const std::vector<glm::vec3>& vertexPositions,
+              const std::vector<std::vector<size_t>>& faceIndices);
 
-    // Build the imgui display
-    virtual void buildCustomUI() override;
-    virtual void buildCustomOptionsUI() override;
-    virtual void buildPickUI(size_t localPickID) override;
+  // Build the imgui display
+  virtual void buildCustomUI() override;
+  virtual void buildCustomOptionsUI() override;
+  virtual void buildPickUI(size_t localPickID) override;
 
-    // Render the the structure on screen
-    virtual void draw() override;
+  // Render the the structure on screen
+  virtual void draw() override;
 
-    // Render for picking
-    virtual void drawPick() override;
+  // Render for picking
+  virtual void drawPick() override;
 
-    virtual void updateObjectSpaceBounds() override;
-    virtual std::string typeName() override;
+  virtual void updateObjectSpaceBounds() override;
+  virtual std::string typeName() override;
 
-    virtual void refresh() override;
+  virtual void refresh() override;
 
-    // === Quantity-related
-    // clang-format off
+  // === Quantity-related
+  // clang-format off
 
   // = Scalars (expect scalar array)
   template <class T> SurfaceVertexScalarQuantity* addVertexScalarQuantity(std::string name, const T& data, DataType type = DataType::STANDARD); 
@@ -145,229 +145,217 @@ class SurfaceMesh : public QuantityStructure<SurfaceMesh> {
   void addVertexSelectionQuantity(std::string name, const T& initialMembership);
   // void addInputCurveQuantity(std::string name);
 
-    // clang-format on
+  // clang-format on
 
 
-    // === Make a one-time selection
-    long long int selectVertex();
-    // size_t selectFace();
+  // === Make a one-time selection
+  long long int selectVertex();
+  // size_t selectFace();
 
-    // === Mutate
-    template <class V>
-    void updateVertexPositions(const V& newPositions);
-    template <class V>
-    void updateVertexPositions2D(const V& newPositions2D);
-
-
-    // === Indexing conventions
-
-    // Permutation arrays. Empty == default ordering
-    std::vector<size_t> vertexPerm;
-    std::vector<size_t> facePerm;
-    std::vector<size_t> edgePerm;
-    std::vector<size_t> halfedgePerm;
-    std::vector<size_t> cornerPerm;
-
-    // Set permutations
-    template <class T>
-    void setVertexPermutation(const T& perm, size_t expectedSize = 0);
-    template <class T>
-    void setFacePermutation(const T& perm, size_t expectedSize = 0);
-    template <class T>
-    void setEdgePermutation(const T& perm, size_t expectedSize = 0);
-    template <class T>
-    void setHalfedgePermutation(const T& perm, size_t expectedSize = 0);
-    template <class T>
-    void setCornerPermutation(const T& perm, size_t expectedSize = 0);
-    template <class T>
-    void setAllPermutations(const std::array<std::pair<T, size_t>, 5>& perms);
-
-    // Get the expected data length, either using the default convention or a permutation as above
-    size_t vertexDataSize;
-    size_t faceDataSize;
-    size_t edgeDataSize;
-    size_t halfedgeDataSize;
-    size_t cornerDataSize;
+  // === Mutate
+  template <class V>
+  void updateVertexPositions(const V& newPositions);
+  template <class V>
+  void updateVertexPositions2D(const V& newPositions2D);
 
 
-    // === Helpers
-    void setShadeStyle(ShadeStyle newShadeStyle);
+  // === Indexing conventions
+
+  // Permutation arrays. Empty == default ordering
+  std::vector<size_t> vertexPerm;
+  std::vector<size_t> facePerm;
+  std::vector<size_t> edgePerm;
+  std::vector<size_t> halfedgePerm;
+  std::vector<size_t> cornerPerm;
+
+  // Set permutations
+  template <class T>
+  void setVertexPermutation(const T& perm, size_t expectedSize = 0);
+  template <class T>
+  void setFacePermutation(const T& perm, size_t expectedSize = 0);
+  template <class T>
+  void setEdgePermutation(const T& perm, size_t expectedSize = 0);
+  template <class T>
+  void setHalfedgePermutation(const T& perm, size_t expectedSize = 0);
+  template <class T>
+  void setCornerPermutation(const T& perm, size_t expectedSize = 0);
+  template <class T>
+  void setAllPermutations(const std::array<std::pair<T, size_t>, 5>& perms);
+
+  // Get the expected data length, either using the default convention or a permutation as above
+  size_t vertexDataSize;
+  size_t faceDataSize;
+  size_t edgeDataSize;
+  size_t halfedgeDataSize;
+  size_t cornerDataSize;
 
 
-    // === Manage the mesh itself
-
-    // Core data
-    std::vector<glm::vec3> vertices;
-    std::vector<std::vector<size_t>> faces;
-
-    // Derived indices
-    std::vector<std::vector<size_t>> edgeIndices;
-    std::vector<std::vector<size_t>> halfedgeIndices;
-    // std::vector<std::vector<size_t>> cornerIndices; // should be the same as halfedgeIndices
-
-    // Counts
-    size_t nVertices() const {
-        return vertices.size();
-    }
-    size_t nFaces() const {
-        return faces.size();
-    }
-
-    size_t nFacesTriangulationCount = 0;
-    size_t nFacesTriangulation() const {
-        return faces.size();
-    }
-
-    size_t nEdgesCount = 0;
-    size_t nEdges() const {
-        return nEdgesCount;
-    }
-
-    size_t nCornersCount = 0; // = nHalfedges = sum face degree
-    size_t nCorners() const {
-        return nCornersCount;
-    }
-    size_t nHalfedges() const {
-        return nCornersCount;
-    }
-
-    // Derived geometric quantities
-    std::vector<glm::vec3> faceNormals;
-    std::vector<glm::vec3> vertexNormals;
-    std::vector<double> faceAreas;
-    std::vector<double> vertexAreas;
-    std::vector<double> edgeLengths;
-
-    // Not necessarily populated by default. Call ensureHaveFaceTangentSpaces() etc to be sure they are populated.
-    std::vector<std::array<glm::vec3, 2>> faceTangentSpaces;
-    std::vector<std::array<glm::vec3, 2>> vertexTangentSpaces;
-
-    // Derived connectivity quantities
-    // Not necessarily populated by default. Call ensureHaveManifoldConnectivity() to be sure they are populated.
-    std::vector<size_t> faceForHalfedge; // for halfedge i, the index of the face it is in
-    // Note that these are only really well-defined on a manifold mesh. On a non-manifold mesh, mesh, they will just
-    // point to _some_ sane entry
-    std::vector<size_t> twinHalfedge; // for halfedge i, the index of a twin halfedge
-
-    // = Mesh helpers
-    void computeCounts();       // call to populate counts and indices
-    void computeGeometryData(); // call to populate normals/areas/lengths
-    void ensureHaveManifoldConnectivity();
-    glm::vec3 faceCenter(size_t iF);
-
-    // if there are no tangent spaces, builds the default ones
-    bool hasFaceTangentSpaces();
-    bool hasVertexTangentSpaces();
-    void ensureHaveFaceTangentSpaces();   // sanity-check which errors if not present
-    void ensureHaveVertexTangentSpaces(); // sanity-check which errors if not present
-    void generateDefaultFaceTangentSpaces();
-    void generateDefaultVertexTangentSpaces();
-
-    // Set tangent space coordinates for vertices
-    template <class T>
-    void setVertexTangentBasisX(const T& vectors);
-    template <class T>
-    void setVertexTangentBasisX2D(const T& vectors);
-
-    // Set tangent space coordinates for faces
-    template <class T>
-    void setFaceTangentBasisX(const T& vectors);
-    template <class T>
-    void setFaceTangentBasisX2D(const T& vectors);
+  // === Helpers
+  void setShadeStyle(ShadeStyle newShadeStyle);
 
 
-    // Set tangent space coordinates for faces
+  // === Manage the mesh itself
+
+  // Core data
+  std::vector<glm::vec3> vertices;
+  std::vector<std::vector<size_t>> faces;
+
+  // Derived indices
+  std::vector<std::vector<size_t>> edgeIndices;
+  std::vector<std::vector<size_t>> halfedgeIndices;
+  // std::vector<std::vector<size_t>> cornerIndices; // should be the same as halfedgeIndices
+
+  // Counts
+  size_t nVertices() const { return vertices.size(); }
+  size_t nFaces() const { return faces.size(); }
+
+  size_t nFacesTriangulationCount = 0;
+  size_t nFacesTriangulation() const { return faces.size(); }
+
+  size_t nEdgesCount = 0;
+  size_t nEdges() const { return nEdgesCount; }
+
+  size_t nCornersCount = 0; // = nHalfedges = sum face degree
+  size_t nCorners() const { return nCornersCount; }
+  size_t nHalfedges() const { return nCornersCount; }
+
+  // Derived geometric quantities
+  std::vector<glm::vec3> faceNormals;
+  std::vector<glm::vec3> vertexNormals;
+  std::vector<double> faceAreas;
+  std::vector<double> vertexAreas;
+  std::vector<double> edgeLengths;
+
+  // Not necessarily populated by default. Call ensureHaveFaceTangentSpaces() etc to be sure they are populated.
+  std::vector<std::array<glm::vec3, 2>> faceTangentSpaces;
+  std::vector<std::array<glm::vec3, 2>> vertexTangentSpaces;
+
+  // Derived connectivity quantities
+  // Not necessarily populated by default. Call ensureHaveManifoldConnectivity() to be sure they are populated.
+  std::vector<size_t> faceForHalfedge; // for halfedge i, the index of the face it is in
+  // Note that these are only really well-defined on a manifold mesh. On a non-manifold mesh, mesh, they will just
+  // point to _some_ sane entry
+  std::vector<size_t> twinHalfedge; // for halfedge i, the index of a twin halfedge
+
+  // = Mesh helpers
+  void computeCounts();       // call to populate counts and indices
+  void computeGeometryData(); // call to populate normals/areas/lengths
+  void ensureHaveManifoldConnectivity();
+  glm::vec3 faceCenter(size_t iF);
+
+  // if there are no tangent spaces, builds the default ones
+  bool hasFaceTangentSpaces();
+  bool hasVertexTangentSpaces();
+  void ensureHaveFaceTangentSpaces();   // sanity-check which errors if not present
+  void ensureHaveVertexTangentSpaces(); // sanity-check which errors if not present
+  void generateDefaultFaceTangentSpaces();
+  void generateDefaultVertexTangentSpaces();
+
+  // Set tangent space coordinates for vertices
+  template <class T>
+  void setVertexTangentBasisX(const T& vectors);
+  template <class T>
+  void setVertexTangentBasisX2D(const T& vectors);
+
+  // Set tangent space coordinates for faces
+  template <class T>
+  void setFaceTangentBasisX(const T& vectors);
+  template <class T>
+  void setFaceTangentBasisX2D(const T& vectors);
 
 
-    // === Member variables ===
-    static const std::string structureTypeName;
-
-    // Picking helpers
-    // One of these will be non-null on return
-    // void getPickedElement(size_t localPickID, size_t& vOut, size_t& fOut, size_t& eOut, size_t& heOut);
-
-    // === Getters and setters for visualization settings
-
-    // Flat or smooth shading
-    SurfaceMesh* setSmoothShade(bool isSmooth);
-    bool isSmoothShade();
-
-    // Color of the mesh
-    SurfaceMesh* setSurfaceColor(glm::vec3 val);
-    glm::vec3 getSurfaceColor();
-
-    // Color of edges
-    SurfaceMesh* setEdgeColor(glm::vec3 val);
-    glm::vec3 getEdgeColor();
-
-    // Material
-    SurfaceMesh* setMaterial(std::string name);
-    std::string getMaterial();
-
-    // Backface color
-    SurfaceMesh* setBackFaceColor(glm::vec3 val);
-    glm::vec3 getBackFaceColor();
-
-    // Width of the edges. Scaled such that 1 is a reasonable weight for visible edges, but values  1 can be used for
-    // bigger edges. Use 0. to disable.
-    SurfaceMesh* setEdgeWidth(double newVal);
-    double getEdgeWidth();
-
-    // Backface policy
-    SurfaceMesh* setBackFacePolicy(BackFacePolicy newPolicy);
-    BackFacePolicy getBackFacePolicy();
-
-    // Rendering helpers used by quantities
-    void setSurfaceMeshUniforms(render::ShaderProgram& p);
-    void fillGeometryBuffers(render::ShaderProgram& p);
-    std::vector<std::string> addSurfaceMeshRules(std::vector<std::string> initRules, bool withMesh = true,
-                                                 bool withSurfaceShade = true);
-
-  private:
-    // Visualization settings
-    PersistentValue<bool> shadeSmooth;
-    PersistentValue<glm::vec3> surfaceColor;
-    PersistentValue<glm::vec3> edgeColor;
-    PersistentValue<std::string> material;
-    PersistentValue<float> edgeWidth;
-    PersistentValue<BackFacePolicy> backFacePolicy;
-    PersistentValue<glm::vec3> backFaceColor;
-
-    // Do setup work related to drawing, including allocating openGL data
-    void prepare();
-    void preparePick();
-    void geometryChanged(); // call whenever geometry changed
-
-    // Picking-related
-    // Order of indexing: vertices, faces, edges, halfedges
-    // Within each set, uses the implicit ordering from the mesh data structure
-    // These starts are LOCAL indices, indexing elements only with the mesh
-    size_t facePickIndStart, edgePickIndStart, halfedgePickIndStart, cornerPickIndStart;
-    void buildVertexInfoGui(size_t vInd);
-    void buildFaceInfoGui(size_t fInd);
-    void buildEdgeInfoGui(size_t eInd);
-    void buildHalfedgeInfoGui(size_t heInd);
-    void buildCornerInfoGui(size_t cInd);
-
-    // Gui implementation details
-
-    // Drawing related things
-    std::shared_ptr<render::ShaderProgram> program;
-    std::shared_ptr<render::ShaderProgram> pickProgram;
+  // Set tangent space coordinates for faces
 
 
-    // === Helper functions
+  // === Member variables ===
+  static const std::string structureTypeName;
 
-    // Initialization work
-    void initializeMeshTriangulation();
+  // Picking helpers
+  // One of these will be non-null on return
+  // void getPickedElement(size_t localPickID, size_t& vOut, size_t& fOut, size_t& eOut, size_t& heOut);
 
-    void fillGeometryBuffersSmooth(render::ShaderProgram& p);
-    void fillGeometryBuffersFlat(render::ShaderProgram& p);
-    glm::vec2 projectToScreenSpace(glm::vec3 coord);
-    // bool screenSpaceTriangleTest(size_t fInd, glm::vec2 testCoords, glm::vec3& bCoordOut);
+  // === Getters and setters for visualization settings
+
+  // Flat or smooth shading
+  SurfaceMesh* setSmoothShade(bool isSmooth);
+  bool isSmoothShade();
+
+  // Color of the mesh
+  SurfaceMesh* setSurfaceColor(glm::vec3 val);
+  glm::vec3 getSurfaceColor();
+
+  // Color of edges
+  SurfaceMesh* setEdgeColor(glm::vec3 val);
+  glm::vec3 getEdgeColor();
+
+  // Material
+  SurfaceMesh* setMaterial(std::string name);
+  std::string getMaterial();
+
+  // Backface color
+  SurfaceMesh* setBackFaceColor(glm::vec3 val);
+  glm::vec3 getBackFaceColor();
+
+  // Width of the edges. Scaled such that 1 is a reasonable weight for visible edges, but values  1 can be used for
+  // bigger edges. Use 0. to disable.
+  SurfaceMesh* setEdgeWidth(double newVal);
+  double getEdgeWidth();
+
+  // Backface policy
+  SurfaceMesh* setBackFacePolicy(BackFacePolicy newPolicy);
+  BackFacePolicy getBackFacePolicy();
+
+  // Rendering helpers used by quantities
+  void setSurfaceMeshUniforms(render::ShaderProgram& p);
+  void fillGeometryBuffers(render::ShaderProgram& p);
+  std::vector<std::string> addSurfaceMeshRules(std::vector<std::string> initRules, bool withMesh = true,
+                                               bool withSurfaceShade = true);
+
+private:
+  // Visualization settings
+  PersistentValue<bool> shadeSmooth;
+  PersistentValue<glm::vec3> surfaceColor;
+  PersistentValue<glm::vec3> edgeColor;
+  PersistentValue<std::string> material;
+  PersistentValue<float> edgeWidth;
+  PersistentValue<BackFacePolicy> backFacePolicy;
+  PersistentValue<glm::vec3> backFaceColor;
+
+  // Do setup work related to drawing, including allocating openGL data
+  void prepare();
+  void preparePick();
+  void geometryChanged(); // call whenever geometry changed
+
+  // Picking-related
+  // Order of indexing: vertices, faces, edges, halfedges
+  // Within each set, uses the implicit ordering from the mesh data structure
+  // These starts are LOCAL indices, indexing elements only with the mesh
+  size_t facePickIndStart, edgePickIndStart, halfedgePickIndStart, cornerPickIndStart;
+  void buildVertexInfoGui(size_t vInd);
+  void buildFaceInfoGui(size_t fInd);
+  void buildEdgeInfoGui(size_t eInd);
+  void buildHalfedgeInfoGui(size_t heInd);
+  void buildCornerInfoGui(size_t cInd);
+
+  // Gui implementation details
+
+  // Drawing related things
+  std::shared_ptr<render::ShaderProgram> program;
+  std::shared_ptr<render::ShaderProgram> pickProgram;
 
 
-    // clang-format off
+  // === Helper functions
+
+  // Initialization work
+  void initializeMeshTriangulation();
+
+  void fillGeometryBuffersSmooth(render::ShaderProgram& p);
+  void fillGeometryBuffersFlat(render::ShaderProgram& p);
+  glm::vec2 projectToScreenSpace(glm::vec3 coord);
+  // bool screenSpaceTriangleTest(size_t fInd, glm::vec2 testCoords, glm::vec3& bCoordOut);
+
+
+  // clang-format off
 
   // === Quantity adders
 
@@ -397,7 +385,7 @@ class SurfaceMesh : public QuantityStructure<SurfaceMesh> {
 
   void setVertexTangentBasisXImpl(const std::vector<glm::vec3>& vectors);
   void setFaceTangentBasisXImpl(const std::vector<glm::vec3>& vectors);
-    // clang-format on
+  // clang-format on
 };
 
 // Register functions

--- a/include/polyscope/surface_mesh.h
+++ b/include/polyscope/surface_mesh.h
@@ -36,6 +36,7 @@ class SurfaceFaceScalarQuantity;
 class SurfaceEdgeScalarQuantity;
 class SurfaceHalfedgeScalarQuantity;
 class SurfaceVertexScalarQuantity;
+class SurfaceCornerScalarQuantity;
 class SurfaceCornerParameterizationQuantity;
 class SurfaceVertexParameterizationQuantity;
 class SurfaceVertexVectorQuantity;
@@ -51,46 +52,47 @@ class SurfaceGraphQuantity;
 
 template <> // Specialize the quantity type
 struct QuantityTypeHelper<SurfaceMesh> {
-  typedef SurfaceMeshQuantity type;
+    typedef SurfaceMeshQuantity type;
 };
 
 
 // === The grand surface mesh class
 
 class SurfaceMesh : public QuantityStructure<SurfaceMesh> {
-public:
-  typedef SurfaceMeshQuantity QuantityType;
+  public:
+    typedef SurfaceMeshQuantity QuantityType;
 
-  // === Member functions ===
+    // === Member functions ===
 
-  // Construct a new surface mesh structure
-  SurfaceMesh(std::string name, const std::vector<glm::vec3>& vertexPositions,
-              const std::vector<std::vector<size_t>>& faceIndices);
+    // Construct a new surface mesh structure
+    SurfaceMesh(std::string name, const std::vector<glm::vec3>& vertexPositions,
+                const std::vector<std::vector<size_t>>& faceIndices);
 
-  // Build the imgui display
-  virtual void buildCustomUI() override;
-  virtual void buildCustomOptionsUI() override;
-  virtual void buildPickUI(size_t localPickID) override;
+    // Build the imgui display
+    virtual void buildCustomUI() override;
+    virtual void buildCustomOptionsUI() override;
+    virtual void buildPickUI(size_t localPickID) override;
 
-  // Render the the structure on screen
-  virtual void draw() override;
+    // Render the the structure on screen
+    virtual void draw() override;
 
-  // Render for picking
-  virtual void drawPick() override;
+    // Render for picking
+    virtual void drawPick() override;
 
-  virtual void updateObjectSpaceBounds() override;
-  virtual std::string typeName() override;
+    virtual void updateObjectSpaceBounds() override;
+    virtual std::string typeName() override;
 
-  virtual void refresh() override;
+    virtual void refresh() override;
 
-  // === Quantity-related
-  // clang-format off
+    // === Quantity-related
+    // clang-format off
 
   // = Scalars (expect scalar array)
   template <class T> SurfaceVertexScalarQuantity* addVertexScalarQuantity(std::string name, const T& data, DataType type = DataType::STANDARD); 
   template <class T> SurfaceFaceScalarQuantity* addFaceScalarQuantity(std::string name, const T& data, DataType type = DataType::STANDARD); 
   template <class T> SurfaceEdgeScalarQuantity* addEdgeScalarQuantity(std::string name, const T& data, DataType type = DataType::STANDARD); 
   template <class T> SurfaceHalfedgeScalarQuantity* addHalfedgeScalarQuantity(std::string name, const T& data, DataType type = DataType::STANDARD);
+    template <class T> SurfaceCornerScalarQuantity* addCornerScalarQuantity(std::string name, const T& data, DataType type = DataType::STANDARD);
 
   // = Distance (expect scalar array)
   template <class T> SurfaceVertexScalarQuantity* addVertexDistanceQuantity(std::string name, const T& data);
@@ -143,215 +145,229 @@ public:
   void addVertexSelectionQuantity(std::string name, const T& initialMembership);
   // void addInputCurveQuantity(std::string name);
 
-  // clang-format on
+    // clang-format on
 
 
-  // === Make a one-time selection
-  long long int selectVertex();
-  // size_t selectFace();
+    // === Make a one-time selection
+    long long int selectVertex();
+    // size_t selectFace();
 
-  // === Mutate
-  template <class V>
-  void updateVertexPositions(const V& newPositions);
-  template <class V>
-  void updateVertexPositions2D(const V& newPositions2D);
-
-
-  // === Indexing conventions
-
-  // Permutation arrays. Empty == default ordering
-  std::vector<size_t> vertexPerm;
-  std::vector<size_t> facePerm;
-  std::vector<size_t> edgePerm;
-  std::vector<size_t> halfedgePerm;
-  std::vector<size_t> cornerPerm;
-
-  // Set permutations
-  template <class T>
-  void setVertexPermutation(const T& perm, size_t expectedSize = 0);
-  template <class T>
-  void setFacePermutation(const T& perm, size_t expectedSize = 0);
-  template <class T>
-  void setEdgePermutation(const T& perm, size_t expectedSize = 0);
-  template <class T>
-  void setHalfedgePermutation(const T& perm, size_t expectedSize = 0);
-  template <class T>
-  void setCornerPermutation(const T& perm, size_t expectedSize = 0);
-  template <class T>
-  void setAllPermutations(const std::array<std::pair<T, size_t>, 5>& perms);
-
-  // Get the expected data length, either using the default convention or a permutation as above
-  size_t vertexDataSize;
-  size_t faceDataSize;
-  size_t edgeDataSize;
-  size_t halfedgeDataSize;
-  size_t cornerDataSize;
+    // === Mutate
+    template <class V>
+    void updateVertexPositions(const V& newPositions);
+    template <class V>
+    void updateVertexPositions2D(const V& newPositions2D);
 
 
-  // === Helpers
-  void setShadeStyle(ShadeStyle newShadeStyle);
+    // === Indexing conventions
+
+    // Permutation arrays. Empty == default ordering
+    std::vector<size_t> vertexPerm;
+    std::vector<size_t> facePerm;
+    std::vector<size_t> edgePerm;
+    std::vector<size_t> halfedgePerm;
+    std::vector<size_t> cornerPerm;
+
+    // Set permutations
+    template <class T>
+    void setVertexPermutation(const T& perm, size_t expectedSize = 0);
+    template <class T>
+    void setFacePermutation(const T& perm, size_t expectedSize = 0);
+    template <class T>
+    void setEdgePermutation(const T& perm, size_t expectedSize = 0);
+    template <class T>
+    void setHalfedgePermutation(const T& perm, size_t expectedSize = 0);
+    template <class T>
+    void setCornerPermutation(const T& perm, size_t expectedSize = 0);
+    template <class T>
+    void setAllPermutations(const std::array<std::pair<T, size_t>, 5>& perms);
+
+    // Get the expected data length, either using the default convention or a permutation as above
+    size_t vertexDataSize;
+    size_t faceDataSize;
+    size_t edgeDataSize;
+    size_t halfedgeDataSize;
+    size_t cornerDataSize;
 
 
-  // === Manage the mesh itself
-
-  // Core data
-  std::vector<glm::vec3> vertices;
-  std::vector<std::vector<size_t>> faces;
-
-  // Derived indices
-  std::vector<std::vector<size_t>> edgeIndices;
-  std::vector<std::vector<size_t>> halfedgeIndices;
-
-  // Counts
-  size_t nVertices() const { return vertices.size(); }
-  size_t nFaces() const { return faces.size(); }
-
-  size_t nFacesTriangulationCount = 0;
-  size_t nFacesTriangulation() const { return faces.size(); }
-
-  size_t nEdgesCount = 0;
-  size_t nEdges() const { return nEdgesCount; }
-
-  size_t nCornersCount = 0; // = nHalfedges = sum face degree
-  size_t nCorners() const { return nCornersCount; }
-  size_t nHalfedges() const { return nCornersCount; }
-
-  // Derived geometric quantities
-  std::vector<glm::vec3> faceNormals;
-  std::vector<glm::vec3> vertexNormals;
-  std::vector<double> faceAreas;
-  std::vector<double> vertexAreas;
-  std::vector<double> edgeLengths;
-
-  // Not necessarily populated by default. Call ensureHaveFaceTangentSpaces() etc to be sure they are populated.
-  std::vector<std::array<glm::vec3, 2>> faceTangentSpaces;
-  std::vector<std::array<glm::vec3, 2>> vertexTangentSpaces;
-
-  // Derived connectivity quantities
-  // Not necessarily populated by default. Call ensureHaveManifoldConnectivity() to be sure they are populated.
-  std::vector<size_t> faceForHalfedge; // for halfedge i, the index of the face it is in
-  // Note that these are only really well-defined on a manifold mesh. On a non-manifold mesh, mesh, they will just
-  // point to _some_ sane entry
-  std::vector<size_t> twinHalfedge; // for halfedge i, the index of a twin halfedge
-
-  // = Mesh helpers
-  void computeCounts();       // call to populate counts and indices
-  void computeGeometryData(); // call to populate normals/areas/lengths
-  void ensureHaveManifoldConnectivity();
-  glm::vec3 faceCenter(size_t iF);
-
-  // if there are no tangent spaces, builds the default ones
-  bool hasFaceTangentSpaces();
-  bool hasVertexTangentSpaces();
-  void ensureHaveFaceTangentSpaces();   // sanity-check which errors if not present
-  void ensureHaveVertexTangentSpaces(); // sanity-check which errors if not present
-  void generateDefaultFaceTangentSpaces();
-  void generateDefaultVertexTangentSpaces();
-
-  // Set tangent space coordinates for vertices
-  template <class T>
-  void setVertexTangentBasisX(const T& vectors);
-  template <class T>
-  void setVertexTangentBasisX2D(const T& vectors);
-
-  // Set tangent space coordinates for faces
-  template <class T>
-  void setFaceTangentBasisX(const T& vectors);
-  template <class T>
-  void setFaceTangentBasisX2D(const T& vectors);
+    // === Helpers
+    void setShadeStyle(ShadeStyle newShadeStyle);
 
 
-  // Set tangent space coordinates for faces
+    // === Manage the mesh itself
+
+    // Core data
+    std::vector<glm::vec3> vertices;
+    std::vector<std::vector<size_t>> faces;
+
+    // Derived indices
+    std::vector<std::vector<size_t>> edgeIndices;
+    std::vector<std::vector<size_t>> halfedgeIndices;
+    // std::vector<std::vector<size_t>> cornerIndices; // should be the same as halfedgeIndices
+
+    // Counts
+    size_t nVertices() const {
+        return vertices.size();
+    }
+    size_t nFaces() const {
+        return faces.size();
+    }
+
+    size_t nFacesTriangulationCount = 0;
+    size_t nFacesTriangulation() const {
+        return faces.size();
+    }
+
+    size_t nEdgesCount = 0;
+    size_t nEdges() const {
+        return nEdgesCount;
+    }
+
+    size_t nCornersCount = 0; // = nHalfedges = sum face degree
+    size_t nCorners() const {
+        return nCornersCount;
+    }
+    size_t nHalfedges() const {
+        return nCornersCount;
+    }
+
+    // Derived geometric quantities
+    std::vector<glm::vec3> faceNormals;
+    std::vector<glm::vec3> vertexNormals;
+    std::vector<double> faceAreas;
+    std::vector<double> vertexAreas;
+    std::vector<double> edgeLengths;
+
+    // Not necessarily populated by default. Call ensureHaveFaceTangentSpaces() etc to be sure they are populated.
+    std::vector<std::array<glm::vec3, 2>> faceTangentSpaces;
+    std::vector<std::array<glm::vec3, 2>> vertexTangentSpaces;
+
+    // Derived connectivity quantities
+    // Not necessarily populated by default. Call ensureHaveManifoldConnectivity() to be sure they are populated.
+    std::vector<size_t> faceForHalfedge; // for halfedge i, the index of the face it is in
+    // Note that these are only really well-defined on a manifold mesh. On a non-manifold mesh, mesh, they will just
+    // point to _some_ sane entry
+    std::vector<size_t> twinHalfedge; // for halfedge i, the index of a twin halfedge
+
+    // = Mesh helpers
+    void computeCounts();       // call to populate counts and indices
+    void computeGeometryData(); // call to populate normals/areas/lengths
+    void ensureHaveManifoldConnectivity();
+    glm::vec3 faceCenter(size_t iF);
+
+    // if there are no tangent spaces, builds the default ones
+    bool hasFaceTangentSpaces();
+    bool hasVertexTangentSpaces();
+    void ensureHaveFaceTangentSpaces();   // sanity-check which errors if not present
+    void ensureHaveVertexTangentSpaces(); // sanity-check which errors if not present
+    void generateDefaultFaceTangentSpaces();
+    void generateDefaultVertexTangentSpaces();
+
+    // Set tangent space coordinates for vertices
+    template <class T>
+    void setVertexTangentBasisX(const T& vectors);
+    template <class T>
+    void setVertexTangentBasisX2D(const T& vectors);
+
+    // Set tangent space coordinates for faces
+    template <class T>
+    void setFaceTangentBasisX(const T& vectors);
+    template <class T>
+    void setFaceTangentBasisX2D(const T& vectors);
 
 
-  // === Member variables ===
-  static const std::string structureTypeName;
-
-  // Picking helpers
-  // One of these will be non-null on return
-  // void getPickedElement(size_t localPickID, size_t& vOut, size_t& fOut, size_t& eOut, size_t& heOut);
-
-  // === Getters and setters for visualization settings
-
-  // Flat or smooth shading
-  SurfaceMesh* setSmoothShade(bool isSmooth);
-  bool isSmoothShade();
-
-  // Color of the mesh
-  SurfaceMesh* setSurfaceColor(glm::vec3 val);
-  glm::vec3 getSurfaceColor();
-
-  // Color of edges
-  SurfaceMesh* setEdgeColor(glm::vec3 val);
-  glm::vec3 getEdgeColor();
-
-  // Material
-  SurfaceMesh* setMaterial(std::string name);
-  std::string getMaterial();
-
-  // Backface color
-  SurfaceMesh* setBackFaceColor(glm::vec3 val);
-  glm::vec3 getBackFaceColor();
-
-  // Width of the edges. Scaled such that 1 is a reasonable weight for visible edges, but values  1 can be used for
-  // bigger edges. Use 0. to disable.
-  SurfaceMesh* setEdgeWidth(double newVal);
-  double getEdgeWidth();
-
-  // Backface policy
-  SurfaceMesh* setBackFacePolicy(BackFacePolicy newPolicy);
-  BackFacePolicy getBackFacePolicy();
-
-  // Rendering helpers used by quantities
-  void setSurfaceMeshUniforms(render::ShaderProgram& p);
-  void fillGeometryBuffers(render::ShaderProgram& p);
-  std::vector<std::string> addSurfaceMeshRules(std::vector<std::string> initRules, bool withMesh = true,
-                                               bool withSurfaceShade = true);
-
-private:
-  // Visualization settings
-  PersistentValue<bool> shadeSmooth;
-  PersistentValue<glm::vec3> surfaceColor;
-  PersistentValue<glm::vec3> edgeColor;
-  PersistentValue<std::string> material;
-  PersistentValue<float> edgeWidth;
-  PersistentValue<BackFacePolicy> backFacePolicy;
-  PersistentValue<glm::vec3> backFaceColor;
-
-  // Do setup work related to drawing, including allocating openGL data
-  void prepare();
-  void preparePick();
-  void geometryChanged(); // call whenever geometry changed
-
-  // Picking-related
-  // Order of indexing: vertices, faces, edges, halfedges
-  // Within each set, uses the implicit ordering from the mesh data structure
-  // These starts are LOCAL indices, indexing elements only with the mesh
-  size_t facePickIndStart, edgePickIndStart, halfedgePickIndStart;
-  void buildVertexInfoGui(size_t vInd);
-  void buildFaceInfoGui(size_t fInd);
-  void buildEdgeInfoGui(size_t eInd);
-  void buildHalfedgeInfoGui(size_t heInd);
-
-  // Gui implementation details
-
-  // Drawing related things
-  std::shared_ptr<render::ShaderProgram> program;
-  std::shared_ptr<render::ShaderProgram> pickProgram;
+    // Set tangent space coordinates for faces
 
 
-  // === Helper functions
+    // === Member variables ===
+    static const std::string structureTypeName;
 
-  // Initialization work
-  void initializeMeshTriangulation();
+    // Picking helpers
+    // One of these will be non-null on return
+    // void getPickedElement(size_t localPickID, size_t& vOut, size_t& fOut, size_t& eOut, size_t& heOut);
 
-  void fillGeometryBuffersSmooth(render::ShaderProgram& p);
-  void fillGeometryBuffersFlat(render::ShaderProgram& p);
-  glm::vec2 projectToScreenSpace(glm::vec3 coord);
-  // bool screenSpaceTriangleTest(size_t fInd, glm::vec2 testCoords, glm::vec3& bCoordOut);
+    // === Getters and setters for visualization settings
+
+    // Flat or smooth shading
+    SurfaceMesh* setSmoothShade(bool isSmooth);
+    bool isSmoothShade();
+
+    // Color of the mesh
+    SurfaceMesh* setSurfaceColor(glm::vec3 val);
+    glm::vec3 getSurfaceColor();
+
+    // Color of edges
+    SurfaceMesh* setEdgeColor(glm::vec3 val);
+    glm::vec3 getEdgeColor();
+
+    // Material
+    SurfaceMesh* setMaterial(std::string name);
+    std::string getMaterial();
+
+    // Backface color
+    SurfaceMesh* setBackFaceColor(glm::vec3 val);
+    glm::vec3 getBackFaceColor();
+
+    // Width of the edges. Scaled such that 1 is a reasonable weight for visible edges, but values  1 can be used for
+    // bigger edges. Use 0. to disable.
+    SurfaceMesh* setEdgeWidth(double newVal);
+    double getEdgeWidth();
+
+    // Backface policy
+    SurfaceMesh* setBackFacePolicy(BackFacePolicy newPolicy);
+    BackFacePolicy getBackFacePolicy();
+
+    // Rendering helpers used by quantities
+    void setSurfaceMeshUniforms(render::ShaderProgram& p);
+    void fillGeometryBuffers(render::ShaderProgram& p);
+    std::vector<std::string> addSurfaceMeshRules(std::vector<std::string> initRules, bool withMesh = true,
+                                                 bool withSurfaceShade = true);
+
+  private:
+    // Visualization settings
+    PersistentValue<bool> shadeSmooth;
+    PersistentValue<glm::vec3> surfaceColor;
+    PersistentValue<glm::vec3> edgeColor;
+    PersistentValue<std::string> material;
+    PersistentValue<float> edgeWidth;
+    PersistentValue<BackFacePolicy> backFacePolicy;
+    PersistentValue<glm::vec3> backFaceColor;
+
+    // Do setup work related to drawing, including allocating openGL data
+    void prepare();
+    void preparePick();
+    void geometryChanged(); // call whenever geometry changed
+
+    // Picking-related
+    // Order of indexing: vertices, faces, edges, halfedges
+    // Within each set, uses the implicit ordering from the mesh data structure
+    // These starts are LOCAL indices, indexing elements only with the mesh
+    size_t facePickIndStart, edgePickIndStart, halfedgePickIndStart, cornerPickIndStart;
+    void buildVertexInfoGui(size_t vInd);
+    void buildFaceInfoGui(size_t fInd);
+    void buildEdgeInfoGui(size_t eInd);
+    void buildHalfedgeInfoGui(size_t heInd);
+    void buildCornerInfoGui(size_t cInd);
+
+    // Gui implementation details
+
+    // Drawing related things
+    std::shared_ptr<render::ShaderProgram> program;
+    std::shared_ptr<render::ShaderProgram> pickProgram;
 
 
-  // clang-format off
+    // === Helper functions
+
+    // Initialization work
+    void initializeMeshTriangulation();
+
+    void fillGeometryBuffersSmooth(render::ShaderProgram& p);
+    void fillGeometryBuffersFlat(render::ShaderProgram& p);
+    glm::vec2 projectToScreenSpace(glm::vec3 coord);
+    // bool screenSpaceTriangleTest(size_t fInd, glm::vec2 testCoords, glm::vec3& bCoordOut);
+
+
+    // clang-format off
 
   // === Quantity adders
 
@@ -361,6 +377,7 @@ private:
   SurfaceFaceScalarQuantity* addFaceScalarQuantityImpl(std::string name, const std::vector<double>& data, DataType type);
   SurfaceEdgeScalarQuantity* addEdgeScalarQuantityImpl(std::string name, const std::vector<double>& data, DataType type);
   SurfaceHalfedgeScalarQuantity* addHalfedgeScalarQuantityImpl(std::string name, const std::vector<double>& data, DataType type);
+  SurfaceCornerScalarQuantity* addCornerScalarQuantityImpl(std::string name, const std::vector<double>& data, DataType type);
   SurfaceVertexScalarQuantity* addVertexDistanceQuantityImpl(std::string name, const std::vector<double>& data);
   SurfaceVertexScalarQuantity* addVertexSignedDistanceQuantityImpl(std::string name, const std::vector<double>& data);
   SurfaceCornerParameterizationQuantity* addParameterizationQuantityImpl(std::string name, const std::vector<glm::vec2>& coords, ParamCoordsType type);
@@ -380,7 +397,7 @@ private:
 
   void setVertexTangentBasisXImpl(const std::vector<glm::vec3>& vectors);
   void setFaceTangentBasisXImpl(const std::vector<glm::vec3>& vectors);
-  // clang-format on
+    // clang-format on
 };
 
 // Register functions

--- a/include/polyscope/surface_mesh.ipp
+++ b/include/polyscope/surface_mesh.ipp
@@ -4,200 +4,202 @@ namespace polyscope {
 // Shorthand to add a mesh to polyscope
 template <class V, class F>
 SurfaceMesh* registerSurfaceMesh(std::string name, const V& vertexPositions, const F& faceIndices) {
-  SurfaceMesh* s = new SurfaceMesh(name, standardizeVectorArray<glm::vec3, 3>(vertexPositions),
-                                   standardizeNestedList<size_t, F>(faceIndices));
-  bool success = registerStructure(s);
-  if (!success) {
-    safeDelete(s);
-  }
+    SurfaceMesh* s = new SurfaceMesh(name, standardizeVectorArray<glm::vec3, 3>(vertexPositions),
+                                     standardizeNestedList<size_t, F>(faceIndices));
+    bool success = registerStructure(s);
+    if (!success) {
+        safeDelete(s);
+    }
 
-  return s;
+    return s;
 }
 template <class V, class F>
 SurfaceMesh* registerSurfaceMesh2D(std::string name, const V& vertexPositions, const F& faceIndices) {
 
-  std::vector<glm::vec3> positions3D = standardizeVectorArray<glm::vec3, 2>(vertexPositions);
-  for (auto& v : positions3D) {
-    v.z = 0.;
-  }
+    std::vector<glm::vec3> positions3D = standardizeVectorArray<glm::vec3, 2>(vertexPositions);
+    for (auto& v : positions3D) {
+        v.z = 0.;
+    }
 
-  SurfaceMesh* s = new SurfaceMesh(name, positions3D, standardizeNestedList<size_t, F>(faceIndices));
-  bool success = registerStructure(s);
-  if (!success) {
-    safeDelete(s);
-  }
+    SurfaceMesh* s = new SurfaceMesh(name, positions3D, standardizeNestedList<size_t, F>(faceIndices));
+    bool success = registerStructure(s);
+    if (!success) {
+        safeDelete(s);
+    }
 
-  return s;
+    return s;
 }
 
 // Shorthand to add a mesh to polyscope while also setting permutations
 template <class V, class F, class P>
 SurfaceMesh* registerSurfaceMesh(std::string name, const V& vertexPositions, const F& faceIndices,
                                  const std::array<std::pair<P, size_t>, 5>& perms) {
-  SurfaceMesh* s = registerSurfaceMesh(name, vertexPositions, faceIndices);
+    SurfaceMesh* s = registerSurfaceMesh(name, vertexPositions, faceIndices);
 
-  if (s) {
-    s->setAllPermutations(perms);
-  }
+    if (s) {
+        s->setAllPermutations(perms);
+    }
 
-  return s;
+    return s;
 }
 
 template <class V>
 void SurfaceMesh::updateVertexPositions(const V& newPositions) {
-  vertices = standardizeVectorArray<glm::vec3, 3>(newPositions);
+    vertices = standardizeVectorArray<glm::vec3, 3>(newPositions);
 
 
-  // Rebuild any necessary quantities
-  geometryChanged();
+    // Rebuild any necessary quantities
+    geometryChanged();
 }
 
 
 template <class V>
 void SurfaceMesh::updateVertexPositions2D(const V& newPositions2D) {
-  std::vector<glm::vec3> positions3D = standardizeVectorArray<glm::vec3, 2>(newPositions2D);
-  for (glm::vec3& v : positions3D) {
-    v.z = 0.;
-  }
+    std::vector<glm::vec3> positions3D = standardizeVectorArray<glm::vec3, 2>(newPositions2D);
+    for (glm::vec3& v : positions3D) {
+        v.z = 0.;
+    }
 
-  // Call the main version
-  updateVertexPositions(positions3D);
+    // Call the main version
+    updateVertexPositions(positions3D);
 }
 
 inline glm::vec3 SurfaceMesh::faceCenter(size_t iF) {
-  glm::vec3 faceCenter = glm::vec3{0., 0., 0.};
-  const auto& face = faces[iF];
-  size_t D = face.size();
-  for (size_t j = 0; j < D; j++) {
-    faceCenter += vertices[face[j]];
-  }
-  faceCenter /= D;
-  return faceCenter;
+    glm::vec3 faceCenter = glm::vec3{0., 0., 0.};
+    const auto& face = faces[iF];
+    size_t D = face.size();
+    for (size_t j = 0; j < D; j++) {
+        faceCenter += vertices[face[j]];
+    }
+    faceCenter /= D;
+    return faceCenter;
 }
 
 // Shorthand to get a mesh from polyscope
 inline SurfaceMesh* getSurfaceMesh(std::string name) {
-  return dynamic_cast<SurfaceMesh*>(getStructure(SurfaceMesh::structureTypeName, name));
+    return dynamic_cast<SurfaceMesh*>(getStructure(SurfaceMesh::structureTypeName, name));
 }
-inline bool hasSurfaceMesh(std::string name) { return hasStructure(SurfaceMesh::structureTypeName, name); }
+inline bool hasSurfaceMesh(std::string name) {
+    return hasStructure(SurfaceMesh::structureTypeName, name);
+}
 inline void removeSurfaceMesh(std::string name, bool errorIfAbsent) {
-  removeStructure(SurfaceMesh::structureTypeName, name, errorIfAbsent);
+    removeStructure(SurfaceMesh::structureTypeName, name, errorIfAbsent);
 }
 
 
 // Make mesh element type printable
 inline std::string getMeshElementTypeName(MeshElement type) {
-  switch (type) {
-  case MeshElement::VERTEX:
-    return "vertex";
-  case MeshElement::FACE:
-    return "face";
-  case MeshElement::EDGE:
-    return "edge";
-  case MeshElement::HALFEDGE:
-    return "halfedge";
-  case MeshElement::CORNER:
-    return "corner";
-  }
-  throw std::runtime_error("broken");
+    switch (type) {
+        case MeshElement::VERTEX:
+            return "vertex";
+        case MeshElement::FACE:
+            return "face";
+        case MeshElement::EDGE:
+            return "edge";
+        case MeshElement::HALFEDGE:
+            return "halfedge";
+        case MeshElement::CORNER:
+            return "corner";
+    }
+    throw std::runtime_error("broken");
 }
 inline std::ostream& operator<<(std::ostream& out, const MeshElement value) {
-  return out << getMeshElementTypeName(value);
+    return out << getMeshElementTypeName(value);
 }
 
 
 template <class T>
 void SurfaceMesh::setVertexPermutation(const T& perm, size_t expectedSize) {
 
-  validateSize(perm, vertexDataSize, "vertex permutation for " + name);
-  vertexPerm = standardizeArray<size_t, T>(perm);
+    validateSize(perm, vertexDataSize, "vertex permutation for " + name);
+    vertexPerm = standardizeArray<size_t, T>(perm);
 
-  vertexDataSize = expectedSize;
-  if (vertexDataSize == 0) {
-    // Find max element to set the data size
-    for (size_t i : vertexPerm) {
-      vertexDataSize = std::max(vertexDataSize, i + 1);
+    vertexDataSize = expectedSize;
+    if (vertexDataSize == 0) {
+        // Find max element to set the data size
+        for (size_t i : vertexPerm) {
+            vertexDataSize = std::max(vertexDataSize, i + 1);
+        }
     }
-  }
 }
 
 template <class T>
 void SurfaceMesh::setFacePermutation(const T& perm, size_t expectedSize) {
 
-  validateSize(perm, faceDataSize, "face permutation for " + name);
-  facePerm = standardizeArray<size_t, T>(perm);
+    validateSize(perm, faceDataSize, "face permutation for " + name);
+    facePerm = standardizeArray<size_t, T>(perm);
 
-  faceDataSize = expectedSize;
-  if (faceDataSize == 0) {
-    // Find max element to set the data size
-    for (size_t i : facePerm) {
-      faceDataSize = std::max(faceDataSize, i + 1);
+    faceDataSize = expectedSize;
+    if (faceDataSize == 0) {
+        // Find max element to set the data size
+        for (size_t i : facePerm) {
+            faceDataSize = std::max(faceDataSize, i + 1);
+        }
     }
-  }
 }
 
 template <class T>
 void SurfaceMesh::setEdgePermutation(const T& perm, size_t expectedSize) {
 
-  validateSize(perm, edgeDataSize, "edge permutation for " + name);
-  edgePerm = standardizeArray<size_t, T>(perm);
+    validateSize(perm, edgeDataSize, "edge permutation for " + name);
+    edgePerm = standardizeArray<size_t, T>(perm);
 
-  edgeDataSize = expectedSize;
-  if (edgeDataSize == 0) {
-    // Find max element to set the data size
-    for (size_t i : edgePerm) {
-      edgeDataSize = std::max(edgeDataSize, i + 1);
+    edgeDataSize = expectedSize;
+    if (edgeDataSize == 0) {
+        // Find max element to set the data size
+        for (size_t i : edgePerm) {
+            edgeDataSize = std::max(edgeDataSize, i + 1);
+        }
     }
-  }
 }
 
 template <class T>
 void SurfaceMesh::setHalfedgePermutation(const T& perm, size_t expectedSize) {
 
-  validateSize(perm, halfedgeDataSize, "halfedge permutation for " + name);
-  halfedgePerm = standardizeArray<size_t, T>(perm);
+    validateSize(perm, halfedgeDataSize, "halfedge permutation for " + name);
+    halfedgePerm = standardizeArray<size_t, T>(perm);
 
-  halfedgeDataSize = expectedSize;
-  if (halfedgeDataSize == 0) {
-    // Find max element to set the data size
-    for (size_t i : halfedgePerm) {
-      halfedgeDataSize = std::max(halfedgeDataSize, i + 1);
+    halfedgeDataSize = expectedSize;
+    if (halfedgeDataSize == 0) {
+        // Find max element to set the data size
+        for (size_t i : halfedgePerm) {
+            halfedgeDataSize = std::max(halfedgeDataSize, i + 1);
+        }
     }
-  }
 }
 
 template <class T>
 void SurfaceMesh::setCornerPermutation(const T& perm, size_t expectedSize) {
 
-  validateSize(perm, cornerDataSize, "corner permutation for " + name);
-  cornerPerm = standardizeArray<size_t, T>(perm);
+    validateSize(perm, cornerDataSize, "corner permutation for " + name);
+    cornerPerm = standardizeArray<size_t, T>(perm);
 
-  cornerDataSize = expectedSize;
-  if (cornerDataSize == 0) {
-    // Find max element to set the data size
-    for (size_t i : cornerPerm) {
-      cornerDataSize = std::max(cornerDataSize, i + 1);
+    cornerDataSize = expectedSize;
+    if (cornerDataSize == 0) {
+        // Find max element to set the data size
+        for (size_t i : cornerPerm) {
+            cornerDataSize = std::max(cornerDataSize, i + 1);
+        }
     }
-  }
 }
 
 template <class T>
 void SurfaceMesh::setAllPermutations(const std::array<std::pair<T, size_t>, 5>& perms) {
-  if (perms[0].first.size() > 0) {
-    setVertexPermutation(perms[0].first, perms[0].second);
-  }
-  if (perms[1].first.size() > 0) {
-    setFacePermutation(perms[1].first, perms[1].second);
-  }
-  if (perms[2].first.size() > 0) {
-    setEdgePermutation(perms[2].first, perms[2].second);
-  }
-  if (perms[3].first.size() > 0) {
-    setHalfedgePermutation(perms[3].first, perms[3].second);
-  }
-  if (perms[4].first.size() > 0) {
-    setCornerPermutation(perms[4].first, perms[4].second);
-  }
+    if (perms[0].first.size() > 0) {
+        setVertexPermutation(perms[0].first, perms[0].second);
+    }
+    if (perms[1].first.size() > 0) {
+        setFacePermutation(perms[1].first, perms[1].second);
+    }
+    if (perms[2].first.size() > 0) {
+        setEdgePermutation(perms[2].first, perms[2].second);
+    }
+    if (perms[3].first.size() > 0) {
+        setHalfedgePermutation(perms[3].first, perms[3].second);
+    }
+    if (perms[4].first.size() > 0) {
+        setCornerPermutation(perms[4].first, perms[4].second);
+    }
 }
 
 // === Quantity adders
@@ -208,223 +210,229 @@ void SurfaceMesh::setAllPermutations(const std::array<std::pair<T, size_t>, 5>& 
 
 template <class T>
 SurfaceVertexColorQuantity* SurfaceMesh::addVertexColorQuantity(std::string name, const T& colors) {
-  validateSize<T>(colors, vertexDataSize, "vertex color quantity " + name);
-  return addVertexColorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(colors));
+    validateSize<T>(colors, vertexDataSize, "vertex color quantity " + name);
+    return addVertexColorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(colors));
 }
 
 
 template <class T>
 SurfaceFaceColorQuantity* SurfaceMesh::addFaceColorQuantity(std::string name, const T& colors) {
-  validateSize<T>(colors, faceDataSize, "face color quantity " + name);
-  return addFaceColorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(colors));
+    validateSize<T>(colors, faceDataSize, "face color quantity " + name);
+    return addFaceColorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(colors));
 }
 
 template <class T>
 SurfaceVertexScalarQuantity* SurfaceMesh::addVertexDistanceQuantity(std::string name, const T& distances) {
-  validateSize(distances, vertexDataSize, "distance quantity " + name);
-  return addVertexDistanceQuantityImpl(name, standardizeArray<double>(distances));
+    validateSize(distances, vertexDataSize, "distance quantity " + name);
+    return addVertexDistanceQuantityImpl(name, standardizeArray<double>(distances));
 }
 
 template <class T>
 SurfaceVertexScalarQuantity* SurfaceMesh::addVertexSignedDistanceQuantity(std::string name, const T& distances) {
-  validateSize(distances, vertexDataSize, "signed distance quantity " + name);
-  return addVertexSignedDistanceQuantityImpl(name, standardizeArray<double>(distances));
+    validateSize(distances, vertexDataSize, "signed distance quantity " + name);
+    return addVertexSignedDistanceQuantityImpl(name, standardizeArray<double>(distances));
 }
 
 // Standard a parameterization, defined at corners
 template <class T>
 SurfaceCornerParameterizationQuantity* SurfaceMesh::addParameterizationQuantity(std::string name, const T& coords,
                                                                                 ParamCoordsType type) {
-  validateSize(coords, cornerDataSize, "parameterization quantity " + name);
-  return addParameterizationQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(coords), type);
+    validateSize(coords, cornerDataSize, "parameterization quantity " + name);
+    return addParameterizationQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(coords), type);
 }
 
 // Parameterization defined at vertices, rather than corners
 template <class T>
 SurfaceVertexParameterizationQuantity* SurfaceMesh::addVertexParameterizationQuantity(std::string name, const T& coords,
                                                                                       ParamCoordsType type) {
-  validateSize(coords, vertexDataSize, "parameterization (at vertices) quantity " + name);
-  return addVertexParameterizationQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(coords), type);
+    validateSize(coords, vertexDataSize, "parameterization (at vertices) quantity " + name);
+    return addVertexParameterizationQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(coords), type);
 }
 
 // "local" parameterization defined at vertices. has different presets: type is WORLD and style is LOCAL
 template <class T>
 SurfaceVertexParameterizationQuantity* SurfaceMesh::addLocalParameterizationQuantity(std::string name, const T& coords,
                                                                                      ParamCoordsType type) {
-  validateSize(coords, vertexDataSize, "parameterization (at vertices) quantity " + name);
-  return addLocalParameterizationQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(coords), type);
+    validateSize(coords, vertexDataSize, "parameterization (at vertices) quantity " + name);
+    return addLocalParameterizationQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(coords), type);
 }
 
 
 inline SurfaceVertexCountQuantity*
 SurfaceMesh::addVertexCountQuantity(std::string name, const std::vector<std::pair<size_t, int>>& values) {
-  for (auto p : values) {
-    if (p.first >= vertexDataSize) {
-      error("passed index " + std::to_string(p.first) + " to addVertexCountQuantity [" + name +
-            "] which is greater than the number of vertices");
+    for (auto p : values) {
+        if (p.first >= vertexDataSize) {
+            error("passed index " + std::to_string(p.first) + " to addVertexCountQuantity [" + name +
+                  "] which is greater than the number of vertices");
+        }
     }
-  }
-  return addVertexCountQuantityImpl(name, values);
+    return addVertexCountQuantityImpl(name, values);
 }
 
 
 inline SurfaceVertexIsolatedScalarQuantity*
 SurfaceMesh::addVertexIsolatedScalarQuantity(std::string name, const std::vector<std::pair<size_t, double>>& values) {
-  for (auto p : values) {
-    if (p.first >= vertexDataSize) {
-      error("passed index " + std::to_string(p.first) + " to addVertexIsolatedScalarQuantity [" + name +
-            "] which is greater than the number of vertices");
+    for (auto p : values) {
+        if (p.first >= vertexDataSize) {
+            error("passed index " + std::to_string(p.first) + " to addVertexIsolatedScalarQuantity [" + name +
+                  "] which is greater than the number of vertices");
+        }
     }
-  }
-  return addVertexIsolatedScalarQuantityImpl(name, values);
+    return addVertexIsolatedScalarQuantityImpl(name, values);
 }
 
 
 inline SurfaceFaceCountQuantity* SurfaceMesh::addFaceCountQuantity(std::string name,
                                                                    const std::vector<std::pair<size_t, int>>& values) {
-  for (auto p : values) {
-    if (p.first >= faceDataSize) {
-      error("passed index " + std::to_string(p.first) + " to addFaceCountQuantity [" + name +
-            "] which is greater than the number of faces");
+    for (auto p : values) {
+        if (p.first >= faceDataSize) {
+            error("passed index " + std::to_string(p.first) + " to addFaceCountQuantity [" + name +
+                  "] which is greater than the number of faces");
+        }
     }
-  }
-  return addFaceCountQuantityImpl(name, values);
+    return addFaceCountQuantityImpl(name, values);
 }
 
 
 template <class P, class E>
 SurfaceGraphQuantity* SurfaceMesh::addSurfaceGraphQuantity(std::string name, const P& nodes, const E& edges) {
-  return addSurfaceGraphQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(nodes),
-                                     standardizeVectorArray<std::array<size_t, 2>, 2>(edges));
+    return addSurfaceGraphQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(nodes),
+                                       standardizeVectorArray<std::array<size_t, 2>, 2>(edges));
 }
 
 template <class P, class E>
 SurfaceGraphQuantity* SurfaceMesh::addSurfaceGraphQuantity2D(std::string name, const P& nodes, const E& edges) {
 
-  std::vector<glm::vec3> nodes3D = standardizeVectorArray<glm::vec3, 2>(nodes);
-  for (glm::vec3& v : nodes3D) {
-    v.z = 0.;
-  }
+    std::vector<glm::vec3> nodes3D = standardizeVectorArray<glm::vec3, 2>(nodes);
+    for (glm::vec3& v : nodes3D) {
+        v.z = 0.;
+    }
 
-  return addSurfaceGraphQuantityImpl(name, nodes3D, standardizeVectorArray<std::array<size_t, 2>, 2>(edges));
+    return addSurfaceGraphQuantityImpl(name, nodes3D, standardizeVectorArray<std::array<size_t, 2>, 2>(edges));
 }
 
 
 template <class P>
 SurfaceGraphQuantity* SurfaceMesh::addSurfaceGraphQuantity(std::string name, const std::vector<P>& paths) {
 
-  // Convert to vector of paths
-  std::vector<std::vector<glm::vec3>> convertPaths;
-  for (const P& inputP : paths) {
-    convertPaths.emplace_back(standardizeVectorArray<glm::vec3, 3>(inputP));
-  }
-
-  // Build flat list of nodes and edges between them
-  std::vector<glm::vec3> nodes;
-  std::vector<std::array<size_t, 2>> edges;
-  for (auto& p : convertPaths) {
-    for (size_t i = 0; i < p.size(); i++) {
-      size_t N = nodes.size();
-      nodes.push_back(p[i]);
-      if (i > 0) {
-        edges.push_back({N - 1, N});
-      }
+    // Convert to vector of paths
+    std::vector<std::vector<glm::vec3>> convertPaths;
+    for (const P& inputP : paths) {
+        convertPaths.emplace_back(standardizeVectorArray<glm::vec3, 3>(inputP));
     }
-  }
 
-  return addSurfaceGraphQuantityImpl(name, nodes, edges);
+    // Build flat list of nodes and edges between them
+    std::vector<glm::vec3> nodes;
+    std::vector<std::array<size_t, 2>> edges;
+    for (auto& p : convertPaths) {
+        for (size_t i = 0; i < p.size(); i++) {
+            size_t N = nodes.size();
+            nodes.push_back(p[i]);
+            if (i > 0) {
+                edges.push_back({N - 1, N});
+            }
+        }
+    }
+
+    return addSurfaceGraphQuantityImpl(name, nodes, edges);
 }
 
 template <class P>
 SurfaceGraphQuantity* SurfaceMesh::addSurfaceGraphQuantity2D(std::string name, const std::vector<P>& paths) {
 
-  // Convert and call the general version
-  std::vector<std::vector<glm::vec3>> paths3D;
-  for (const P& inputP : paths) {
-    std::vector<glm::vec3> p = standardizeVectorArray<glm::vec3, 2>(inputP);
-    for (glm::vec3& v : p) {
-      v.z = 0.;
+    // Convert and call the general version
+    std::vector<std::vector<glm::vec3>> paths3D;
+    for (const P& inputP : paths) {
+        std::vector<glm::vec3> p = standardizeVectorArray<glm::vec3, 2>(inputP);
+        for (glm::vec3& v : p) {
+            v.z = 0.;
+        }
+        paths3D.emplace_back(p);
     }
-    paths3D.emplace_back(p);
-  }
 
-  return addSurfaceGraphQuantity(name, paths3D);
+    return addSurfaceGraphQuantity(name, paths3D);
 }
 
 
 template <class T>
 SurfaceVertexScalarQuantity* SurfaceMesh::addVertexScalarQuantity(std::string name, const T& data, DataType type) {
-  validateSize(data, vertexDataSize, "vertex scalar quantity " + name);
-  return addVertexScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
+    validateSize(data, vertexDataSize, "vertex scalar quantity " + name);
+    return addVertexScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
 }
 
 template <class T>
 SurfaceFaceScalarQuantity* SurfaceMesh::addFaceScalarQuantity(std::string name, const T& data, DataType type) {
-  validateSize(data, faceDataSize, "face scalar quantity " + name);
-  return addFaceScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
+    validateSize(data, faceDataSize, "face scalar quantity " + name);
+    return addFaceScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
 }
 
 
 template <class T>
 SurfaceEdgeScalarQuantity* SurfaceMesh::addEdgeScalarQuantity(std::string name, const T& data, DataType type) {
-  validateSize(data, edgeDataSize, "edge scalar quantity " + name);
-  return addEdgeScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
+    validateSize(data, edgeDataSize, "edge scalar quantity " + name);
+    return addEdgeScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
 }
 
 template <class T>
 SurfaceHalfedgeScalarQuantity* SurfaceMesh::addHalfedgeScalarQuantity(std::string name, const T& data, DataType type) {
-  validateSize(data, halfedgeDataSize, "halfedge scalar quantity " + name);
-  return addHalfedgeScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
+    validateSize(data, halfedgeDataSize, "halfedge scalar quantity " + name);
+    return addHalfedgeScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
+}
+
+template <class T>
+SurfaceCornerScalarQuantity* SurfaceMesh::addCornerScalarQuantity(std::string name, const T& data, DataType type) {
+    validateSize(data, cornerDataSize, "corner scalar quantity " + name);
+    return addCornerScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
 }
 
 
 template <class T>
 SurfaceVertexVectorQuantity* SurfaceMesh::addVertexVectorQuantity(std::string name, const T& vectors,
                                                                   VectorType vectorType) {
-  validateSize(vectors, vertexDataSize, "vertex vector quantity " + name);
-  return addVertexVectorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(vectors), vectorType);
+    validateSize(vectors, vertexDataSize, "vertex vector quantity " + name);
+    return addVertexVectorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(vectors), vectorType);
 }
 template <class T>
 SurfaceVertexVectorQuantity* SurfaceMesh::addVertexVectorQuantity2D(std::string name, const T& vectors,
                                                                     VectorType vectorType) {
-  validateSize(vectors, vertexDataSize, "vertex vector quantity " + name);
-  std::vector<glm::vec3> vectors3D = standardizeVectorArray<glm::vec3, 2>(vectors);
-  for (auto& v : vectors3D) {
-    v.z = 0.;
-  }
-  return addVertexVectorQuantityImpl(name, vectors3D, vectorType);
+    validateSize(vectors, vertexDataSize, "vertex vector quantity " + name);
+    std::vector<glm::vec3> vectors3D = standardizeVectorArray<glm::vec3, 2>(vectors);
+    for (auto& v : vectors3D) {
+        v.z = 0.;
+    }
+    return addVertexVectorQuantityImpl(name, vectors3D, vectorType);
 }
 
 template <class T>
 SurfaceFaceVectorQuantity* SurfaceMesh::addFaceVectorQuantity(std::string name, const T& vectors,
                                                               VectorType vectorType) {
-  validateSize(vectors, faceDataSize, "face vector quantity " + name);
-  return addFaceVectorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(vectors), vectorType);
+    validateSize(vectors, faceDataSize, "face vector quantity " + name);
+    return addFaceVectorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(vectors), vectorType);
 }
 template <class T>
 SurfaceFaceVectorQuantity* SurfaceMesh::addFaceVectorQuantity2D(std::string name, const T& vectors,
                                                                 VectorType vectorType) {
-  validateSize(vectors, faceDataSize, "face vector quantity " + name);
-  std::vector<glm::vec3> vectors3D = standardizeVectorArray<glm::vec3, 2>(vectors);
-  for (auto& v : vectors3D) {
-    v.z = 0.;
-  }
-  return addFaceVectorQuantityImpl(name, vectors3D, vectorType);
+    validateSize(vectors, faceDataSize, "face vector quantity " + name);
+    std::vector<glm::vec3> vectors3D = standardizeVectorArray<glm::vec3, 2>(vectors);
+    for (auto& v : vectors3D) {
+        v.z = 0.;
+    }
+    return addFaceVectorQuantityImpl(name, vectors3D, vectorType);
 }
 
 template <class T>
 SurfaceFaceIntrinsicVectorQuantity* SurfaceMesh::addFaceIntrinsicVectorQuantity(std::string name, const T& vectors,
                                                                                 int nSym, VectorType vectorType) {
-  validateSize(vectors, faceDataSize, "face intrinsic vector quantity " + name);
-  return addFaceIntrinsicVectorQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(vectors), nSym, vectorType);
+    validateSize(vectors, faceDataSize, "face intrinsic vector quantity " + name);
+    return addFaceIntrinsicVectorQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(vectors), nSym, vectorType);
 }
 
 
 template <class T>
 SurfaceVertexIntrinsicVectorQuantity* SurfaceMesh::addVertexIntrinsicVectorQuantity(std::string name, const T& vectors,
                                                                                     int nSym, VectorType vectorType) {
-  validateSize(vectors, vertexDataSize, "vertex intrinsic vector quantity " + name);
-  return addVertexIntrinsicVectorQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(vectors), nSym, vectorType);
+    validateSize(vectors, vertexDataSize, "vertex intrinsic vector quantity " + name);
+    return addVertexIntrinsicVectorQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(vectors), nSym, vectorType);
 }
 
 
@@ -433,46 +441,46 @@ SurfaceVertexIntrinsicVectorQuantity* SurfaceMesh::addVertexIntrinsicVectorQuant
 template <class T, class O>
 SurfaceOneFormIntrinsicVectorQuantity* SurfaceMesh::addOneFormIntrinsicVectorQuantity(std::string name, const T& data,
                                                                                       const O& orientations) {
-  validateSize(data, edgeDataSize, "one form intrinsic vector quantity " + name);
-  return addOneFormIntrinsicVectorQuantityImpl(name, standardizeArray<double, T>(data),
-                                               standardizeArray<char, O>(orientations));
+    validateSize(data, edgeDataSize, "one form intrinsic vector quantity " + name);
+    return addOneFormIntrinsicVectorQuantityImpl(name, standardizeArray<double, T>(data),
+                                                 standardizeArray<char, O>(orientations));
 }
 
 
 template <class T>
 void SurfaceMesh::setVertexTangentBasisX(const T& vectors) {
-  validateSize(vectors, vertexDataSize, "vertex tangent basis X");
-  setVertexTangentBasisXImpl(standardizeVectorArray<glm::vec3, 3>(vectors));
+    validateSize(vectors, vertexDataSize, "vertex tangent basis X");
+    setVertexTangentBasisXImpl(standardizeVectorArray<glm::vec3, 3>(vectors));
 }
 
 template <class T>
 void SurfaceMesh::setVertexTangentBasisX2D(const T& vectors) {
-  validateSize(vectors, vertexDataSize, "vertex tangent basis X");
+    validateSize(vectors, vertexDataSize, "vertex tangent basis X");
 
-  std::vector<glm::vec3> vec3D = standardizeVectorArray<glm::vec3, 2>(vectors);
-  for (glm::vec3& v : vec3D) {
-    v.z = 0.;
-  }
+    std::vector<glm::vec3> vec3D = standardizeVectorArray<glm::vec3, 2>(vectors);
+    for (glm::vec3& v : vec3D) {
+        v.z = 0.;
+    }
 
-  setVertexTangentBasisXImpl(vec3D);
+    setVertexTangentBasisXImpl(vec3D);
 }
 
 template <class T>
 void SurfaceMesh::setFaceTangentBasisX(const T& vectors) {
-  validateSize(vectors, faceDataSize, "face tangent basis X");
-  setFaceTangentBasisXImpl(standardizeVectorArray<glm::vec3, 3>(vectors));
+    validateSize(vectors, faceDataSize, "face tangent basis X");
+    setFaceTangentBasisXImpl(standardizeVectorArray<glm::vec3, 3>(vectors));
 }
 
 template <class T>
 void SurfaceMesh::setFaceTangentBasisX2D(const T& vectors) {
-  validateSize(vectors, faceDataSize, "face tangent basis X");
+    validateSize(vectors, faceDataSize, "face tangent basis X");
 
-  std::vector<glm::vec3> vec3D = standardizeVectorArray<glm::vec3, 2>(vectors);
-  for (glm::vec3& v : vec3D) {
-    v.z = 0.;
-  }
+    std::vector<glm::vec3> vec3D = standardizeVectorArray<glm::vec3, 2>(vectors);
+    for (glm::vec3& v : vec3D) {
+        v.z = 0.;
+    }
 
-  setFaceTangentBasisXImpl(vec3D);
+    setFaceTangentBasisXImpl(vec3D);
 }
 
 

--- a/include/polyscope/surface_mesh.ipp
+++ b/include/polyscope/surface_mesh.ipp
@@ -4,202 +4,200 @@ namespace polyscope {
 // Shorthand to add a mesh to polyscope
 template <class V, class F>
 SurfaceMesh* registerSurfaceMesh(std::string name, const V& vertexPositions, const F& faceIndices) {
-    SurfaceMesh* s = new SurfaceMesh(name, standardizeVectorArray<glm::vec3, 3>(vertexPositions),
-                                     standardizeNestedList<size_t, F>(faceIndices));
-    bool success = registerStructure(s);
-    if (!success) {
-        safeDelete(s);
-    }
+  SurfaceMesh* s = new SurfaceMesh(name, standardizeVectorArray<glm::vec3, 3>(vertexPositions),
+                                   standardizeNestedList<size_t, F>(faceIndices));
+  bool success = registerStructure(s);
+  if (!success) {
+    safeDelete(s);
+  }
 
-    return s;
+  return s;
 }
 template <class V, class F>
 SurfaceMesh* registerSurfaceMesh2D(std::string name, const V& vertexPositions, const F& faceIndices) {
 
-    std::vector<glm::vec3> positions3D = standardizeVectorArray<glm::vec3, 2>(vertexPositions);
-    for (auto& v : positions3D) {
-        v.z = 0.;
-    }
+  std::vector<glm::vec3> positions3D = standardizeVectorArray<glm::vec3, 2>(vertexPositions);
+  for (auto& v : positions3D) {
+    v.z = 0.;
+  }
 
-    SurfaceMesh* s = new SurfaceMesh(name, positions3D, standardizeNestedList<size_t, F>(faceIndices));
-    bool success = registerStructure(s);
-    if (!success) {
-        safeDelete(s);
-    }
+  SurfaceMesh* s = new SurfaceMesh(name, positions3D, standardizeNestedList<size_t, F>(faceIndices));
+  bool success = registerStructure(s);
+  if (!success) {
+    safeDelete(s);
+  }
 
-    return s;
+  return s;
 }
 
 // Shorthand to add a mesh to polyscope while also setting permutations
 template <class V, class F, class P>
 SurfaceMesh* registerSurfaceMesh(std::string name, const V& vertexPositions, const F& faceIndices,
                                  const std::array<std::pair<P, size_t>, 5>& perms) {
-    SurfaceMesh* s = registerSurfaceMesh(name, vertexPositions, faceIndices);
+  SurfaceMesh* s = registerSurfaceMesh(name, vertexPositions, faceIndices);
 
-    if (s) {
-        s->setAllPermutations(perms);
-    }
+  if (s) {
+    s->setAllPermutations(perms);
+  }
 
-    return s;
+  return s;
 }
 
 template <class V>
 void SurfaceMesh::updateVertexPositions(const V& newPositions) {
-    vertices = standardizeVectorArray<glm::vec3, 3>(newPositions);
+  vertices = standardizeVectorArray<glm::vec3, 3>(newPositions);
 
 
-    // Rebuild any necessary quantities
-    geometryChanged();
+  // Rebuild any necessary quantities
+  geometryChanged();
 }
 
 
 template <class V>
 void SurfaceMesh::updateVertexPositions2D(const V& newPositions2D) {
-    std::vector<glm::vec3> positions3D = standardizeVectorArray<glm::vec3, 2>(newPositions2D);
-    for (glm::vec3& v : positions3D) {
-        v.z = 0.;
-    }
+  std::vector<glm::vec3> positions3D = standardizeVectorArray<glm::vec3, 2>(newPositions2D);
+  for (glm::vec3& v : positions3D) {
+    v.z = 0.;
+  }
 
-    // Call the main version
-    updateVertexPositions(positions3D);
+  // Call the main version
+  updateVertexPositions(positions3D);
 }
 
 inline glm::vec3 SurfaceMesh::faceCenter(size_t iF) {
-    glm::vec3 faceCenter = glm::vec3{0., 0., 0.};
-    const auto& face = faces[iF];
-    size_t D = face.size();
-    for (size_t j = 0; j < D; j++) {
-        faceCenter += vertices[face[j]];
-    }
-    faceCenter /= D;
-    return faceCenter;
+  glm::vec3 faceCenter = glm::vec3{0., 0., 0.};
+  const auto& face = faces[iF];
+  size_t D = face.size();
+  for (size_t j = 0; j < D; j++) {
+    faceCenter += vertices[face[j]];
+  }
+  faceCenter /= D;
+  return faceCenter;
 }
 
 // Shorthand to get a mesh from polyscope
 inline SurfaceMesh* getSurfaceMesh(std::string name) {
-    return dynamic_cast<SurfaceMesh*>(getStructure(SurfaceMesh::structureTypeName, name));
+  return dynamic_cast<SurfaceMesh*>(getStructure(SurfaceMesh::structureTypeName, name));
 }
-inline bool hasSurfaceMesh(std::string name) {
-    return hasStructure(SurfaceMesh::structureTypeName, name);
-}
+inline bool hasSurfaceMesh(std::string name) { return hasStructure(SurfaceMesh::structureTypeName, name); }
 inline void removeSurfaceMesh(std::string name, bool errorIfAbsent) {
-    removeStructure(SurfaceMesh::structureTypeName, name, errorIfAbsent);
+  removeStructure(SurfaceMesh::structureTypeName, name, errorIfAbsent);
 }
 
 
 // Make mesh element type printable
 inline std::string getMeshElementTypeName(MeshElement type) {
-    switch (type) {
-        case MeshElement::VERTEX:
-            return "vertex";
-        case MeshElement::FACE:
-            return "face";
-        case MeshElement::EDGE:
-            return "edge";
-        case MeshElement::HALFEDGE:
-            return "halfedge";
-        case MeshElement::CORNER:
-            return "corner";
-    }
-    throw std::runtime_error("broken");
+  switch (type) {
+  case MeshElement::VERTEX:
+    return "vertex";
+  case MeshElement::FACE:
+    return "face";
+  case MeshElement::EDGE:
+    return "edge";
+  case MeshElement::HALFEDGE:
+    return "halfedge";
+  case MeshElement::CORNER:
+    return "corner";
+  }
+  throw std::runtime_error("broken");
 }
 inline std::ostream& operator<<(std::ostream& out, const MeshElement value) {
-    return out << getMeshElementTypeName(value);
+  return out << getMeshElementTypeName(value);
 }
 
 
 template <class T>
 void SurfaceMesh::setVertexPermutation(const T& perm, size_t expectedSize) {
 
-    validateSize(perm, vertexDataSize, "vertex permutation for " + name);
-    vertexPerm = standardizeArray<size_t, T>(perm);
+  validateSize(perm, vertexDataSize, "vertex permutation for " + name);
+  vertexPerm = standardizeArray<size_t, T>(perm);
 
-    vertexDataSize = expectedSize;
-    if (vertexDataSize == 0) {
-        // Find max element to set the data size
-        for (size_t i : vertexPerm) {
-            vertexDataSize = std::max(vertexDataSize, i + 1);
-        }
+  vertexDataSize = expectedSize;
+  if (vertexDataSize == 0) {
+    // Find max element to set the data size
+    for (size_t i : vertexPerm) {
+      vertexDataSize = std::max(vertexDataSize, i + 1);
     }
+  }
 }
 
 template <class T>
 void SurfaceMesh::setFacePermutation(const T& perm, size_t expectedSize) {
 
-    validateSize(perm, faceDataSize, "face permutation for " + name);
-    facePerm = standardizeArray<size_t, T>(perm);
+  validateSize(perm, faceDataSize, "face permutation for " + name);
+  facePerm = standardizeArray<size_t, T>(perm);
 
-    faceDataSize = expectedSize;
-    if (faceDataSize == 0) {
-        // Find max element to set the data size
-        for (size_t i : facePerm) {
-            faceDataSize = std::max(faceDataSize, i + 1);
-        }
+  faceDataSize = expectedSize;
+  if (faceDataSize == 0) {
+    // Find max element to set the data size
+    for (size_t i : facePerm) {
+      faceDataSize = std::max(faceDataSize, i + 1);
     }
+  }
 }
 
 template <class T>
 void SurfaceMesh::setEdgePermutation(const T& perm, size_t expectedSize) {
 
-    validateSize(perm, edgeDataSize, "edge permutation for " + name);
-    edgePerm = standardizeArray<size_t, T>(perm);
+  validateSize(perm, edgeDataSize, "edge permutation for " + name);
+  edgePerm = standardizeArray<size_t, T>(perm);
 
-    edgeDataSize = expectedSize;
-    if (edgeDataSize == 0) {
-        // Find max element to set the data size
-        for (size_t i : edgePerm) {
-            edgeDataSize = std::max(edgeDataSize, i + 1);
-        }
+  edgeDataSize = expectedSize;
+  if (edgeDataSize == 0) {
+    // Find max element to set the data size
+    for (size_t i : edgePerm) {
+      edgeDataSize = std::max(edgeDataSize, i + 1);
     }
+  }
 }
 
 template <class T>
 void SurfaceMesh::setHalfedgePermutation(const T& perm, size_t expectedSize) {
 
-    validateSize(perm, halfedgeDataSize, "halfedge permutation for " + name);
-    halfedgePerm = standardizeArray<size_t, T>(perm);
+  validateSize(perm, halfedgeDataSize, "halfedge permutation for " + name);
+  halfedgePerm = standardizeArray<size_t, T>(perm);
 
-    halfedgeDataSize = expectedSize;
-    if (halfedgeDataSize == 0) {
-        // Find max element to set the data size
-        for (size_t i : halfedgePerm) {
-            halfedgeDataSize = std::max(halfedgeDataSize, i + 1);
-        }
+  halfedgeDataSize = expectedSize;
+  if (halfedgeDataSize == 0) {
+    // Find max element to set the data size
+    for (size_t i : halfedgePerm) {
+      halfedgeDataSize = std::max(halfedgeDataSize, i + 1);
     }
+  }
 }
 
 template <class T>
 void SurfaceMesh::setCornerPermutation(const T& perm, size_t expectedSize) {
 
-    validateSize(perm, cornerDataSize, "corner permutation for " + name);
-    cornerPerm = standardizeArray<size_t, T>(perm);
+  validateSize(perm, cornerDataSize, "corner permutation for " + name);
+  cornerPerm = standardizeArray<size_t, T>(perm);
 
-    cornerDataSize = expectedSize;
-    if (cornerDataSize == 0) {
-        // Find max element to set the data size
-        for (size_t i : cornerPerm) {
-            cornerDataSize = std::max(cornerDataSize, i + 1);
-        }
+  cornerDataSize = expectedSize;
+  if (cornerDataSize == 0) {
+    // Find max element to set the data size
+    for (size_t i : cornerPerm) {
+      cornerDataSize = std::max(cornerDataSize, i + 1);
     }
+  }
 }
 
 template <class T>
 void SurfaceMesh::setAllPermutations(const std::array<std::pair<T, size_t>, 5>& perms) {
-    if (perms[0].first.size() > 0) {
-        setVertexPermutation(perms[0].first, perms[0].second);
-    }
-    if (perms[1].first.size() > 0) {
-        setFacePermutation(perms[1].first, perms[1].second);
-    }
-    if (perms[2].first.size() > 0) {
-        setEdgePermutation(perms[2].first, perms[2].second);
-    }
-    if (perms[3].first.size() > 0) {
-        setHalfedgePermutation(perms[3].first, perms[3].second);
-    }
-    if (perms[4].first.size() > 0) {
-        setCornerPermutation(perms[4].first, perms[4].second);
-    }
+  if (perms[0].first.size() > 0) {
+    setVertexPermutation(perms[0].first, perms[0].second);
+  }
+  if (perms[1].first.size() > 0) {
+    setFacePermutation(perms[1].first, perms[1].second);
+  }
+  if (perms[2].first.size() > 0) {
+    setEdgePermutation(perms[2].first, perms[2].second);
+  }
+  if (perms[3].first.size() > 0) {
+    setHalfedgePermutation(perms[3].first, perms[3].second);
+  }
+  if (perms[4].first.size() > 0) {
+    setCornerPermutation(perms[4].first, perms[4].second);
+  }
 }
 
 // === Quantity adders
@@ -210,229 +208,229 @@ void SurfaceMesh::setAllPermutations(const std::array<std::pair<T, size_t>, 5>& 
 
 template <class T>
 SurfaceVertexColorQuantity* SurfaceMesh::addVertexColorQuantity(std::string name, const T& colors) {
-    validateSize<T>(colors, vertexDataSize, "vertex color quantity " + name);
-    return addVertexColorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(colors));
+  validateSize<T>(colors, vertexDataSize, "vertex color quantity " + name);
+  return addVertexColorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(colors));
 }
 
 
 template <class T>
 SurfaceFaceColorQuantity* SurfaceMesh::addFaceColorQuantity(std::string name, const T& colors) {
-    validateSize<T>(colors, faceDataSize, "face color quantity " + name);
-    return addFaceColorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(colors));
+  validateSize<T>(colors, faceDataSize, "face color quantity " + name);
+  return addFaceColorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(colors));
 }
 
 template <class T>
 SurfaceVertexScalarQuantity* SurfaceMesh::addVertexDistanceQuantity(std::string name, const T& distances) {
-    validateSize(distances, vertexDataSize, "distance quantity " + name);
-    return addVertexDistanceQuantityImpl(name, standardizeArray<double>(distances));
+  validateSize(distances, vertexDataSize, "distance quantity " + name);
+  return addVertexDistanceQuantityImpl(name, standardizeArray<double>(distances));
 }
 
 template <class T>
 SurfaceVertexScalarQuantity* SurfaceMesh::addVertexSignedDistanceQuantity(std::string name, const T& distances) {
-    validateSize(distances, vertexDataSize, "signed distance quantity " + name);
-    return addVertexSignedDistanceQuantityImpl(name, standardizeArray<double>(distances));
+  validateSize(distances, vertexDataSize, "signed distance quantity " + name);
+  return addVertexSignedDistanceQuantityImpl(name, standardizeArray<double>(distances));
 }
 
 // Standard a parameterization, defined at corners
 template <class T>
 SurfaceCornerParameterizationQuantity* SurfaceMesh::addParameterizationQuantity(std::string name, const T& coords,
                                                                                 ParamCoordsType type) {
-    validateSize(coords, cornerDataSize, "parameterization quantity " + name);
-    return addParameterizationQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(coords), type);
+  validateSize(coords, cornerDataSize, "parameterization quantity " + name);
+  return addParameterizationQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(coords), type);
 }
 
 // Parameterization defined at vertices, rather than corners
 template <class T>
 SurfaceVertexParameterizationQuantity* SurfaceMesh::addVertexParameterizationQuantity(std::string name, const T& coords,
                                                                                       ParamCoordsType type) {
-    validateSize(coords, vertexDataSize, "parameterization (at vertices) quantity " + name);
-    return addVertexParameterizationQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(coords), type);
+  validateSize(coords, vertexDataSize, "parameterization (at vertices) quantity " + name);
+  return addVertexParameterizationQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(coords), type);
 }
 
 // "local" parameterization defined at vertices. has different presets: type is WORLD and style is LOCAL
 template <class T>
 SurfaceVertexParameterizationQuantity* SurfaceMesh::addLocalParameterizationQuantity(std::string name, const T& coords,
                                                                                      ParamCoordsType type) {
-    validateSize(coords, vertexDataSize, "parameterization (at vertices) quantity " + name);
-    return addLocalParameterizationQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(coords), type);
+  validateSize(coords, vertexDataSize, "parameterization (at vertices) quantity " + name);
+  return addLocalParameterizationQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(coords), type);
 }
 
 
 inline SurfaceVertexCountQuantity*
 SurfaceMesh::addVertexCountQuantity(std::string name, const std::vector<std::pair<size_t, int>>& values) {
-    for (auto p : values) {
-        if (p.first >= vertexDataSize) {
-            error("passed index " + std::to_string(p.first) + " to addVertexCountQuantity [" + name +
-                  "] which is greater than the number of vertices");
-        }
+  for (auto p : values) {
+    if (p.first >= vertexDataSize) {
+      error("passed index " + std::to_string(p.first) + " to addVertexCountQuantity [" + name +
+            "] which is greater than the number of vertices");
     }
-    return addVertexCountQuantityImpl(name, values);
+  }
+  return addVertexCountQuantityImpl(name, values);
 }
 
 
 inline SurfaceVertexIsolatedScalarQuantity*
 SurfaceMesh::addVertexIsolatedScalarQuantity(std::string name, const std::vector<std::pair<size_t, double>>& values) {
-    for (auto p : values) {
-        if (p.first >= vertexDataSize) {
-            error("passed index " + std::to_string(p.first) + " to addVertexIsolatedScalarQuantity [" + name +
-                  "] which is greater than the number of vertices");
-        }
+  for (auto p : values) {
+    if (p.first >= vertexDataSize) {
+      error("passed index " + std::to_string(p.first) + " to addVertexIsolatedScalarQuantity [" + name +
+            "] which is greater than the number of vertices");
     }
-    return addVertexIsolatedScalarQuantityImpl(name, values);
+  }
+  return addVertexIsolatedScalarQuantityImpl(name, values);
 }
 
 
 inline SurfaceFaceCountQuantity* SurfaceMesh::addFaceCountQuantity(std::string name,
                                                                    const std::vector<std::pair<size_t, int>>& values) {
-    for (auto p : values) {
-        if (p.first >= faceDataSize) {
-            error("passed index " + std::to_string(p.first) + " to addFaceCountQuantity [" + name +
-                  "] which is greater than the number of faces");
-        }
+  for (auto p : values) {
+    if (p.first >= faceDataSize) {
+      error("passed index " + std::to_string(p.first) + " to addFaceCountQuantity [" + name +
+            "] which is greater than the number of faces");
     }
-    return addFaceCountQuantityImpl(name, values);
+  }
+  return addFaceCountQuantityImpl(name, values);
 }
 
 
 template <class P, class E>
 SurfaceGraphQuantity* SurfaceMesh::addSurfaceGraphQuantity(std::string name, const P& nodes, const E& edges) {
-    return addSurfaceGraphQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(nodes),
-                                       standardizeVectorArray<std::array<size_t, 2>, 2>(edges));
+  return addSurfaceGraphQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(nodes),
+                                     standardizeVectorArray<std::array<size_t, 2>, 2>(edges));
 }
 
 template <class P, class E>
 SurfaceGraphQuantity* SurfaceMesh::addSurfaceGraphQuantity2D(std::string name, const P& nodes, const E& edges) {
 
-    std::vector<glm::vec3> nodes3D = standardizeVectorArray<glm::vec3, 2>(nodes);
-    for (glm::vec3& v : nodes3D) {
-        v.z = 0.;
-    }
+  std::vector<glm::vec3> nodes3D = standardizeVectorArray<glm::vec3, 2>(nodes);
+  for (glm::vec3& v : nodes3D) {
+    v.z = 0.;
+  }
 
-    return addSurfaceGraphQuantityImpl(name, nodes3D, standardizeVectorArray<std::array<size_t, 2>, 2>(edges));
+  return addSurfaceGraphQuantityImpl(name, nodes3D, standardizeVectorArray<std::array<size_t, 2>, 2>(edges));
 }
 
 
 template <class P>
 SurfaceGraphQuantity* SurfaceMesh::addSurfaceGraphQuantity(std::string name, const std::vector<P>& paths) {
 
-    // Convert to vector of paths
-    std::vector<std::vector<glm::vec3>> convertPaths;
-    for (const P& inputP : paths) {
-        convertPaths.emplace_back(standardizeVectorArray<glm::vec3, 3>(inputP));
-    }
+  // Convert to vector of paths
+  std::vector<std::vector<glm::vec3>> convertPaths;
+  for (const P& inputP : paths) {
+    convertPaths.emplace_back(standardizeVectorArray<glm::vec3, 3>(inputP));
+  }
 
-    // Build flat list of nodes and edges between them
-    std::vector<glm::vec3> nodes;
-    std::vector<std::array<size_t, 2>> edges;
-    for (auto& p : convertPaths) {
-        for (size_t i = 0; i < p.size(); i++) {
-            size_t N = nodes.size();
-            nodes.push_back(p[i]);
-            if (i > 0) {
-                edges.push_back({N - 1, N});
-            }
-        }
+  // Build flat list of nodes and edges between them
+  std::vector<glm::vec3> nodes;
+  std::vector<std::array<size_t, 2>> edges;
+  for (auto& p : convertPaths) {
+    for (size_t i = 0; i < p.size(); i++) {
+      size_t N = nodes.size();
+      nodes.push_back(p[i]);
+      if (i > 0) {
+        edges.push_back({N - 1, N});
+      }
     }
+  }
 
-    return addSurfaceGraphQuantityImpl(name, nodes, edges);
+  return addSurfaceGraphQuantityImpl(name, nodes, edges);
 }
 
 template <class P>
 SurfaceGraphQuantity* SurfaceMesh::addSurfaceGraphQuantity2D(std::string name, const std::vector<P>& paths) {
 
-    // Convert and call the general version
-    std::vector<std::vector<glm::vec3>> paths3D;
-    for (const P& inputP : paths) {
-        std::vector<glm::vec3> p = standardizeVectorArray<glm::vec3, 2>(inputP);
-        for (glm::vec3& v : p) {
-            v.z = 0.;
-        }
-        paths3D.emplace_back(p);
+  // Convert and call the general version
+  std::vector<std::vector<glm::vec3>> paths3D;
+  for (const P& inputP : paths) {
+    std::vector<glm::vec3> p = standardizeVectorArray<glm::vec3, 2>(inputP);
+    for (glm::vec3& v : p) {
+      v.z = 0.;
     }
+    paths3D.emplace_back(p);
+  }
 
-    return addSurfaceGraphQuantity(name, paths3D);
+  return addSurfaceGraphQuantity(name, paths3D);
 }
 
 
 template <class T>
 SurfaceVertexScalarQuantity* SurfaceMesh::addVertexScalarQuantity(std::string name, const T& data, DataType type) {
-    validateSize(data, vertexDataSize, "vertex scalar quantity " + name);
-    return addVertexScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
+  validateSize(data, vertexDataSize, "vertex scalar quantity " + name);
+  return addVertexScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
 }
 
 template <class T>
 SurfaceFaceScalarQuantity* SurfaceMesh::addFaceScalarQuantity(std::string name, const T& data, DataType type) {
-    validateSize(data, faceDataSize, "face scalar quantity " + name);
-    return addFaceScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
+  validateSize(data, faceDataSize, "face scalar quantity " + name);
+  return addFaceScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
 }
 
 
 template <class T>
 SurfaceEdgeScalarQuantity* SurfaceMesh::addEdgeScalarQuantity(std::string name, const T& data, DataType type) {
-    validateSize(data, edgeDataSize, "edge scalar quantity " + name);
-    return addEdgeScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
+  validateSize(data, edgeDataSize, "edge scalar quantity " + name);
+  return addEdgeScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
 }
 
 template <class T>
 SurfaceHalfedgeScalarQuantity* SurfaceMesh::addHalfedgeScalarQuantity(std::string name, const T& data, DataType type) {
-    validateSize(data, halfedgeDataSize, "halfedge scalar quantity " + name);
-    return addHalfedgeScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
+  validateSize(data, halfedgeDataSize, "halfedge scalar quantity " + name);
+  return addHalfedgeScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
 }
 
 template <class T>
 SurfaceCornerScalarQuantity* SurfaceMesh::addCornerScalarQuantity(std::string name, const T& data, DataType type) {
-    validateSize(data, cornerDataSize, "corner scalar quantity " + name);
-    return addCornerScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
+  validateSize(data, cornerDataSize, "corner scalar quantity " + name);
+  return addCornerScalarQuantityImpl(name, standardizeArray<double, T>(data), type);
 }
 
 
 template <class T>
 SurfaceVertexVectorQuantity* SurfaceMesh::addVertexVectorQuantity(std::string name, const T& vectors,
                                                                   VectorType vectorType) {
-    validateSize(vectors, vertexDataSize, "vertex vector quantity " + name);
-    return addVertexVectorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(vectors), vectorType);
+  validateSize(vectors, vertexDataSize, "vertex vector quantity " + name);
+  return addVertexVectorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(vectors), vectorType);
 }
 template <class T>
 SurfaceVertexVectorQuantity* SurfaceMesh::addVertexVectorQuantity2D(std::string name, const T& vectors,
                                                                     VectorType vectorType) {
-    validateSize(vectors, vertexDataSize, "vertex vector quantity " + name);
-    std::vector<glm::vec3> vectors3D = standardizeVectorArray<glm::vec3, 2>(vectors);
-    for (auto& v : vectors3D) {
-        v.z = 0.;
-    }
-    return addVertexVectorQuantityImpl(name, vectors3D, vectorType);
+  validateSize(vectors, vertexDataSize, "vertex vector quantity " + name);
+  std::vector<glm::vec3> vectors3D = standardizeVectorArray<glm::vec3, 2>(vectors);
+  for (auto& v : vectors3D) {
+    v.z = 0.;
+  }
+  return addVertexVectorQuantityImpl(name, vectors3D, vectorType);
 }
 
 template <class T>
 SurfaceFaceVectorQuantity* SurfaceMesh::addFaceVectorQuantity(std::string name, const T& vectors,
                                                               VectorType vectorType) {
-    validateSize(vectors, faceDataSize, "face vector quantity " + name);
-    return addFaceVectorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(vectors), vectorType);
+  validateSize(vectors, faceDataSize, "face vector quantity " + name);
+  return addFaceVectorQuantityImpl(name, standardizeVectorArray<glm::vec3, 3>(vectors), vectorType);
 }
 template <class T>
 SurfaceFaceVectorQuantity* SurfaceMesh::addFaceVectorQuantity2D(std::string name, const T& vectors,
                                                                 VectorType vectorType) {
-    validateSize(vectors, faceDataSize, "face vector quantity " + name);
-    std::vector<glm::vec3> vectors3D = standardizeVectorArray<glm::vec3, 2>(vectors);
-    for (auto& v : vectors3D) {
-        v.z = 0.;
-    }
-    return addFaceVectorQuantityImpl(name, vectors3D, vectorType);
+  validateSize(vectors, faceDataSize, "face vector quantity " + name);
+  std::vector<glm::vec3> vectors3D = standardizeVectorArray<glm::vec3, 2>(vectors);
+  for (auto& v : vectors3D) {
+    v.z = 0.;
+  }
+  return addFaceVectorQuantityImpl(name, vectors3D, vectorType);
 }
 
 template <class T>
 SurfaceFaceIntrinsicVectorQuantity* SurfaceMesh::addFaceIntrinsicVectorQuantity(std::string name, const T& vectors,
                                                                                 int nSym, VectorType vectorType) {
-    validateSize(vectors, faceDataSize, "face intrinsic vector quantity " + name);
-    return addFaceIntrinsicVectorQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(vectors), nSym, vectorType);
+  validateSize(vectors, faceDataSize, "face intrinsic vector quantity " + name);
+  return addFaceIntrinsicVectorQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(vectors), nSym, vectorType);
 }
 
 
 template <class T>
 SurfaceVertexIntrinsicVectorQuantity* SurfaceMesh::addVertexIntrinsicVectorQuantity(std::string name, const T& vectors,
                                                                                     int nSym, VectorType vectorType) {
-    validateSize(vectors, vertexDataSize, "vertex intrinsic vector quantity " + name);
-    return addVertexIntrinsicVectorQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(vectors), nSym, vectorType);
+  validateSize(vectors, vertexDataSize, "vertex intrinsic vector quantity " + name);
+  return addVertexIntrinsicVectorQuantityImpl(name, standardizeVectorArray<glm::vec2, 2>(vectors), nSym, vectorType);
 }
 
 
@@ -441,46 +439,46 @@ SurfaceVertexIntrinsicVectorQuantity* SurfaceMesh::addVertexIntrinsicVectorQuant
 template <class T, class O>
 SurfaceOneFormIntrinsicVectorQuantity* SurfaceMesh::addOneFormIntrinsicVectorQuantity(std::string name, const T& data,
                                                                                       const O& orientations) {
-    validateSize(data, edgeDataSize, "one form intrinsic vector quantity " + name);
-    return addOneFormIntrinsicVectorQuantityImpl(name, standardizeArray<double, T>(data),
-                                                 standardizeArray<char, O>(orientations));
+  validateSize(data, edgeDataSize, "one form intrinsic vector quantity " + name);
+  return addOneFormIntrinsicVectorQuantityImpl(name, standardizeArray<double, T>(data),
+                                               standardizeArray<char, O>(orientations));
 }
 
 
 template <class T>
 void SurfaceMesh::setVertexTangentBasisX(const T& vectors) {
-    validateSize(vectors, vertexDataSize, "vertex tangent basis X");
-    setVertexTangentBasisXImpl(standardizeVectorArray<glm::vec3, 3>(vectors));
+  validateSize(vectors, vertexDataSize, "vertex tangent basis X");
+  setVertexTangentBasisXImpl(standardizeVectorArray<glm::vec3, 3>(vectors));
 }
 
 template <class T>
 void SurfaceMesh::setVertexTangentBasisX2D(const T& vectors) {
-    validateSize(vectors, vertexDataSize, "vertex tangent basis X");
+  validateSize(vectors, vertexDataSize, "vertex tangent basis X");
 
-    std::vector<glm::vec3> vec3D = standardizeVectorArray<glm::vec3, 2>(vectors);
-    for (glm::vec3& v : vec3D) {
-        v.z = 0.;
-    }
+  std::vector<glm::vec3> vec3D = standardizeVectorArray<glm::vec3, 2>(vectors);
+  for (glm::vec3& v : vec3D) {
+    v.z = 0.;
+  }
 
-    setVertexTangentBasisXImpl(vec3D);
+  setVertexTangentBasisXImpl(vec3D);
 }
 
 template <class T>
 void SurfaceMesh::setFaceTangentBasisX(const T& vectors) {
-    validateSize(vectors, faceDataSize, "face tangent basis X");
-    setFaceTangentBasisXImpl(standardizeVectorArray<glm::vec3, 3>(vectors));
+  validateSize(vectors, faceDataSize, "face tangent basis X");
+  setFaceTangentBasisXImpl(standardizeVectorArray<glm::vec3, 3>(vectors));
 }
 
 template <class T>
 void SurfaceMesh::setFaceTangentBasisX2D(const T& vectors) {
-    validateSize(vectors, faceDataSize, "face tangent basis X");
+  validateSize(vectors, faceDataSize, "face tangent basis X");
 
-    std::vector<glm::vec3> vec3D = standardizeVectorArray<glm::vec3, 2>(vectors);
-    for (glm::vec3& v : vec3D) {
-        v.z = 0.;
-    }
+  std::vector<glm::vec3> vec3D = standardizeVectorArray<glm::vec3, 2>(vectors);
+  for (glm::vec3& v : vec3D) {
+    v.z = 0.;
+  }
 
-    setFaceTangentBasisXImpl(vec3D);
+  setFaceTangentBasisXImpl(vec3D);
 }
 
 

--- a/include/polyscope/surface_mesh_quantity.h
+++ b/include/polyscope/surface_mesh_quantity.h
@@ -12,17 +12,17 @@ class SurfaceMesh;
 
 // Extend Quantity<SurfaceMesh> to add a few extra functions
 class SurfaceMeshQuantity : public Quantity<SurfaceMesh> {
-  public:
-    SurfaceMeshQuantity(std::string name, SurfaceMesh& parentStructure, bool dominates = false);
-    ~SurfaceMeshQuantity(){};
+public:
+  SurfaceMeshQuantity(std::string name, SurfaceMesh& parentStructure, bool dominates = false);
+  ~SurfaceMeshQuantity(){};
 
-  public:
-    // Build GUI info about this element
-    virtual void buildVertexInfoGUI(size_t vInd);
-    virtual void buildFaceInfoGUI(size_t fInd);
-    virtual void buildEdgeInfoGUI(size_t eInd);
-    virtual void buildHalfedgeInfoGUI(size_t heInd);
-    virtual void buildCornerInfoGUI(size_t cInd);
+public:
+  // Build GUI info about this element
+  virtual void buildVertexInfoGUI(size_t vInd);
+  virtual void buildFaceInfoGUI(size_t fInd);
+  virtual void buildEdgeInfoGUI(size_t eInd);
+  virtual void buildHalfedgeInfoGUI(size_t heInd);
+  virtual void buildCornerInfoGUI(size_t cInd);
 };
 
 } // namespace polyscope

--- a/include/polyscope/surface_mesh_quantity.h
+++ b/include/polyscope/surface_mesh_quantity.h
@@ -12,16 +12,17 @@ class SurfaceMesh;
 
 // Extend Quantity<SurfaceMesh> to add a few extra functions
 class SurfaceMeshQuantity : public Quantity<SurfaceMesh> {
-public:
-  SurfaceMeshQuantity(std::string name, SurfaceMesh& parentStructure, bool dominates = false);
-  ~SurfaceMeshQuantity() {};
+  public:
+    SurfaceMeshQuantity(std::string name, SurfaceMesh& parentStructure, bool dominates = false);
+    ~SurfaceMeshQuantity(){};
 
-public:
-  // Build GUI info about this element
-  virtual void buildVertexInfoGUI(size_t vInd);
-  virtual void buildFaceInfoGUI(size_t fInd);
-  virtual void buildEdgeInfoGUI(size_t eInd);
-  virtual void buildHalfedgeInfoGUI(size_t heInd);
+  public:
+    // Build GUI info about this element
+    virtual void buildVertexInfoGUI(size_t vInd);
+    virtual void buildFaceInfoGUI(size_t fInd);
+    virtual void buildEdgeInfoGUI(size_t eInd);
+    virtual void buildHalfedgeInfoGUI(size_t heInd);
+    virtual void buildCornerInfoGUI(size_t cInd);
 };
 
 } // namespace polyscope

--- a/include/polyscope/surface_scalar_quantity.h
+++ b/include/polyscope/surface_scalar_quantity.h
@@ -11,21 +11,21 @@
 namespace polyscope {
 
 class SurfaceScalarQuantity : public SurfaceMeshQuantity, public ScalarQuantity<SurfaceScalarQuantity> {
-public:
-  SurfaceScalarQuantity(std::string name, SurfaceMesh& mesh_, std::string definedOn, const std::vector<double>& values_,
-                        DataType dataType);
+  public:
+    SurfaceScalarQuantity(std::string name, SurfaceMesh& mesh_, std::string definedOn,
+                          const std::vector<double>& values_, DataType dataType);
 
-  virtual void draw() override;
-  virtual void buildCustomUI() override;
-  virtual std::string niceName() override;
-  virtual void refresh() override;
+    virtual void draw() override;
+    virtual void buildCustomUI() override;
+    virtual std::string niceName() override;
+    virtual void refresh() override;
 
-protected:
-  const std::string definedOn;
-  std::shared_ptr<render::ShaderProgram> program;
+  protected:
+    const std::string definedOn;
+    std::shared_ptr<render::ShaderProgram> program;
 
-  // Helpers
-  virtual void createProgram() = 0;
+    // Helpers
+    virtual void createProgram() = 0;
 };
 
 // ========================================================
@@ -33,15 +33,15 @@ protected:
 // ========================================================
 
 class SurfaceVertexScalarQuantity : public SurfaceScalarQuantity {
-public:
-  SurfaceVertexScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
-                              DataType dataType_ = DataType::STANDARD);
+  public:
+    SurfaceVertexScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
+                                DataType dataType_ = DataType::STANDARD);
 
-  virtual void createProgram() override;
+    virtual void createProgram() override;
 
-  void fillColorBuffers(render::ShaderProgram& p);
+    void fillColorBuffers(render::ShaderProgram& p);
 
-  void buildVertexInfoGUI(size_t vInd) override;
+    void buildVertexInfoGUI(size_t vInd) override;
 };
 
 
@@ -50,15 +50,15 @@ public:
 // ========================================================
 
 class SurfaceFaceScalarQuantity : public SurfaceScalarQuantity {
-public:
-  SurfaceFaceScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
-                            DataType dataType_ = DataType::STANDARD);
+  public:
+    SurfaceFaceScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
+                              DataType dataType_ = DataType::STANDARD);
 
-  virtual void createProgram() override;
+    virtual void createProgram() override;
 
-  void fillColorBuffers(render::ShaderProgram& p);
+    void fillColorBuffers(render::ShaderProgram& p);
 
-  void buildFaceInfoGUI(size_t fInd) override;
+    void buildFaceInfoGUI(size_t fInd) override;
 };
 
 
@@ -67,16 +67,16 @@ public:
 // ========================================================
 
 class SurfaceEdgeScalarQuantity : public SurfaceScalarQuantity {
-public:
-  SurfaceEdgeScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
-                            DataType dataType_ = DataType::STANDARD);
-  //   ~SurfaceVertexScalarQuantity();
+  public:
+    SurfaceEdgeScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
+                              DataType dataType_ = DataType::STANDARD);
+    //   ~SurfaceVertexScalarQuantity();
 
-  virtual void createProgram() override;
+    virtual void createProgram() override;
 
-  void fillColorBuffers(render::ShaderProgram& p);
+    void fillColorBuffers(render::ShaderProgram& p);
 
-  void buildEdgeInfoGUI(size_t edgeInd) override;
+    void buildEdgeInfoGUI(size_t edgeInd) override;
 };
 
 // ========================================================
@@ -84,16 +84,32 @@ public:
 // ========================================================
 
 class SurfaceHalfedgeScalarQuantity : public SurfaceScalarQuantity {
-public:
-  SurfaceHalfedgeScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
+  public:
+    SurfaceHalfedgeScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
+                                  DataType dataType_ = DataType::STANDARD);
+    //   ~SurfaceVertexScalarQuantity();
+
+    virtual void createProgram() override;
+
+    void fillColorBuffers(render::ShaderProgram& p);
+
+    void buildHalfedgeInfoGUI(size_t heInd) override;
+};
+
+// ========================================================
+// ==========          Corner Scalar           ==========
+// ========================================================
+
+class SurfaceCornerScalarQuantity : public SurfaceScalarQuantity {
+  public:
+    SurfaceCornerScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
                                 DataType dataType_ = DataType::STANDARD);
-  //   ~SurfaceVertexScalarQuantity();
 
-  virtual void createProgram() override;
+    virtual void createProgram() override;
 
-  void fillColorBuffers(render::ShaderProgram& p);
+    void fillColorBuffers(render::ShaderProgram& p);
 
-  void buildHalfedgeInfoGUI(size_t heInd) override;
+    void buildCornerInfoGUI(size_t cInd) override;
 };
 
 

--- a/include/polyscope/surface_scalar_quantity.h
+++ b/include/polyscope/surface_scalar_quantity.h
@@ -11,21 +11,21 @@
 namespace polyscope {
 
 class SurfaceScalarQuantity : public SurfaceMeshQuantity, public ScalarQuantity<SurfaceScalarQuantity> {
-  public:
-    SurfaceScalarQuantity(std::string name, SurfaceMesh& mesh_, std::string definedOn,
-                          const std::vector<double>& values_, DataType dataType);
+public:
+  SurfaceScalarQuantity(std::string name, SurfaceMesh& mesh_, std::string definedOn, const std::vector<double>& values_,
+                        DataType dataType);
 
-    virtual void draw() override;
-    virtual void buildCustomUI() override;
-    virtual std::string niceName() override;
-    virtual void refresh() override;
+  virtual void draw() override;
+  virtual void buildCustomUI() override;
+  virtual std::string niceName() override;
+  virtual void refresh() override;
 
-  protected:
-    const std::string definedOn;
-    std::shared_ptr<render::ShaderProgram> program;
+protected:
+  const std::string definedOn;
+  std::shared_ptr<render::ShaderProgram> program;
 
-    // Helpers
-    virtual void createProgram() = 0;
+  // Helpers
+  virtual void createProgram() = 0;
 };
 
 // ========================================================
@@ -33,15 +33,15 @@ class SurfaceScalarQuantity : public SurfaceMeshQuantity, public ScalarQuantity<
 // ========================================================
 
 class SurfaceVertexScalarQuantity : public SurfaceScalarQuantity {
-  public:
-    SurfaceVertexScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
-                                DataType dataType_ = DataType::STANDARD);
+public:
+  SurfaceVertexScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
+                              DataType dataType_ = DataType::STANDARD);
 
-    virtual void createProgram() override;
+  virtual void createProgram() override;
 
-    void fillColorBuffers(render::ShaderProgram& p);
+  void fillColorBuffers(render::ShaderProgram& p);
 
-    void buildVertexInfoGUI(size_t vInd) override;
+  void buildVertexInfoGUI(size_t vInd) override;
 };
 
 
@@ -50,15 +50,15 @@ class SurfaceVertexScalarQuantity : public SurfaceScalarQuantity {
 // ========================================================
 
 class SurfaceFaceScalarQuantity : public SurfaceScalarQuantity {
-  public:
-    SurfaceFaceScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
-                              DataType dataType_ = DataType::STANDARD);
+public:
+  SurfaceFaceScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
+                            DataType dataType_ = DataType::STANDARD);
 
-    virtual void createProgram() override;
+  virtual void createProgram() override;
 
-    void fillColorBuffers(render::ShaderProgram& p);
+  void fillColorBuffers(render::ShaderProgram& p);
 
-    void buildFaceInfoGUI(size_t fInd) override;
+  void buildFaceInfoGUI(size_t fInd) override;
 };
 
 
@@ -67,16 +67,16 @@ class SurfaceFaceScalarQuantity : public SurfaceScalarQuantity {
 // ========================================================
 
 class SurfaceEdgeScalarQuantity : public SurfaceScalarQuantity {
-  public:
-    SurfaceEdgeScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
-                              DataType dataType_ = DataType::STANDARD);
-    //   ~SurfaceVertexScalarQuantity();
+public:
+  SurfaceEdgeScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
+                            DataType dataType_ = DataType::STANDARD);
+  //   ~SurfaceVertexScalarQuantity();
 
-    virtual void createProgram() override;
+  virtual void createProgram() override;
 
-    void fillColorBuffers(render::ShaderProgram& p);
+  void fillColorBuffers(render::ShaderProgram& p);
 
-    void buildEdgeInfoGUI(size_t edgeInd) override;
+  void buildEdgeInfoGUI(size_t edgeInd) override;
 };
 
 // ========================================================
@@ -84,16 +84,16 @@ class SurfaceEdgeScalarQuantity : public SurfaceScalarQuantity {
 // ========================================================
 
 class SurfaceHalfedgeScalarQuantity : public SurfaceScalarQuantity {
-  public:
-    SurfaceHalfedgeScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
-                                  DataType dataType_ = DataType::STANDARD);
-    //   ~SurfaceVertexScalarQuantity();
+public:
+  SurfaceHalfedgeScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
+                                DataType dataType_ = DataType::STANDARD);
+  //   ~SurfaceVertexScalarQuantity();
 
-    virtual void createProgram() override;
+  virtual void createProgram() override;
 
-    void fillColorBuffers(render::ShaderProgram& p);
+  void fillColorBuffers(render::ShaderProgram& p);
 
-    void buildHalfedgeInfoGUI(size_t heInd) override;
+  void buildHalfedgeInfoGUI(size_t heInd) override;
 };
 
 // ========================================================
@@ -101,15 +101,15 @@ class SurfaceHalfedgeScalarQuantity : public SurfaceScalarQuantity {
 // ========================================================
 
 class SurfaceCornerScalarQuantity : public SurfaceScalarQuantity {
-  public:
-    SurfaceCornerScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
-                                DataType dataType_ = DataType::STANDARD);
+public:
+  SurfaceCornerScalarQuantity(std::string name, const std::vector<double>& values_, SurfaceMesh& mesh_,
+                              DataType dataType_ = DataType::STANDARD);
 
-    virtual void createProgram() override;
+  virtual void createProgram() override;
 
-    void fillColorBuffers(render::ShaderProgram& p);
+  void fillColorBuffers(render::ShaderProgram& p);
 
-    void buildCornerInfoGUI(size_t cInd) override;
+  void buildCornerInfoGUI(size_t cInd) override;
 };
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -282,7 +282,7 @@ add_definitions(-DNOMINMAX)
 # Include settings
 target_include_directories(polyscope PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include")
 target_include_directories(polyscope PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../deps/glm")
-target_include_directories(polyscope PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../deps/args") # not used, polyscope generates no apps directly
+#target_include_directories(polyscope PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../deps/args") # not used, polyscope generates no apps directly
 target_include_directories(polyscope PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../deps/happly")
 target_include_directories(polyscope PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../deps/json/include")
 target_include_directories(polyscope PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../deps/stb")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -282,7 +282,7 @@ add_definitions(-DNOMINMAX)
 # Include settings
 target_include_directories(polyscope PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include")
 target_include_directories(polyscope PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../deps/glm")
-#target_include_directories(polyscope PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../deps/args") # not used, polyscope generates no apps directly
+target_include_directories(polyscope PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../deps/args") # not used, polyscope generates no apps directly
 target_include_directories(polyscope PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../deps/happly")
 target_include_directories(polyscope PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../deps/json/include")
 target_include_directories(polyscope PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../deps/stb")

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -25,481 +25,475 @@ namespace polyscope {
 // Helpers
 namespace {
 
-    // === Implement the context stack
+// === Implement the context stack
 
-    // The context stack should _always_ have at least one context in it. The lowest context is the one created at
-    // initialization.
-    struct ContextEntry {
-        ImGuiContext* context;
-        std::function<void()> callback;
-        bool drawDefaultUI;
-    };
-    std::vector<ContextEntry> contextStack;
+// The context stack should _always_ have at least one context in it. The lowest context is the one created at
+// initialization.
+struct ContextEntry {
+  ImGuiContext* context;
+  std::function<void()> callback;
+  bool drawDefaultUI;
+};
+std::vector<ContextEntry> contextStack;
 
-    bool redrawNextFrame = true;
+bool redrawNextFrame = true;
 
-    // Some state about imgui windows to stack them
-    float imguiStackMargin = 10;
-    float lastWindowHeightPolyscope = 200;
-    float lastWindowHeightUser = 200;
-    float leftWindowsWidth = 305;
-    float rightWindowsWidth = 500;
+// Some state about imgui windows to stack them
+float imguiStackMargin = 10;
+float lastWindowHeightPolyscope = 200;
+float lastWindowHeightUser = 200;
+float leftWindowsWidth = 305;
+float rightWindowsWidth = 500;
 
 
-    const std::string prefsFilename = ".polyscope.ini";
+const std::string prefsFilename = ".polyscope.ini";
 
-    void readPrefsFile() {
+void readPrefsFile() {
 
-        try {
+  try {
 
-            std::ifstream inStream(prefsFilename);
-            if (inStream) {
+    std::ifstream inStream(prefsFilename);
+    if (inStream) {
 
-                json prefsJSON;
-                inStream >> prefsJSON;
+      json prefsJSON;
+      inStream >> prefsJSON;
 
-                // Set values
-                // Do some basic validation on the sizes first to work around bugs with bogus values getting written to
-                // init file
-                if (prefsJSON.count("windowWidth") > 0) {
-                    int val = prefsJSON["windowWidth"];
-                    if (val >= 64 && val < 10000) view::windowWidth = val;
-                }
-                if (prefsJSON.count("windowHeight") > 0) {
-                    int val = prefsJSON["windowHeight"];
-                    if (val >= 64 && val < 10000) view::windowHeight = val;
-                }
-                if (prefsJSON.count("windowPosX") > 0) {
-                    int val = prefsJSON["windowPosX"];
-                    if (val >= 0 && val < 10000) view::initWindowPosX = val;
-                }
-                if (prefsJSON.count("windowPosY") > 0) {
-                    int val = prefsJSON["windowPosY"];
-                    if (val >= 0 && val < 10000) view::initWindowPosY = val;
-                }
-            }
-
-        }
-        // We never really care if something goes wrong while loading preferences, so eat all exceptions
-        catch (...) {
-            polyscope::warning("Parsing of prefs file failed");
-        }
+      // Set values
+      // Do some basic validation on the sizes first to work around bugs with bogus values getting written to
+      // init file
+      if (prefsJSON.count("windowWidth") > 0) {
+        int val = prefsJSON["windowWidth"];
+        if (val >= 64 && val < 10000) view::windowWidth = val;
+      }
+      if (prefsJSON.count("windowHeight") > 0) {
+        int val = prefsJSON["windowHeight"];
+        if (val >= 64 && val < 10000) view::windowHeight = val;
+      }
+      if (prefsJSON.count("windowPosX") > 0) {
+        int val = prefsJSON["windowPosX"];
+        if (val >= 0 && val < 10000) view::initWindowPosX = val;
+      }
+      if (prefsJSON.count("windowPosY") > 0) {
+        int val = prefsJSON["windowPosY"];
+        if (val >= 0 && val < 10000) view::initWindowPosY = val;
+      }
     }
 
-    void writePrefsFile() {
+  }
+  // We never really care if something goes wrong while loading preferences, so eat all exceptions
+  catch (...) {
+    polyscope::warning("Parsing of prefs file failed");
+  }
+}
 
-        // Update values as needed
-        int posX, posY;
-        std::tie(posX, posY) = render::engine->getWindowPos();
-        int windowWidth = view::windowWidth;
-        int windowHeight = view::windowHeight;
+void writePrefsFile() {
 
-        // Validate values. Don't write the prefs file if any of these values are obviously bogus (this seems to happen
-        // at least on Windows when the application is minimzed)
-        bool valuesValid = true;
-        valuesValid &= posX >= 0 && posX < 10000;
-        valuesValid &= posY >= 0 && posY < 10000;
-        valuesValid &= windowWidth >= 64 && windowWidth < 10000;
-        valuesValid &= windowHeight >= 64 && windowHeight < 10000;
-        if (!valuesValid) return;
+  // Update values as needed
+  int posX, posY;
+  std::tie(posX, posY) = render::engine->getWindowPos();
+  int windowWidth = view::windowWidth;
+  int windowHeight = view::windowHeight;
 
-        // Build json object
-        json prefsJSON = {
-            {"windowWidth", windowWidth},
-            {"windowHeight", windowHeight},
-            {"windowPosX", posX},
-            {"windowPosY", posY},
-        };
+  // Validate values. Don't write the prefs file if any of these values are obviously bogus (this seems to happen
+  // at least on Windows when the application is minimzed)
+  bool valuesValid = true;
+  valuesValid &= posX >= 0 && posX < 10000;
+  valuesValid &= posY >= 0 && posY < 10000;
+  valuesValid &= windowWidth >= 64 && windowWidth < 10000;
+  valuesValid &= windowHeight >= 64 && windowHeight < 10000;
+  if (!valuesValid) return;
 
-        // Write out json object
-        std::ofstream o(prefsFilename);
-        o << std::setw(4) << prefsJSON << std::endl;
-    }
+  // Build json object
+  json prefsJSON = {
+      {"windowWidth", windowWidth},
+      {"windowHeight", windowHeight},
+      {"windowPosX", posX},
+      {"windowPosY", posY},
+  };
+
+  // Write out json object
+  std::ofstream o(prefsFilename);
+  o << std::setw(4) << prefsJSON << std::endl;
+}
 
 }; // namespace
 
 // === Core global functions
 
 void init(std::string backend) {
-    if (state::initialized) {
-        if (backend != state::backend) {
-            throw std::runtime_error("re-initializing with different backend is not supported");
-        }
-        // otherwise silently allow multiple-init
-        return;
+  if (state::initialized) {
+    if (backend != state::backend) {
+      throw std::runtime_error("re-initializing with different backend is not supported");
     }
+    // otherwise silently allow multiple-init
+    return;
+  }
 
-    state::backend = backend;
+  state::backend = backend;
 
-    if (options::usePrefsFile) {
-        readPrefsFile();
-    }
+  if (options::usePrefsFile) {
+    readPrefsFile();
+  }
 
-    // Initialize the rendering engine
-    render::initializeRenderEngine(backend);
+  // Initialize the rendering engine
+  render::initializeRenderEngine(backend);
 
-    // Initialie ImGUI
-    IMGUI_CHECKVERSION();
-    render::engine->initializeImGui();
-    // push a fake context which will never be used (but dodges some invalidation issues)
-    contextStack.push_back(ContextEntry{ImGui::GetCurrentContext(), nullptr, false});
+  // Initialie ImGUI
+  IMGUI_CHECKVERSION();
+  render::engine->initializeImGui();
+  // push a fake context which will never be used (but dodges some invalidation issues)
+  contextStack.push_back(ContextEntry{ImGui::GetCurrentContext(), nullptr, false});
 
-    view::invalidateView();
+  view::invalidateView();
 
-    state::initialized = true;
-    state::doDefaultMouseInteraction = true;
+  state::initialized = true;
+  state::doDefaultMouseInteraction = true;
 }
 
 void pushContext(std::function<void()> callbackFunction, bool drawDefaultUI) {
 
-    // Create a new context and push it on to the stack
-    ImGuiContext* newContext = ImGui::CreateContext(render::engine->getImGuiGlobalFontAtlas());
-    ImGuiIO& oldIO = ImGui::GetIO(); // used to copy below, see note
-    ImGui::SetCurrentContext(newContext);
+  // Create a new context and push it on to the stack
+  ImGuiContext* newContext = ImGui::CreateContext(render::engine->getImGuiGlobalFontAtlas());
+  ImGuiIO& oldIO = ImGui::GetIO(); // used to copy below, see note
+  ImGui::SetCurrentContext(newContext);
 
-    if (options::configureImGuiStyleCallback) {
-        options::configureImGuiStyleCallback();
+  if (options::configureImGuiStyleCallback) {
+    options::configureImGuiStyleCallback();
+  }
+
+  ImGui::GetIO() = oldIO; // Copy all of the old IO values to new. With ImGUI 1.76 (and some previous versions), this
+                          // was necessary to fix a bug where keys like delete, etc would break in subcontexts. The
+                          // problem was that the key mappings (e.g. GLFW_KEY_BACKSPACE --> ImGuiKey_Backspace) need
+                          // to be populated in io.KeyMap, and these entries would get lost on creating a new context.
+  contextStack.push_back(ContextEntry{newContext, callbackFunction, drawDefaultUI});
+
+  if (contextStack.size() > 50) {
+    // Catch bugs with nested show()
+    throw std::runtime_error(
+        "Uh oh, polyscope::show() was recusively MANY times (depth > 50), this is probably a bug. Perhaps "
+        "you are accidentally calling show every time polyscope::userCallback executes?");
+  };
+
+  // Make sure the window is visible
+  render::engine->showWindow();
+
+  // Re-enter main loop until the context has been popped
+  size_t currentContextStackSize = contextStack.size();
+  while (contextStack.size() >= currentContextStackSize) {
+
+    mainLoopIteration();
+
+    // auto-exit if the window is closed
+    if (render::engine->windowRequestsClose()) {
+      popContext();
     }
+  }
 
-    ImGui::GetIO() = oldIO; // Copy all of the old IO values to new. With ImGUI 1.76 (and some previous versions), this
-                            // was necessary to fix a bug where keys like delete, etc would break in subcontexts. The
-                            // problem was that the key mappings (e.g. GLFW_KEY_BACKSPACE --> ImGuiKey_Backspace) need
-                            // to be populated in io.KeyMap, and these entries would get lost on creating a new context.
-    contextStack.push_back(ContextEntry{newContext, callbackFunction, drawDefaultUI});
+  oldIO = ImGui::GetIO(); // Copy new IO values to old. I haven't encountered anything that strictly requires this,
+                          // but it feels like we should mirror the behavior from pushing.
 
-    if (contextStack.size() > 50) {
-        // Catch bugs with nested show()
-        throw std::runtime_error(
-            "Uh oh, polyscope::show() was recusively MANY times (depth > 50), this is probably a bug. Perhaps "
-            "you are accidentally calling show every time polyscope::userCallback executes?");
-    };
+  ImGui::DestroyContext(newContext);
 
-    // Make sure the window is visible
-    render::engine->showWindow();
-
-    // Re-enter main loop until the context has been popped
-    size_t currentContextStackSize = contextStack.size();
-    while (contextStack.size() >= currentContextStackSize) {
-
-        mainLoopIteration();
-
-        // auto-exit if the window is closed
-        if (render::engine->windowRequestsClose()) {
-            popContext();
-        }
-    }
-
-    oldIO = ImGui::GetIO(); // Copy new IO values to old. I haven't encountered anything that strictly requires this,
-                            // but it feels like we should mirror the behavior from pushing.
-
-    ImGui::DestroyContext(newContext);
-
-    // Restore the previous context, if there was one
-    if (!contextStack.empty()) {
-        ImGui::SetCurrentContext(contextStack.back().context);
-    }
+  // Restore the previous context, if there was one
+  if (!contextStack.empty()) {
+    ImGui::SetCurrentContext(contextStack.back().context);
+  }
 }
 
 
 void popContext() {
-    if (contextStack.empty()) {
-        error("Called popContext() too many times");
-        return;
-    }
-    contextStack.pop_back();
+  if (contextStack.empty()) {
+    error("Called popContext() too many times");
+    return;
+  }
+  contextStack.pop_back();
 }
 
-void requestRedraw() {
-    redrawNextFrame = true;
-}
-bool redrawRequested() {
-    return redrawNextFrame;
-}
+void requestRedraw() { redrawNextFrame = true; }
+bool redrawRequested() { return redrawNextFrame; }
 
 void drawStructures() {
 
-    // Draw all off the structures registered with polyscope
+  // Draw all off the structures registered with polyscope
 
-    for (auto catMap : state::structures) {
-        for (auto s : catMap.second) {
-            // make sure the right settings are active
-            // render::engine->setDepthMode();
-            // render::engine->applyTransparencySettings();
+  for (auto catMap : state::structures) {
+    for (auto s : catMap.second) {
+      // make sure the right settings are active
+      // render::engine->setDepthMode();
+      // render::engine->applyTransparencySettings();
 
-            s.second->draw();
-        }
+      s.second->draw();
     }
+  }
 
-    // Also render any slice plane geometry
-    for (SlicePlane* s : state::slicePlanes) {
-        s->drawGeometry();
-    }
+  // Also render any slice plane geometry
+  for (SlicePlane* s : state::slicePlanes) {
+    s->drawGeometry();
+  }
 }
 
 namespace {
 
-    float dragDistSinceLastRelease = 0.0;
+float dragDistSinceLastRelease = 0.0;
 
-    void processInputEvents() {
-        ImGuiIO& io = ImGui::GetIO();
+void processInputEvents() {
+  ImGuiIO& io = ImGui::GetIO();
 
-        // If any mouse button is pressed, trigger a redraw
-        if (ImGui::IsAnyMouseDown()) {
-            requestRedraw();
+  // If any mouse button is pressed, trigger a redraw
+  if (ImGui::IsAnyMouseDown()) {
+    requestRedraw();
+  }
+
+  bool widgetCapturedMouse = false;
+  for (Widget* w : state::widgets) {
+    widgetCapturedMouse = w->interact();
+    if (widgetCapturedMouse) {
+      break;
+    }
+  }
+
+  // Handle scroll events for 3D view
+  if (state::doDefaultMouseInteraction) {
+    if (!io.WantCaptureMouse && !widgetCapturedMouse) {
+      double xoffset = io.MouseWheelH;
+      double yoffset = io.MouseWheel;
+
+      if (xoffset != 0 || yoffset != 0) {
+        requestRedraw();
+
+        // On some setups, shift flips the scroll direction, so take the max
+        // scrolling in any direction
+        double maxScroll = xoffset;
+        if (std::abs(yoffset) > std::abs(xoffset)) {
+          maxScroll = yoffset;
         }
 
-        bool widgetCapturedMouse = false;
-        for (Widget* w : state::widgets) {
-            widgetCapturedMouse = w->interact();
-            if (widgetCapturedMouse) {
-                break;
-            }
+        // Pass camera commands to the camera
+        if (maxScroll != 0.0) {
+          bool scrollClipPlane = io.KeyShift;
+
+          if (scrollClipPlane) {
+            view::processClipPlaneShift(maxScroll);
+          } else {
+            view::processZoom(maxScroll);
+          }
+        }
+      }
+    }
+
+    // === Mouse inputs
+    if (!io.WantCaptureMouse && !widgetCapturedMouse) {
+
+      // Process drags
+      bool dragLeft = ImGui::IsMouseDragging(0);
+      bool dragRight = !dragLeft && ImGui::IsMouseDragging(1); // left takes priority, so only one can be true
+      if (dragLeft || dragRight) {
+
+        glm::vec2 dragDelta{io.MouseDelta.x / view::windowWidth, -io.MouseDelta.y / view::windowHeight};
+        dragDistSinceLastRelease += std::abs(dragDelta.x);
+        dragDistSinceLastRelease += std::abs(dragDelta.y);
+
+        // exactly one of these will be true
+        bool isRotate = dragLeft && !io.KeyShift && !io.KeyCtrl;
+        bool isTranslate = (dragLeft && io.KeyShift && !io.KeyCtrl) || dragRight;
+        bool isDragZoom = dragLeft && io.KeyShift && io.KeyCtrl;
+
+        if (isDragZoom) {
+          view::processZoom(dragDelta.y * 5);
+        }
+        if (isRotate) {
+          glm::vec2 currPos{io.MousePos.x / view::windowWidth,
+                            (view::windowHeight - io.MousePos.y) / view::windowHeight};
+          currPos = (currPos * 2.0f) - glm::vec2{1.0, 1.0};
+          if (std::abs(currPos.x) <= 1.0 && std::abs(currPos.y) <= 1.0) {
+            view::processRotate(currPos - 2.0f * dragDelta, currPos);
+          }
+        }
+        if (isTranslate) {
+          view::processTranslate(dragDelta);
+        }
+      }
+
+      // Click picks
+      float dragIgnoreThreshold = 0.01;
+      if (ImGui::IsMouseReleased(0)) {
+
+        // Don't pick at the end of a long drag
+        if (dragDistSinceLastRelease < dragIgnoreThreshold) {
+          ImVec2 p = ImGui::GetMousePos();
+          std::pair<Structure*, size_t> pickResult =
+              pick::evaluatePickQuery(io.DisplayFramebufferScale.x * p.x, io.DisplayFramebufferScale.y * p.y);
+          pick::setSelection(pickResult);
         }
 
-        // Handle scroll events for 3D view
-        if (state::doDefaultMouseInteraction) {
-            if (!io.WantCaptureMouse && !widgetCapturedMouse) {
-                double xoffset = io.MouseWheelH;
-                double yoffset = io.MouseWheel;
-
-                if (xoffset != 0 || yoffset != 0) {
-                    requestRedraw();
-
-                    // On some setups, shift flips the scroll direction, so take the max
-                    // scrolling in any direction
-                    double maxScroll = xoffset;
-                    if (std::abs(yoffset) > std::abs(xoffset)) {
-                        maxScroll = yoffset;
-                    }
-
-                    // Pass camera commands to the camera
-                    if (maxScroll != 0.0) {
-                        bool scrollClipPlane = io.KeyShift;
-
-                        if (scrollClipPlane) {
-                            view::processClipPlaneShift(maxScroll);
-                        } else {
-                            view::processZoom(maxScroll);
-                        }
-                    }
-                }
-            }
-
-            // === Mouse inputs
-            if (!io.WantCaptureMouse && !widgetCapturedMouse) {
-
-                // Process drags
-                bool dragLeft = ImGui::IsMouseDragging(0);
-                bool dragRight = !dragLeft && ImGui::IsMouseDragging(1); // left takes priority, so only one can be true
-                if (dragLeft || dragRight) {
-
-                    glm::vec2 dragDelta{io.MouseDelta.x / view::windowWidth, -io.MouseDelta.y / view::windowHeight};
-                    dragDistSinceLastRelease += std::abs(dragDelta.x);
-                    dragDistSinceLastRelease += std::abs(dragDelta.y);
-
-                    // exactly one of these will be true
-                    bool isRotate = dragLeft && !io.KeyShift && !io.KeyCtrl;
-                    bool isTranslate = (dragLeft && io.KeyShift && !io.KeyCtrl) || dragRight;
-                    bool isDragZoom = dragLeft && io.KeyShift && io.KeyCtrl;
-
-                    if (isDragZoom) {
-                        view::processZoom(dragDelta.y * 5);
-                    }
-                    if (isRotate) {
-                        glm::vec2 currPos{io.MousePos.x / view::windowWidth,
-                                          (view::windowHeight - io.MousePos.y) / view::windowHeight};
-                        currPos = (currPos * 2.0f) - glm::vec2{1.0, 1.0};
-                        if (std::abs(currPos.x) <= 1.0 && std::abs(currPos.y) <= 1.0) {
-                            view::processRotate(currPos - 2.0f * dragDelta, currPos);
-                        }
-                    }
-                    if (isTranslate) {
-                        view::processTranslate(dragDelta);
-                    }
-                }
-
-                // Click picks
-                float dragIgnoreThreshold = 0.01;
-                if (ImGui::IsMouseReleased(0)) {
-
-                    // Don't pick at the end of a long drag
-                    if (dragDistSinceLastRelease < dragIgnoreThreshold) {
-                        ImVec2 p = ImGui::GetMousePos();
-                        std::pair<Structure*, size_t> pickResult = pick::evaluatePickQuery(
-                            io.DisplayFramebufferScale.x * p.x, io.DisplayFramebufferScale.y * p.y);
-                        pick::setSelection(pickResult);
-                    }
-
-                    // Reset the drag distance after any release
-                    dragDistSinceLastRelease = 0.0;
-                }
-                // Clear pick
-                if (ImGui::IsMouseReleased(1)) {
-                    if (dragDistSinceLastRelease < dragIgnoreThreshold) {
-                        pick::resetSelection();
-                    }
-                    dragDistSinceLastRelease = 0.0;
-                }
-            }
+        // Reset the drag distance after any release
+        dragDistSinceLastRelease = 0.0;
+      }
+      // Clear pick
+      if (ImGui::IsMouseReleased(1)) {
+        if (dragDistSinceLastRelease < dragIgnoreThreshold) {
+          pick::resetSelection();
         }
+        dragDistSinceLastRelease = 0.0;
+      }
+    }
+  }
 
-        // === Key-press inputs
-        if (!io.WantCaptureKeyboard) {
+  // === Key-press inputs
+  if (!io.WantCaptureKeyboard) {
 
-            // ctrl-c
-            if (io.KeyCtrl && render::engine->isKeyPressed('c')) {
-                std::string outData = view::getCameraJson();
-                render::engine->setClipboardText(outData);
-            }
+    // ctrl-c
+    if (io.KeyCtrl && render::engine->isKeyPressed('c')) {
+      std::string outData = view::getCameraJson();
+      render::engine->setClipboardText(outData);
+    }
 
-            // ctrl-v
-            if (io.KeyCtrl && render::engine->isKeyPressed('v')) {
-                std::string clipboardData = render::engine->getClipboardText();
-                view::setCameraFromJson(clipboardData, true);
-            }
-        }
+    // ctrl-v
+    if (io.KeyCtrl && render::engine->isKeyPressed('v')) {
+      std::string clipboardData = render::engine->getClipboardText();
+      view::setCameraFromJson(clipboardData, true);
+    }
+  }
+}
+
+
+void renderSlicePlanes() {
+  for (SlicePlane* s : state::slicePlanes) {
+    s->draw();
+  }
+}
+
+void renderScene() {
+  processLazyProperties();
+
+  render::engine->applyTransparencySettings();
+
+  render::engine->sceneBuffer->clearColor = {0., 0., 0.};
+  render::engine->sceneBuffer->clearAlpha = 0.;
+  render::engine->sceneBuffer->clear();
+
+  if (!render::engine->bindSceneBuffer()) return;
+
+  // If a view has never been set, this will set it to the home view
+  view::ensureViewValid();
+
+  if (render::engine->getTransparencyMode() == TransparencyMode::Pretty) {
+    // Special depth peeling case: multiple render passes
+    // We will perform several "peeled" rounds of rendering in to the usual scene buffer. After each, we will
+    // manually composite in to the final scene buffer.
+
+
+    // Clear the final buffer explicitly since we will gradually composite in to it rather than just blitting
+    // directly as in normal rendering.
+    render::engine->sceneBufferFinal->clearColor = glm::vec3{0., 0., 0.};
+    render::engine->sceneBufferFinal->clearAlpha = 0;
+    render::engine->sceneBufferFinal->clear();
+
+    render::engine->setDepthMode(); // we need depth to be enabled for the clear below to do anything
+    render::engine->sceneDepthMinFrame->clear();
+
+
+    for (int iPass = 0; iPass < options::transparencyRenderPasses; iPass++) {
+
+      render::engine->bindSceneBuffer();
+      render::engine->clearSceneBuffer();
+
+      render::engine->applyTransparencySettings();
+      drawStructures();
+
+      // Draw ground plane, slicers, etc
+      bool isRedraw = iPass > 0;
+      render::engine->groundPlane.draw(isRedraw);
+      if (!isRedraw) {
+        // Only on first pass (kinda weird, but works out, and doesn't really matter)
+        renderSlicePlanes();
+      }
+
+      // Composite the result of this pass in to the result buffer
+      render::engine->sceneBufferFinal->bind();
+      render::engine->setDepthMode(DepthMode::Disable);
+      render::engine->setBlendMode(BlendMode::Under);
+      render::engine->compositePeel->draw();
+
+      // Update the minimum depth texture
+      render::engine->updateMinDepthTexture();
     }
 
 
-    void renderSlicePlanes() {
-        for (SlicePlane* s : state::slicePlanes) {
-            s->draw();
-        }
-    }
+  } else {
+    // Normal case: single render pass
+    render::engine->applyTransparencySettings();
 
-    void renderScene() {
-        processLazyProperties();
+    drawStructures();
 
-        render::engine->applyTransparencySettings();
+    render::engine->groundPlane.draw();
+    renderSlicePlanes();
 
-        render::engine->sceneBuffer->clearColor = {0., 0., 0.};
-        render::engine->sceneBuffer->clearAlpha = 0.;
-        render::engine->sceneBuffer->clear();
+    render::engine->sceneBuffer->blitTo(render::engine->sceneBufferFinal.get());
+  }
+} // namespace
 
-        if (!render::engine->bindSceneBuffer()) return;
+void renderSceneToScreen() {
+  render::engine->bindDisplay();
+  if (options::debugDrawPickBuffer) {
+    // special debug draw
+    pick::evaluatePickQuery(-1, -1); // populate the buffer
+    render::engine->pickFramebuffer->blitTo(render::engine->displayBuffer.get());
+  } else {
+    render::engine->applyLightingTransform(render::engine->sceneColorFinal);
+  }
+}
 
-        // If a view has never been set, this will set it to the home view
-        view::ensureViewValid();
-
-        if (render::engine->getTransparencyMode() == TransparencyMode::Pretty) {
-            // Special depth peeling case: multiple render passes
-            // We will perform several "peeled" rounds of rendering in to the usual scene buffer. After each, we will
-            // manually composite in to the final scene buffer.
-
-
-            // Clear the final buffer explicitly since we will gradually composite in to it rather than just blitting
-            // directly as in normal rendering.
-            render::engine->sceneBufferFinal->clearColor = glm::vec3{0., 0., 0.};
-            render::engine->sceneBufferFinal->clearAlpha = 0;
-            render::engine->sceneBufferFinal->clear();
-
-            render::engine->setDepthMode(); // we need depth to be enabled for the clear below to do anything
-            render::engine->sceneDepthMinFrame->clear();
-
-
-            for (int iPass = 0; iPass < options::transparencyRenderPasses; iPass++) {
-
-                render::engine->bindSceneBuffer();
-                render::engine->clearSceneBuffer();
-
-                render::engine->applyTransparencySettings();
-                drawStructures();
-
-                // Draw ground plane, slicers, etc
-                bool isRedraw = iPass > 0;
-                render::engine->groundPlane.draw(isRedraw);
-                if (!isRedraw) {
-                    // Only on first pass (kinda weird, but works out, and doesn't really matter)
-                    renderSlicePlanes();
-                }
-
-                // Composite the result of this pass in to the result buffer
-                render::engine->sceneBufferFinal->bind();
-                render::engine->setDepthMode(DepthMode::Disable);
-                render::engine->setBlendMode(BlendMode::Under);
-                render::engine->compositePeel->draw();
-
-                // Update the minimum depth texture
-                render::engine->updateMinDepthTexture();
-            }
-
-
-        } else {
-            // Normal case: single render pass
-            render::engine->applyTransparencySettings();
-
-            drawStructures();
-
-            render::engine->groundPlane.draw();
-            renderSlicePlanes();
-
-            render::engine->sceneBuffer->blitTo(render::engine->sceneBufferFinal.get());
-        }
-    } // namespace
-
-    void renderSceneToScreen() {
-        render::engine->bindDisplay();
-        if (options::debugDrawPickBuffer) {
-            // special debug draw
-            pick::evaluatePickQuery(-1, -1); // populate the buffer
-            render::engine->pickFramebuffer->blitTo(render::engine->displayBuffer.get());
-        } else {
-            render::engine->applyLightingTransform(render::engine->sceneColorFinal);
-        }
-    }
-
-    auto lastMainLoopIterTime = std::chrono::steady_clock::now();
+auto lastMainLoopIterTime = std::chrono::steady_clock::now();
 
 } // namespace
 
 void buildPolyscopeGui() {
 
-    // Create window
-    static bool showPolyscopeWindow = true;
-    ImGui::SetNextWindowPos(ImVec2(imguiStackMargin, imguiStackMargin));
-    ImGui::SetNextWindowSize(ImVec2(leftWindowsWidth, 0.));
+  // Create window
+  static bool showPolyscopeWindow = true;
+  ImGui::SetNextWindowPos(ImVec2(imguiStackMargin, imguiStackMargin));
+  ImGui::SetNextWindowSize(ImVec2(leftWindowsWidth, 0.));
 
-    ImGui::Begin("Polyscope", &showPolyscopeWindow);
+  ImGui::Begin("Polyscope", &showPolyscopeWindow);
 
-    if (ImGui::Button("Reset View")) {
-        view::flyToHomeView();
-    }
-    ImGui::SameLine();
-    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(1.0f, 0.0f));
-    if (ImGui::Button("Screenshot")) {
-        screenshot(options::screenshotTransparency);
-    }
-    ImGui::SameLine();
-    if (ImGui::ArrowButton("##Option", ImGuiDir_Down)) {
-        ImGui::OpenPopup("ScreenshotOptionsPopup");
-    }
-    ImGui::PopStyleVar();
-    if (ImGui::BeginPopup("ScreenshotOptionsPopup")) {
+  if (ImGui::Button("Reset View")) {
+    view::flyToHomeView();
+  }
+  ImGui::SameLine();
+  ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(1.0f, 0.0f));
+  if (ImGui::Button("Screenshot")) {
+    screenshot(options::screenshotTransparency);
+  }
+  ImGui::SameLine();
+  if (ImGui::ArrowButton("##Option", ImGuiDir_Down)) {
+    ImGui::OpenPopup("ScreenshotOptionsPopup");
+  }
+  ImGui::PopStyleVar();
+  if (ImGui::BeginPopup("ScreenshotOptionsPopup")) {
 
-        ImGui::Checkbox("with transparency", &options::screenshotTransparency);
+    ImGui::Checkbox("with transparency", &options::screenshotTransparency);
 
-        if (ImGui::BeginMenu("file format")) {
-            if (ImGui::MenuItem(".png", NULL, options::screenshotExtension == ".png"))
-                options::screenshotExtension = ".png";
-            if (ImGui::MenuItem(".jpg", NULL, options::screenshotExtension == ".jpg"))
-                options::screenshotExtension = ".jpg";
-            ImGui::EndMenu();
-        }
-
-        ImGui::EndPopup();
+    if (ImGui::BeginMenu("file format")) {
+      if (ImGui::MenuItem(".png", NULL, options::screenshotExtension == ".png")) options::screenshotExtension = ".png";
+      if (ImGui::MenuItem(".jpg", NULL, options::screenshotExtension == ".jpg")) options::screenshotExtension = ".jpg";
+      ImGui::EndMenu();
     }
 
+    ImGui::EndPopup();
+  }
 
-    ImGui::SameLine();
-    if (ImGui::Button("Controls")) {
-        // do nothing, just want hover state
-    }
-    if (ImGui::IsItemHovered()) {
 
-        ImGui::SetNextWindowPos(ImVec2(2 * imguiStackMargin + leftWindowsWidth, imguiStackMargin));
-        ImGui::SetNextWindowSize(ImVec2(0., 0.));
+  ImGui::SameLine();
+  if (ImGui::Button("Controls")) {
+    // do nothing, just want hover state
+  }
+  if (ImGui::IsItemHovered()) {
 
-        // clang-format off
+    ImGui::SetNextWindowPos(ImVec2(2 * imguiStackMargin + leftWindowsWidth, imguiStackMargin));
+    ImGui::SetNextWindowSize(ImVec2(0., 0.));
+
+    // clang-format off
 		ImGui::Begin("Controls", NULL, ImGuiWindowFlags_NoTitleBar);
 		ImGui::TextUnformatted("View Navigation:");			
 			ImGui::TextUnformatted("      Rotate: [left click drag]");
@@ -517,585 +511,580 @@ void buildPolyscopeGui() {
 			ImGui::TextUnformatted("     that element will be shown on the right. Use [right click]");
 			ImGui::TextUnformatted("     to clear the selection.");
 		ImGui::End();
-        // clang-format on
+    // clang-format on
+  }
+
+  // View options tree
+  view::buildViewGui();
+
+  // Appearance options tree
+  render::engine->buildEngineGui();
+
+  // Debug options tree
+  ImGui::SetNextTreeNodeOpen(false, ImGuiCond_FirstUseEver);
+  if (ImGui::TreeNode("Debug")) {
+    if (ImGui::Button("Force refresh")) {
+      refresh();
     }
+    ImGui::Checkbox("Show pick buffer", &options::debugDrawPickBuffer);
+    ImGui::Checkbox("Always redraw", &options::alwaysRedraw);
 
-    // View options tree
-    view::buildViewGui();
-
-    // Appearance options tree
-    render::engine->buildEngineGui();
-
-    // Debug options tree
-    ImGui::SetNextTreeNodeOpen(false, ImGuiCond_FirstUseEver);
-    if (ImGui::TreeNode("Debug")) {
-        if (ImGui::Button("Force refresh")) {
-            refresh();
-        }
-        ImGui::Checkbox("Show pick buffer", &options::debugDrawPickBuffer);
-        ImGui::Checkbox("Always redraw", &options::alwaysRedraw);
-
-        static bool showDebugTextures = false;
-        ImGui::Checkbox("Show debug textures", &showDebugTextures);
-        if (showDebugTextures) {
-            render::engine->showTextureInImGuiWindow("Scene", render::engine->sceneColor.get());
-            render::engine->showTextureInImGuiWindow("Scene Final", render::engine->sceneColorFinal.get());
-        }
-        ImGui::TreePop();
+    static bool showDebugTextures = false;
+    ImGui::Checkbox("Show debug textures", &showDebugTextures);
+    if (showDebugTextures) {
+      render::engine->showTextureInImGuiWindow("Scene", render::engine->sceneColor.get());
+      render::engine->showTextureInImGuiWindow("Scene Final", render::engine->sceneColorFinal.get());
     }
+    ImGui::TreePop();
+  }
 
-    // fps
-    ImGui::Text("%.1f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
+  // fps
+  ImGui::Text("%.1f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
 
-    lastWindowHeightPolyscope = imguiStackMargin + ImGui::GetWindowHeight();
-    leftWindowsWidth = ImGui::GetWindowWidth();
+  lastWindowHeightPolyscope = imguiStackMargin + ImGui::GetWindowHeight();
+  leftWindowsWidth = ImGui::GetWindowWidth();
 
-    ImGui::End();
+  ImGui::End();
 }
 
 void buildStructureGui() {
-    // Create window
-    static bool showStructureWindow = true;
+  // Create window
+  static bool showStructureWindow = true;
 
-    ImGui::SetNextWindowPos(ImVec2(imguiStackMargin, lastWindowHeightPolyscope + 2 * imguiStackMargin));
-    ImGui::SetNextWindowSize(
-        ImVec2(leftWindowsWidth, view::windowHeight - lastWindowHeightPolyscope - 3 * imguiStackMargin));
+  ImGui::SetNextWindowPos(ImVec2(imguiStackMargin, lastWindowHeightPolyscope + 2 * imguiStackMargin));
+  ImGui::SetNextWindowSize(
+      ImVec2(leftWindowsWidth, view::windowHeight - lastWindowHeightPolyscope - 3 * imguiStackMargin));
 
-    ImGui::Begin("Structures", &showStructureWindow);
+  ImGui::Begin("Structures", &showStructureWindow);
 
-    for (auto catMapEntry : state::structures) {
-        std::string catName = catMapEntry.first;
+  for (auto catMapEntry : state::structures) {
+    std::string catName = catMapEntry.first;
 
-        std::map<std::string, Structure*>& structureMap = catMapEntry.second;
+    std::map<std::string, Structure*>& structureMap = catMapEntry.second;
 
-        ImGui::PushID(catName.c_str()); // ensure there are no conflicts with
-                                        // identically-named labels
+    ImGui::PushID(catName.c_str()); // ensure there are no conflicts with
+                                    // identically-named labels
 
-        // Build the structure's UI
-        ImGui::SetNextTreeNodeOpen(structureMap.size() > 0, ImGuiCond_FirstUseEver);
-        if (ImGui::CollapsingHeader((catName + " (" + std::to_string(structureMap.size()) + ")").c_str())) {
-            // Draw shared GUI elements for all instances of the structure
-            if (structureMap.size() > 0) {
-                structureMap.begin()->second->buildSharedStructureUI();
-            }
+    // Build the structure's UI
+    ImGui::SetNextTreeNodeOpen(structureMap.size() > 0, ImGuiCond_FirstUseEver);
+    if (ImGui::CollapsingHeader((catName + " (" + std::to_string(structureMap.size()) + ")").c_str())) {
+      // Draw shared GUI elements for all instances of the structure
+      if (structureMap.size() > 0) {
+        structureMap.begin()->second->buildSharedStructureUI();
+      }
 
-            for (auto x : structureMap) {
-                ImGui::SetNextTreeNodeOpen(structureMap.size() <= 8,
-                                           ImGuiCond_FirstUseEver); // closed by default if more than 8
-                x.second->buildUI();
-            }
-        }
-
-        ImGui::PopID();
+      for (auto x : structureMap) {
+        ImGui::SetNextTreeNodeOpen(structureMap.size() <= 8,
+                                   ImGuiCond_FirstUseEver); // closed by default if more than 8
+        x.second->buildUI();
+      }
     }
 
-    leftWindowsWidth = ImGui::GetWindowWidth();
+    ImGui::PopID();
+  }
 
-    ImGui::End();
+  leftWindowsWidth = ImGui::GetWindowWidth();
+
+  ImGui::End();
 }
 
 void buildPickGui() {
-    if (pick::haveSelection()) {
+  if (pick::haveSelection()) {
 
-        ImGui::SetNextWindowPos(ImVec2(view::windowWidth - (rightWindowsWidth + imguiStackMargin),
-                                       2 * imguiStackMargin + lastWindowHeightUser));
-        ImGui::SetNextWindowSize(ImVec2(rightWindowsWidth, 0.));
+    ImGui::SetNextWindowPos(ImVec2(view::windowWidth - (rightWindowsWidth + imguiStackMargin),
+                                   2 * imguiStackMargin + lastWindowHeightUser));
+    ImGui::SetNextWindowSize(ImVec2(rightWindowsWidth, 0.));
 
-        ImGui::Begin("Selection", nullptr);
-        std::pair<Structure*, size_t> selection = pick::getSelection();
+    ImGui::Begin("Selection", nullptr);
+    std::pair<Structure*, size_t> selection = pick::getSelection();
 
-        ImGui::TextUnformatted((selection.first->typeName() + ": " + selection.first->name).c_str());
-        ImGui::Separator();
-        selection.first->buildPickUI(selection.second);
+    ImGui::TextUnformatted((selection.first->typeName() + ": " + selection.first->name).c_str());
+    ImGui::Separator();
+    selection.first->buildPickUI(selection.second);
 
-        rightWindowsWidth = ImGui::GetWindowWidth();
-        ImGui::End();
-    }
+    rightWindowsWidth = ImGui::GetWindowWidth();
+    ImGui::End();
+  }
 }
 
 void buildUserGuiAndInvokeCallback() {
 
-    if (!options::invokeUserCallbackForNestedShow && contextStack.size() > 2) {
-        return;
+  if (!options::invokeUserCallbackForNestedShow && contextStack.size() > 2) {
+    return;
+  }
+
+  if (state::userCallback) {
+
+    if (options::buildGui && options::openImGuiWindowForUserCallback) {
+      ImGui::PushID("user_callback");
+      ImGui::SetNextWindowPos(ImVec2(view::windowWidth - (rightWindowsWidth + imguiStackMargin), imguiStackMargin));
+      ImGui::SetNextWindowSize(ImVec2(rightWindowsWidth, 0.));
+
+      ImGui::Begin("Command UI", nullptr);
     }
 
-    if (state::userCallback) {
+    state::userCallback();
 
-        if (options::buildGui && options::openImGuiWindowForUserCallback) {
-            ImGui::PushID("user_callback");
-            ImGui::SetNextWindowPos(
-                ImVec2(view::windowWidth - (rightWindowsWidth + imguiStackMargin), imguiStackMargin));
-            ImGui::SetNextWindowSize(ImVec2(rightWindowsWidth, 0.));
-
-            ImGui::Begin("Command UI", nullptr);
-        }
-
-        state::userCallback();
-
-        if (options::buildGui && options::openImGuiWindowForUserCallback) {
-            rightWindowsWidth = ImGui::GetWindowWidth();
-            lastWindowHeightUser = imguiStackMargin + ImGui::GetWindowHeight();
-            ImGui::End();
-            ImGui::PopID();
-        } else {
-            lastWindowHeightUser = imguiStackMargin;
-        }
-
+    if (options::buildGui && options::openImGuiWindowForUserCallback) {
+      rightWindowsWidth = ImGui::GetWindowWidth();
+      lastWindowHeightUser = imguiStackMargin + ImGui::GetWindowHeight();
+      ImGui::End();
+      ImGui::PopID();
     } else {
-        lastWindowHeightUser = imguiStackMargin;
+      lastWindowHeightUser = imguiStackMargin;
     }
+
+  } else {
+    lastWindowHeightUser = imguiStackMargin;
+  }
 }
 
 void draw(bool withUI, bool withContextCallback) {
-    processLazyProperties();
+  processLazyProperties();
 
-    // Update buffer and context
-    render::engine->makeContextCurrent();
-    render::engine->bindDisplay();
-    render::engine->setBackgroundColor({view::bgColor[0], view::bgColor[1], view::bgColor[2]});
-    render::engine->setBackgroundAlpha(view::bgColor[3]);
-    render::engine->clearDisplay();
+  // Update buffer and context
+  render::engine->makeContextCurrent();
+  render::engine->bindDisplay();
+  render::engine->setBackgroundColor({view::bgColor[0], view::bgColor[1], view::bgColor[2]});
+  render::engine->setBackgroundAlpha(view::bgColor[3]);
+  render::engine->clearDisplay();
 
-    if (withUI) {
-        render::engine->ImGuiNewFrame();
-    }
+  if (withUI) {
+    render::engine->ImGuiNewFrame();
+  }
 
-    // Build the GUI components
-    if (withUI) {
-        if (contextStack.back().drawDefaultUI) {
+  // Build the GUI components
+  if (withUI) {
+    if (contextStack.back().drawDefaultUI) {
 
-            // Note: It is important to build the user GUI first, because it is likely that callbacks there will modify
-            // polyscope data. If we do these modifications happen later in the render cycle, they might invalidate data
-            // which is necessary when ImGui::Render() happens below.
-            buildUserGuiAndInvokeCallback();
+      // Note: It is important to build the user GUI first, because it is likely that callbacks there will modify
+      // polyscope data. If we do these modifications happen later in the render cycle, they might invalidate data
+      // which is necessary when ImGui::Render() happens below.
+      buildUserGuiAndInvokeCallback();
 
-            if (options::buildGui) {
-                buildPolyscopeGui();
-                buildStructureGui();
-                buildPickGui();
+      if (options::buildGui) {
+        buildPolyscopeGui();
+        buildStructureGui();
+        buildPickGui();
 
-                for (Widget* w : state::widgets) {
-                    w->buildGUI();
-                }
-            }
-        }
-    }
-
-    // Execute the context callback, if there is one.
-    // This callback is Polyscope implementation detail, which is distinct from the userCallback (which gets called
-    // below)
-    if (withContextCallback && contextStack.back().callback) {
-        (contextStack.back().callback)();
-    }
-
-    processLazyProperties();
-
-    // Draw structures in the scene
-    if (redrawNextFrame || options::alwaysRedraw) {
-        renderScene();
-        redrawNextFrame = false;
-    }
-    renderSceneToScreen();
-
-    // Draw the GUI
-    if (withUI) {
-        // render widgets
-        render::engine->bindDisplay();
         for (Widget* w : state::widgets) {
-            w->draw();
+          w->buildGUI();
         }
-
-        render::engine->bindDisplay();
-        render::engine->ImGuiRender();
+      }
     }
+  }
+
+  // Execute the context callback, if there is one.
+  // This callback is Polyscope implementation detail, which is distinct from the userCallback (which gets called
+  // below)
+  if (withContextCallback && contextStack.back().callback) {
+    (contextStack.back().callback)();
+  }
+
+  processLazyProperties();
+
+  // Draw structures in the scene
+  if (redrawNextFrame || options::alwaysRedraw) {
+    renderScene();
+    redrawNextFrame = false;
+  }
+  renderSceneToScreen();
+
+  // Draw the GUI
+  if (withUI) {
+    // render widgets
+    render::engine->bindDisplay();
+    for (Widget* w : state::widgets) {
+      w->draw();
+    }
+
+    render::engine->bindDisplay();
+    render::engine->ImGuiRender();
+  }
 }
 
 
 void mainLoopIteration() {
 
-    processLazyProperties();
+  processLazyProperties();
 
-    // The windowing system will let this busy-loop in some situations, unfortunately. Make sure that doesn't happen.
-    if (options::maxFPS != -1) {
-        auto currTime = std::chrono::steady_clock::now();
-        long microsecPerLoop = 1000000 / options::maxFPS;
-        microsecPerLoop = (95 * microsecPerLoop) / 100; // give a little slack so we actually hit target fps
-        while (std::chrono::duration_cast<std::chrono::microseconds>(currTime - lastMainLoopIterTime).count() <
-               microsecPerLoop) {
-            std::this_thread::yield();
-            currTime = std::chrono::steady_clock::now();
-        }
+  // The windowing system will let this busy-loop in some situations, unfortunately. Make sure that doesn't happen.
+  if (options::maxFPS != -1) {
+    auto currTime = std::chrono::steady_clock::now();
+    long microsecPerLoop = 1000000 / options::maxFPS;
+    microsecPerLoop = (95 * microsecPerLoop) / 100; // give a little slack so we actually hit target fps
+    while (std::chrono::duration_cast<std::chrono::microseconds>(currTime - lastMainLoopIterTime).count() <
+           microsecPerLoop) {
+      std::this_thread::yield();
+      currTime = std::chrono::steady_clock::now();
     }
-    lastMainLoopIterTime = std::chrono::steady_clock::now();
+  }
+  lastMainLoopIterTime = std::chrono::steady_clock::now();
 
-    render::engine->makeContextCurrent();
-    render::engine->updateWindowSize();
+  render::engine->makeContextCurrent();
+  render::engine->updateWindowSize();
 
-    // Process UI events
-    render::engine->pollEvents();
-    processInputEvents();
-    view::updateFlight();
-    showDelayedWarnings();
+  // Process UI events
+  render::engine->pollEvents();
+  processInputEvents();
+  view::updateFlight();
+  showDelayedWarnings();
 
-    // Rendering
-    draw();
-    render::engine->swapDisplayBuffers();
+  // Rendering
+  draw();
+  render::engine->swapDisplayBuffers();
 }
 
 void show(size_t forFrames) {
 
-    if (!state::initialized) {
-        throw std::logic_error(options::printPrefix +
-                               "must initialize Polyscope with polyscope::init() before calling polyscope::show().");
+  if (!state::initialized) {
+    throw std::logic_error(options::printPrefix +
+                           "must initialize Polyscope with polyscope::init() before calling polyscope::show().");
+  }
+
+  // the popContext() doesn't quit until _after_ the last frame, so we need to decrement by 1 to get the count right
+  if (forFrames > 0) forFrames--;
+
+  auto checkFrames = [&]() {
+    if (forFrames == 0) {
+      popContext();
+    } else {
+      forFrames--;
     }
+  };
 
-    // the popContext() doesn't quit until _after_ the last frame, so we need to decrement by 1 to get the count right
-    if (forFrames > 0) forFrames--;
+  if (options::giveFocusOnShow) {
+    render::engine->focusWindow();
+  }
 
-    auto checkFrames = [&]() {
-        if (forFrames == 0) {
-            popContext();
-        } else {
-            forFrames--;
-        }
-    };
+  pushContext(checkFrames);
 
-    if (options::giveFocusOnShow) {
-        render::engine->focusWindow();
-    }
+  if (options::usePrefsFile) {
+    writePrefsFile();
+  }
 
-    pushContext(checkFrames);
-
-    if (options::usePrefsFile) {
-        writePrefsFile();
-    }
-
-    // if this was the outermost show(), hide the window afterward
-    if (contextStack.size() == 1) {
-        render::engine->hideWindow();
-    }
+  // if this was the outermost show(), hide the window afterward
+  if (contextStack.size() == 1) {
+    render::engine->hideWindow();
+  }
 }
 
 void shutdown() {
 
-    // TODO should we make an effort to destruct everything here?
-    if (options::usePrefsFile) {
-        writePrefsFile();
-    }
+  // TODO should we make an effort to destruct everything here?
+  if (options::usePrefsFile) {
+    writePrefsFile();
+  }
 
-    render::engine->shutdownImGui();
+  render::engine->shutdownImGui();
 }
 
 bool registerStructure(Structure* s, bool replaceIfPresent) {
 
-    // Make sure a map for the type exists
-    std::string typeName = s->typeName();
-    if (state::structures.find(typeName) == state::structures.end()) {
-        state::structures[typeName] = std::map<std::string, Structure*>();
-    }
-    std::map<std::string, Structure*>& sMap = state::structures[typeName];
+  // Make sure a map for the type exists
+  std::string typeName = s->typeName();
+  if (state::structures.find(typeName) == state::structures.end()) {
+    state::structures[typeName] = std::map<std::string, Structure*>();
+  }
+  std::map<std::string, Structure*>& sMap = state::structures[typeName];
 
-    // Check if the structure name is in use
-    bool inUse = sMap.find(s->name) != sMap.end();
-    if (inUse) {
-        if (replaceIfPresent) {
-            removeStructure(s->name);
-        } else {
-            polyscope::error("Attempted to register structure with name " + s->name +
-                             ", but a structure with that name already exists");
-            return false;
-        }
+  // Check if the structure name is in use
+  bool inUse = sMap.find(s->name) != sMap.end();
+  if (inUse) {
+    if (replaceIfPresent) {
+      removeStructure(s->name);
+    } else {
+      polyscope::error("Attempted to register structure with name " + s->name +
+                       ", but a structure with that name already exists");
+      return false;
     }
+  }
 
-    // Center/scale if desired
-    if (options::autocenterStructures) {
-        s->centerBoundingBox();
-    }
-    if (options::autoscaleStructures) {
-        s->rescaleToUnit();
-    }
+  // Center/scale if desired
+  if (options::autocenterStructures) {
+    s->centerBoundingBox();
+  }
+  if (options::autoscaleStructures) {
+    s->rescaleToUnit();
+  }
 
-    // Add the new structure
-    sMap[s->name] = s;
-    updateStructureExtents();
-    requestRedraw();
+  // Add the new structure
+  sMap[s->name] = s;
+  updateStructureExtents();
+  requestRedraw();
 
-    return true;
+  return true;
 }
 
 Structure* getStructure(std::string type, std::string name) {
 
-    if (type == "" || name == "") return nullptr;
+  if (type == "" || name == "") return nullptr;
 
-    // If there are no structures of that type it is an automatic fail
-    if (state::structures.find(type) == state::structures.end()) {
-        error("No structures of type " + type + " registered");
-        return nullptr;
-    }
-    std::map<std::string, Structure*>& sMap = state::structures[type];
+  // If there are no structures of that type it is an automatic fail
+  if (state::structures.find(type) == state::structures.end()) {
+    error("No structures of type " + type + " registered");
+    return nullptr;
+  }
+  std::map<std::string, Structure*>& sMap = state::structures[type];
 
-    // Special automatic case, return any
-    if (name == "") {
-        if (sMap.size() != 1) {
-            error(
-                "Cannot use automatic structure get with empty name unless there is exactly one structure of that type "
-                "registered");
-            return nullptr;
-        }
-        return sMap.begin()->second;
+  // Special automatic case, return any
+  if (name == "") {
+    if (sMap.size() != 1) {
+      error("Cannot use automatic structure get with empty name unless there is exactly one structure of that type "
+            "registered");
+      return nullptr;
     }
+    return sMap.begin()->second;
+  }
 
-    // General case
-    if (sMap.find(name) == sMap.end()) {
-        error("No structure of type " + type + " with name " + name + " registered");
-        return nullptr;
-    }
-    return sMap[name];
+  // General case
+  if (sMap.find(name) == sMap.end()) {
+    error("No structure of type " + type + " with name " + name + " registered");
+    return nullptr;
+  }
+  return sMap[name];
 }
 
 bool hasStructure(std::string type, std::string name) {
-    // If there are no structures of that type it is an automatic fail
-    if (state::structures.find(type) == state::structures.end()) {
-        return false;
-    }
-    std::map<std::string, Structure*>& sMap = state::structures[type];
+  // If there are no structures of that type it is an automatic fail
+  if (state::structures.find(type) == state::structures.end()) {
+    return false;
+  }
+  std::map<std::string, Structure*>& sMap = state::structures[type];
 
-    // Special automatic case, return any
-    if (name == "") {
-        if (sMap.size() != 1) {
-            error(
-                "Cannot use automatic structure get with empty name unless there is exactly one structure of that type "
-                "registered");
-        }
-        return true;
+  // Special automatic case, return any
+  if (name == "") {
+    if (sMap.size() != 1) {
+      error("Cannot use automatic structure get with empty name unless there is exactly one structure of that type "
+            "registered");
     }
-    return sMap.find(name) != sMap.end();
+    return true;
+  }
+  return sMap.find(name) != sMap.end();
 }
 
 
 void removeStructure(std::string type, std::string name, bool errorIfAbsent) {
 
-    // If there are no structures of that type it is an automatic fail
-    if (state::structures.find(type) == state::structures.end()) {
-        if (errorIfAbsent) {
-            error("No structures of type " + type + " registered");
-        }
-        return;
+  // If there are no structures of that type it is an automatic fail
+  if (state::structures.find(type) == state::structures.end()) {
+    if (errorIfAbsent) {
+      error("No structures of type " + type + " registered");
     }
-    std::map<std::string, Structure*>& sMap = state::structures[type];
-
-    // Check if structure exists
-    if (sMap.find(name) == sMap.end()) {
-        if (errorIfAbsent) {
-            error("No structure of type " + type + " and name " + name + " registered");
-        }
-        return;
-    }
-
-    // Structure exists, remove it
-    Structure* s = sMap[name];
-    pick::resetSelectionIfStructure(s);
-    sMap.erase(s->name);
-    delete s;
-    updateStructureExtents();
     return;
+  }
+  std::map<std::string, Structure*>& sMap = state::structures[type];
+
+  // Check if structure exists
+  if (sMap.find(name) == sMap.end()) {
+    if (errorIfAbsent) {
+      error("No structure of type " + type + " and name " + name + " registered");
+    }
+    return;
+  }
+
+  // Structure exists, remove it
+  Structure* s = sMap[name];
+  pick::resetSelectionIfStructure(s);
+  sMap.erase(s->name);
+  delete s;
+  updateStructureExtents();
+  return;
 }
 
 void removeStructure(Structure* structure, bool errorIfAbsent) {
-    removeStructure(structure->typeName(), structure->name, errorIfAbsent);
+  removeStructure(structure->typeName(), structure->name, errorIfAbsent);
 }
 
 void removeStructure(std::string name, bool errorIfAbsent) {
 
-    // Check if we can find exactly one structure matching the name
-    Structure* targetStruct = nullptr;
-    for (auto typeMap : state::structures) {
-        for (auto entry : typeMap.second) {
+  // Check if we can find exactly one structure matching the name
+  Structure* targetStruct = nullptr;
+  for (auto typeMap : state::structures) {
+    for (auto entry : typeMap.second) {
 
-            // Found a matching structure
-            if (entry.first == name) {
-                if (targetStruct == nullptr) {
-                    targetStruct = entry.second;
-                } else {
-                    error("Cannot use automatic structure remove with empty name unless there is exactly one structure "
-                          "of that "
-                          "type registered. Found two structures of different types with that name: " +
-                          targetStruct->typeName() + " and " + typeMap.first + ".");
-                    return;
-                }
-            }
+      // Found a matching structure
+      if (entry.first == name) {
+        if (targetStruct == nullptr) {
+          targetStruct = entry.second;
+        } else {
+          error("Cannot use automatic structure remove with empty name unless there is exactly one structure "
+                "of that "
+                "type registered. Found two structures of different types with that name: " +
+                targetStruct->typeName() + " and " + typeMap.first + ".");
+          return;
         }
+      }
     }
+  }
 
-    // Error if none found.
-    if (targetStruct == nullptr) {
-        if (errorIfAbsent) {
-            error("No structure named: " + name + " to remove.");
-        }
-        return;
+  // Error if none found.
+  if (targetStruct == nullptr) {
+    if (errorIfAbsent) {
+      error("No structure named: " + name + " to remove.");
     }
+    return;
+  }
 
-    removeStructure(targetStruct->typeName(), targetStruct->name, errorIfAbsent);
-    requestRedraw();
+  removeStructure(targetStruct->typeName(), targetStruct->name, errorIfAbsent);
+  requestRedraw();
 }
 
 void removeAllStructures() {
 
-    for (auto typeMap : state::structures) {
+  for (auto typeMap : state::structures) {
 
-        // dodge iterator invalidation
-        std::vector<std::string> names;
-        for (auto entry : typeMap.second) {
-            names.push_back(entry.first);
-        }
-
-        // remove all
-        for (auto name : names) {
-            removeStructure(typeMap.first, name);
-        }
+    // dodge iterator invalidation
+    std::vector<std::string> names;
+    for (auto entry : typeMap.second) {
+      names.push_back(entry.first);
     }
 
-    requestRedraw();
-    pick::resetSelection();
+    // remove all
+    for (auto name : names) {
+      removeStructure(typeMap.first, name);
+    }
+  }
+
+  requestRedraw();
+  pick::resetSelection();
 }
 
 void refresh() {
 
-    // reset the ground plane
-    render::engine->groundPlane.prepare();
+  // reset the ground plane
+  render::engine->groundPlane.prepare();
 
-    // reset all of the structures
-    for (auto cat : state::structures) {
-        for (auto x : cat.second) {
-            x.second->refresh();
-        }
+  // reset all of the structures
+  for (auto cat : state::structures) {
+    for (auto x : cat.second) {
+      x.second->refresh();
     }
+  }
 
-    requestRedraw();
+  requestRedraw();
 }
 
 // Cached versions of lazy properties used for updates
 namespace lazy {
-    TransparencyMode transparencyMode = TransparencyMode::None;
-    int transparencyRenderPasses = 8;
-    int ssaaFactor = 1;
-    bool groundPlaneEnabled = true;
-    GroundPlaneMode groundPlaneMode = GroundPlaneMode::TileReflection;
-    ScaledValue<float> groundPlaneHeightFactor = 0;
-    int shadowBlurIters = 2;
-    float shadowDarkness = .4;
+TransparencyMode transparencyMode = TransparencyMode::None;
+int transparencyRenderPasses = 8;
+int ssaaFactor = 1;
+bool groundPlaneEnabled = true;
+GroundPlaneMode groundPlaneMode = GroundPlaneMode::TileReflection;
+ScaledValue<float> groundPlaneHeightFactor = 0;
+int shadowBlurIters = 2;
+float shadowDarkness = .4;
 } // namespace lazy
 
 void processLazyProperties() {
 
-    // Note: This function essentially represents lazy software design, and it's an ugly and error-prone part of the
-    // system. The reason for it that some settings require action on a change (e..g re-drawing the scene), but we want
-    // to allow variable-set syntax like `polyscope::setting = newVal;` rather than getters and setters like
-    // `polyscope::setSetting(newVal);`. It might have been better to simple set options with setter from the start, but
-    // that ship has sailed.
-    //
-    // This function is a workaround which polls for changes to options settings, and performs any necessary additional
-    // work.
+  // Note: This function essentially represents lazy software design, and it's an ugly and error-prone part of the
+  // system. The reason for it that some settings require action on a change (e..g re-drawing the scene), but we want
+  // to allow variable-set syntax like `polyscope::setting = newVal;` rather than getters and setters like
+  // `polyscope::setSetting(newVal);`. It might have been better to simple set options with setter from the start, but
+  // that ship has sailed.
+  //
+  // This function is a workaround which polls for changes to options settings, and performs any necessary additional
+  // work.
 
 
-    // transparency mode
-    if (lazy::transparencyMode != options::transparencyMode) {
-        lazy::transparencyMode = options::transparencyMode;
-        render::engine->setTransparencyMode(options::transparencyMode);
-    }
+  // transparency mode
+  if (lazy::transparencyMode != options::transparencyMode) {
+    lazy::transparencyMode = options::transparencyMode;
+    render::engine->setTransparencyMode(options::transparencyMode);
+  }
 
-    // transparency render passes
-    if (lazy::transparencyRenderPasses != options::transparencyRenderPasses) {
-        lazy::transparencyRenderPasses = options::transparencyRenderPasses;
-        requestRedraw();
-    }
+  // transparency render passes
+  if (lazy::transparencyRenderPasses != options::transparencyRenderPasses) {
+    lazy::transparencyRenderPasses = options::transparencyRenderPasses;
+    requestRedraw();
+  }
 
-    // ssaa
-    if (lazy::ssaaFactor != options::ssaaFactor) {
-        lazy::ssaaFactor = options::ssaaFactor;
-        render::engine->setSSAAFactor(options::ssaaFactor);
-    }
+  // ssaa
+  if (lazy::ssaaFactor != options::ssaaFactor) {
+    lazy::ssaaFactor = options::ssaaFactor;
+    render::engine->setSSAAFactor(options::ssaaFactor);
+  }
 
-    // ground plane
-    if (lazy::groundPlaneEnabled != options::groundPlaneEnabled || lazy::groundPlaneMode != options::groundPlaneMode) {
-        lazy::groundPlaneEnabled = options::groundPlaneEnabled;
-        if (!options::groundPlaneEnabled) {
-            // if the (depecated) groundPlaneEnabled = false, set mode to None, so we only have one variable to check
-            options::groundPlaneMode = GroundPlaneMode::None;
-        }
-        lazy::groundPlaneMode = options::groundPlaneMode;
-        render::engine->groundPlane.prepare();
-        requestRedraw();
+  // ground plane
+  if (lazy::groundPlaneEnabled != options::groundPlaneEnabled || lazy::groundPlaneMode != options::groundPlaneMode) {
+    lazy::groundPlaneEnabled = options::groundPlaneEnabled;
+    if (!options::groundPlaneEnabled) {
+      // if the (depecated) groundPlaneEnabled = false, set mode to None, so we only have one variable to check
+      options::groundPlaneMode = GroundPlaneMode::None;
     }
-    if (lazy::groundPlaneHeightFactor.asAbsolute() != options::groundPlaneHeightFactor.asAbsolute() ||
-        lazy::groundPlaneHeightFactor.isRelative() != options::groundPlaneHeightFactor.isRelative()) {
-        lazy::groundPlaneHeightFactor = options::groundPlaneHeightFactor;
-        requestRedraw();
-    }
-    if (lazy::shadowBlurIters != options::shadowBlurIters) {
-        lazy::shadowBlurIters = options::shadowBlurIters;
-        requestRedraw();
-    }
-    if (lazy::shadowDarkness != options::shadowDarkness) {
-        lazy::shadowDarkness = options::shadowDarkness;
-        requestRedraw();
-    }
+    lazy::groundPlaneMode = options::groundPlaneMode;
+    render::engine->groundPlane.prepare();
+    requestRedraw();
+  }
+  if (lazy::groundPlaneHeightFactor.asAbsolute() != options::groundPlaneHeightFactor.asAbsolute() ||
+      lazy::groundPlaneHeightFactor.isRelative() != options::groundPlaneHeightFactor.isRelative()) {
+    lazy::groundPlaneHeightFactor = options::groundPlaneHeightFactor;
+    requestRedraw();
+  }
+  if (lazy::shadowBlurIters != options::shadowBlurIters) {
+    lazy::shadowBlurIters = options::shadowBlurIters;
+    requestRedraw();
+  }
+  if (lazy::shadowDarkness != options::shadowDarkness) {
+    lazy::shadowDarkness = options::shadowDarkness;
+    requestRedraw();
+  }
 };
 
 void updateStructureExtents() {
 
-    if (!options::automaticallyComputeSceneExtents) {
-        return;
+  if (!options::automaticallyComputeSceneExtents) {
+    return;
+  }
+
+  // Note: the cost multiple calls to this function scales only with the number of structures, not the size of the
+  // data in those structures, because structures internally cache the extents of their data.
+
+  // Compute length scale and bbox as the max of all structures
+  state::lengthScale = 0.0;
+  glm::vec3 minBbox = glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
+  glm::vec3 maxBbox = -glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
+
+  for (auto cat : state::structures) {
+    for (auto x : cat.second) {
+      state::lengthScale = std::max(state::lengthScale, x.second->lengthScale());
+      auto bbox = x.second->boundingBox();
+      minBbox = componentwiseMin(minBbox, std::get<0>(bbox));
+      maxBbox = componentwiseMax(maxBbox, std::get<1>(bbox));
     }
+  }
 
-    // Note: the cost multiple calls to this function scales only with the number of structures, not the size of the
-    // data in those structures, because structures internally cache the extents of their data.
+  // If we got a non-finite bounding box, fix it
+  if (!isFinite(minBbox) || !isFinite(maxBbox)) {
+    minBbox = -glm::vec3{1, 1, 1};
+    maxBbox = glm::vec3{1, 1, 1};
+  }
 
-    // Compute length scale and bbox as the max of all structures
-    state::lengthScale = 0.0;
-    glm::vec3 minBbox = glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
-    glm::vec3 maxBbox = -glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
+  // If we got a degenerate bounding box, perturb it slightly
+  if (minBbox == maxBbox) {
+    double offsetScale = (state::lengthScale == 0) ? 1e-5 : state::lengthScale * 1e-5;
+    glm::vec3 offset{offsetScale, offsetScale, offsetScale};
+    minBbox = minBbox - offset / 2.f;
+    maxBbox = maxBbox + offset / 2.f;
+  }
 
-    for (auto cat : state::structures) {
-        for (auto x : cat.second) {
-            state::lengthScale = std::max(state::lengthScale, x.second->lengthScale());
-            auto bbox = x.second->boundingBox();
-            minBbox = componentwiseMin(minBbox, std::get<0>(bbox));
-            maxBbox = componentwiseMax(maxBbox, std::get<1>(bbox));
-        }
-    }
+  std::get<0>(state::boundingBox) = minBbox;
+  std::get<1>(state::boundingBox) = maxBbox;
 
-    // If we got a non-finite bounding box, fix it
-    if (!isFinite(minBbox) || !isFinite(maxBbox)) {
-        minBbox = -glm::vec3{1, 1, 1};
-        maxBbox = glm::vec3{1, 1, 1};
-    }
+  // If we got a bounding box but not a length scale we can use the size of the
+  // box as a scale. If we got neither, we'll end up with a constant near 1 due
+  // to the above correction
+  if (state::lengthScale == 0) {
+    state::lengthScale = glm::length(maxBbox - minBbox);
+  }
 
-    // If we got a degenerate bounding box, perturb it slightly
-    if (minBbox == maxBbox) {
-        double offsetScale = (state::lengthScale == 0) ? 1e-5 : state::lengthScale * 1e-5;
-        glm::vec3 offset{offsetScale, offsetScale, offsetScale};
-        minBbox = minBbox - offset / 2.f;
-        maxBbox = maxBbox + offset / 2.f;
-    }
-
-    std::get<0>(state::boundingBox) = minBbox;
-    std::get<1>(state::boundingBox) = maxBbox;
-
-    // If we got a bounding box but not a length scale we can use the size of the
-    // box as a scale. If we got neither, we'll end up with a constant near 1 due
-    // to the above correction
-    if (state::lengthScale == 0) {
-        state::lengthScale = glm::length(maxBbox - minBbox);
-    }
-
-    requestRedraw();
+  requestRedraw();
 }
 
 namespace state {
-    glm::vec3 center() {
-        return 0.5f * (std::get<0>(state::boundingBox) + std::get<1>(state::boundingBox));
-    }
+glm::vec3 center() { return 0.5f * (std::get<0>(state::boundingBox) + std::get<1>(state::boundingBox)); }
 } // namespace state
 
 } // namespace polyscope

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -25,474 +25,481 @@ namespace polyscope {
 // Helpers
 namespace {
 
-// === Implement the context stack
+    // === Implement the context stack
 
-// The context stack should _always_ have at least one context in it. The lowest context is the one created at
-// initialization.
-struct ContextEntry {
-  ImGuiContext* context;
-  std::function<void()> callback;
-  bool drawDefaultUI;
-};
-std::vector<ContextEntry> contextStack;
+    // The context stack should _always_ have at least one context in it. The lowest context is the one created at
+    // initialization.
+    struct ContextEntry {
+        ImGuiContext* context;
+        std::function<void()> callback;
+        bool drawDefaultUI;
+    };
+    std::vector<ContextEntry> contextStack;
 
-bool redrawNextFrame = true;
+    bool redrawNextFrame = true;
 
-// Some state about imgui windows to stack them
-float imguiStackMargin = 10;
-float lastWindowHeightPolyscope = 200;
-float lastWindowHeightUser = 200;
-float leftWindowsWidth = 305;
-float rightWindowsWidth = 500;
+    // Some state about imgui windows to stack them
+    float imguiStackMargin = 10;
+    float lastWindowHeightPolyscope = 200;
+    float lastWindowHeightUser = 200;
+    float leftWindowsWidth = 305;
+    float rightWindowsWidth = 500;
 
 
-const std::string prefsFilename = ".polyscope.ini";
+    const std::string prefsFilename = ".polyscope.ini";
 
-void readPrefsFile() {
+    void readPrefsFile() {
 
-  try {
+        try {
 
-    std::ifstream inStream(prefsFilename);
-    if (inStream) {
+            std::ifstream inStream(prefsFilename);
+            if (inStream) {
 
-      json prefsJSON;
-      inStream >> prefsJSON;
+                json prefsJSON;
+                inStream >> prefsJSON;
 
-      // Set values
-      // Do some basic validation on the sizes first to work around bugs with bogus values getting written to init file
-      if (prefsJSON.count("windowWidth") > 0) {
-        int val = prefsJSON["windowWidth"];
-        if (val >= 64 && val < 10000) view::windowWidth = val;
-      }
-      if (prefsJSON.count("windowHeight") > 0) {
-        int val = prefsJSON["windowHeight"];
-        if (val >= 64 && val < 10000) view::windowHeight = val;
-      }
-      if (prefsJSON.count("windowPosX") > 0) {
-        int val = prefsJSON["windowPosX"];
-        if (val >= 0 && val < 10000) view::initWindowPosX = val;
-      }
-      if (prefsJSON.count("windowPosY") > 0) {
-        int val = prefsJSON["windowPosY"];
-        if (val >= 0 && val < 10000) view::initWindowPosY = val;
-      }
+                // Set values
+                // Do some basic validation on the sizes first to work around bugs with bogus values getting written to
+                // init file
+                if (prefsJSON.count("windowWidth") > 0) {
+                    int val = prefsJSON["windowWidth"];
+                    if (val >= 64 && val < 10000) view::windowWidth = val;
+                }
+                if (prefsJSON.count("windowHeight") > 0) {
+                    int val = prefsJSON["windowHeight"];
+                    if (val >= 64 && val < 10000) view::windowHeight = val;
+                }
+                if (prefsJSON.count("windowPosX") > 0) {
+                    int val = prefsJSON["windowPosX"];
+                    if (val >= 0 && val < 10000) view::initWindowPosX = val;
+                }
+                if (prefsJSON.count("windowPosY") > 0) {
+                    int val = prefsJSON["windowPosY"];
+                    if (val >= 0 && val < 10000) view::initWindowPosY = val;
+                }
+            }
+
+        }
+        // We never really care if something goes wrong while loading preferences, so eat all exceptions
+        catch (...) {
+            polyscope::warning("Parsing of prefs file failed");
+        }
     }
 
-  }
-  // We never really care if something goes wrong while loading preferences, so eat all exceptions
-  catch (...) {
-    polyscope::warning("Parsing of prefs file failed");
-  }
-}
+    void writePrefsFile() {
 
-void writePrefsFile() {
+        // Update values as needed
+        int posX, posY;
+        std::tie(posX, posY) = render::engine->getWindowPos();
+        int windowWidth = view::windowWidth;
+        int windowHeight = view::windowHeight;
 
-  // Update values as needed
-  int posX, posY;
-  std::tie(posX, posY) = render::engine->getWindowPos();
-  int windowWidth = view::windowWidth;
-  int windowHeight = view::windowHeight;
+        // Validate values. Don't write the prefs file if any of these values are obviously bogus (this seems to happen
+        // at least on Windows when the application is minimzed)
+        bool valuesValid = true;
+        valuesValid &= posX >= 0 && posX < 10000;
+        valuesValid &= posY >= 0 && posY < 10000;
+        valuesValid &= windowWidth >= 64 && windowWidth < 10000;
+        valuesValid &= windowHeight >= 64 && windowHeight < 10000;
+        if (!valuesValid) return;
 
-  // Validate values. Don't write the prefs file if any of these values are obviously bogus (this seems to happen at
-  // least on Windows when the application is minimzed)
-  bool valuesValid = true;
-  valuesValid &= posX >= 0 && posX < 10000;
-  valuesValid &= posY >= 0 && posY < 10000;
-  valuesValid &= windowWidth >= 64 && windowWidth < 10000;
-  valuesValid &= windowHeight >= 64 && windowHeight < 10000;
-  if (!valuesValid) return;
+        // Build json object
+        json prefsJSON = {
+            {"windowWidth", windowWidth},
+            {"windowHeight", windowHeight},
+            {"windowPosX", posX},
+            {"windowPosY", posY},
+        };
 
-  // Build json object
-  json prefsJSON = {
-      {"windowWidth", windowWidth},
-      {"windowHeight", windowHeight},
-      {"windowPosX", posX},
-      {"windowPosY", posY},
-  };
-
-  // Write out json object
-  std::ofstream o(prefsFilename);
-  o << std::setw(4) << prefsJSON << std::endl;
-}
+        // Write out json object
+        std::ofstream o(prefsFilename);
+        o << std::setw(4) << prefsJSON << std::endl;
+    }
 
 }; // namespace
 
 // === Core global functions
 
 void init(std::string backend) {
-  if (state::initialized) {
-    if (backend != state::backend) {
-      throw std::runtime_error("re-initializing with different backend is not supported");
+    if (state::initialized) {
+        if (backend != state::backend) {
+            throw std::runtime_error("re-initializing with different backend is not supported");
+        }
+        // otherwise silently allow multiple-init
+        return;
     }
-    // otherwise silently allow multiple-init
-    return;
-  }
 
-  state::backend = backend;
+    state::backend = backend;
 
-  if (options::usePrefsFile) {
-    readPrefsFile();
-  }
+    if (options::usePrefsFile) {
+        readPrefsFile();
+    }
 
-  // Initialize the rendering engine
-  render::initializeRenderEngine(backend);
+    // Initialize the rendering engine
+    render::initializeRenderEngine(backend);
 
-  // Initialie ImGUI
-  IMGUI_CHECKVERSION();
-  render::engine->initializeImGui();
-  // push a fake context which will never be used (but dodges some invalidation issues)
-  contextStack.push_back(ContextEntry{ImGui::GetCurrentContext(), nullptr, false});
+    // Initialie ImGUI
+    IMGUI_CHECKVERSION();
+    render::engine->initializeImGui();
+    // push a fake context which will never be used (but dodges some invalidation issues)
+    contextStack.push_back(ContextEntry{ImGui::GetCurrentContext(), nullptr, false});
 
-  view::invalidateView();
+    view::invalidateView();
 
-  state::initialized = true;
-  state::doDefaultMouseInteraction = true;
+    state::initialized = true;
+    state::doDefaultMouseInteraction = true;
 }
 
 void pushContext(std::function<void()> callbackFunction, bool drawDefaultUI) {
 
-  // Create a new context and push it on to the stack
-  ImGuiContext* newContext = ImGui::CreateContext(render::engine->getImGuiGlobalFontAtlas());
-  ImGuiIO& oldIO = ImGui::GetIO(); // used to copy below, see note
-  ImGui::SetCurrentContext(newContext);
+    // Create a new context and push it on to the stack
+    ImGuiContext* newContext = ImGui::CreateContext(render::engine->getImGuiGlobalFontAtlas());
+    ImGuiIO& oldIO = ImGui::GetIO(); // used to copy below, see note
+    ImGui::SetCurrentContext(newContext);
 
-  if (options::configureImGuiStyleCallback) {
-    options::configureImGuiStyleCallback();
-  }
-
-  ImGui::GetIO() = oldIO; // Copy all of the old IO values to new. With ImGUI 1.76 (and some previous versions), this
-                          // was necessary to fix a bug where keys like delete, etc would break in subcontexts. The
-                          // problem was that the key mappings (e.g. GLFW_KEY_BACKSPACE --> ImGuiKey_Backspace) need to
-                          // be populated in io.KeyMap, and these entries would get lost on creating a new context.
-  contextStack.push_back(ContextEntry{newContext, callbackFunction, drawDefaultUI});
-
-  if (contextStack.size() > 50) {
-    // Catch bugs with nested show()
-    throw std::runtime_error(
-        "Uh oh, polyscope::show() was recusively MANY times (depth > 50), this is probably a bug. Perhaps "
-        "you are accidentally calling show every time polyscope::userCallback executes?");
-  };
-
-  // Make sure the window is visible
-  render::engine->showWindow();
-
-  // Re-enter main loop until the context has been popped
-  size_t currentContextStackSize = contextStack.size();
-  while (contextStack.size() >= currentContextStackSize) {
-
-    mainLoopIteration();
-
-    // auto-exit if the window is closed
-    if (render::engine->windowRequestsClose()) {
-      popContext();
+    if (options::configureImGuiStyleCallback) {
+        options::configureImGuiStyleCallback();
     }
-  }
 
-  oldIO = ImGui::GetIO(); // Copy new IO values to old. I haven't encountered anything that strictly requires this, but
-                          // it feels like we should mirror the behavior from pushing.
+    ImGui::GetIO() = oldIO; // Copy all of the old IO values to new. With ImGUI 1.76 (and some previous versions), this
+                            // was necessary to fix a bug where keys like delete, etc would break in subcontexts. The
+                            // problem was that the key mappings (e.g. GLFW_KEY_BACKSPACE --> ImGuiKey_Backspace) need
+                            // to be populated in io.KeyMap, and these entries would get lost on creating a new context.
+    contextStack.push_back(ContextEntry{newContext, callbackFunction, drawDefaultUI});
 
-  ImGui::DestroyContext(newContext);
+    if (contextStack.size() > 50) {
+        // Catch bugs with nested show()
+        throw std::runtime_error(
+            "Uh oh, polyscope::show() was recusively MANY times (depth > 50), this is probably a bug. Perhaps "
+            "you are accidentally calling show every time polyscope::userCallback executes?");
+    };
 
-  // Restore the previous context, if there was one
-  if (!contextStack.empty()) {
-    ImGui::SetCurrentContext(contextStack.back().context);
-  }
+    // Make sure the window is visible
+    render::engine->showWindow();
+
+    // Re-enter main loop until the context has been popped
+    size_t currentContextStackSize = contextStack.size();
+    while (contextStack.size() >= currentContextStackSize) {
+
+        mainLoopIteration();
+
+        // auto-exit if the window is closed
+        if (render::engine->windowRequestsClose()) {
+            popContext();
+        }
+    }
+
+    oldIO = ImGui::GetIO(); // Copy new IO values to old. I haven't encountered anything that strictly requires this,
+                            // but it feels like we should mirror the behavior from pushing.
+
+    ImGui::DestroyContext(newContext);
+
+    // Restore the previous context, if there was one
+    if (!contextStack.empty()) {
+        ImGui::SetCurrentContext(contextStack.back().context);
+    }
 }
 
 
 void popContext() {
-  if (contextStack.empty()) {
-    error("Called popContext() too many times");
-    return;
-  }
-  contextStack.pop_back();
+    if (contextStack.empty()) {
+        error("Called popContext() too many times");
+        return;
+    }
+    contextStack.pop_back();
 }
 
-void requestRedraw() { redrawNextFrame = true; }
-bool redrawRequested() { return redrawNextFrame; }
+void requestRedraw() {
+    redrawNextFrame = true;
+}
+bool redrawRequested() {
+    return redrawNextFrame;
+}
 
 void drawStructures() {
 
-  // Draw all off the structures registered with polyscope
+    // Draw all off the structures registered with polyscope
 
-  for (auto catMap : state::structures) {
-    for (auto s : catMap.second) {
-      // make sure the right settings are active
-      // render::engine->setDepthMode();
-      // render::engine->applyTransparencySettings();
+    for (auto catMap : state::structures) {
+        for (auto s : catMap.second) {
+            // make sure the right settings are active
+            // render::engine->setDepthMode();
+            // render::engine->applyTransparencySettings();
 
-      s.second->draw();
+            s.second->draw();
+        }
     }
-  }
 
-  // Also render any slice plane geometry
-  for (SlicePlane* s : state::slicePlanes) {
-    s->drawGeometry();
-  }
+    // Also render any slice plane geometry
+    for (SlicePlane* s : state::slicePlanes) {
+        s->drawGeometry();
+    }
 }
 
 namespace {
 
-float dragDistSinceLastRelease = 0.0;
+    float dragDistSinceLastRelease = 0.0;
 
-void processInputEvents() {
-  ImGuiIO& io = ImGui::GetIO();
+    void processInputEvents() {
+        ImGuiIO& io = ImGui::GetIO();
 
-  // If any mouse button is pressed, trigger a redraw
-  if (ImGui::IsAnyMouseDown()) {
-    requestRedraw();
-  }
-
-  bool widgetCapturedMouse = false;
-  for (Widget* w : state::widgets) {
-    widgetCapturedMouse = w->interact();
-    if (widgetCapturedMouse) {
-      break;
-    }
-  }
-
-  // Handle scroll events for 3D view
-  if (state::doDefaultMouseInteraction) {
-    if (!io.WantCaptureMouse && !widgetCapturedMouse) {
-      double xoffset = io.MouseWheelH;
-      double yoffset = io.MouseWheel;
-
-      if (xoffset != 0 || yoffset != 0) {
-        requestRedraw();
-
-        // On some setups, shift flips the scroll direction, so take the max
-        // scrolling in any direction
-        double maxScroll = xoffset;
-        if (std::abs(yoffset) > std::abs(xoffset)) {
-          maxScroll = yoffset;
+        // If any mouse button is pressed, trigger a redraw
+        if (ImGui::IsAnyMouseDown()) {
+            requestRedraw();
         }
 
-        // Pass camera commands to the camera
-        if (maxScroll != 0.0) {
-          bool scrollClipPlane = io.KeyShift;
-
-          if (scrollClipPlane) {
-            view::processClipPlaneShift(maxScroll);
-          } else {
-            view::processZoom(maxScroll);
-          }
-        }
-      }
-    }
-
-    // === Mouse inputs
-    if (!io.WantCaptureMouse && !widgetCapturedMouse) {
-
-      // Process drags
-      bool dragLeft = ImGui::IsMouseDragging(0);
-      bool dragRight = !dragLeft && ImGui::IsMouseDragging(1); // left takes priority, so only one can be true
-      if (dragLeft || dragRight) {
-
-        glm::vec2 dragDelta{io.MouseDelta.x / view::windowWidth, -io.MouseDelta.y / view::windowHeight};
-        dragDistSinceLastRelease += std::abs(dragDelta.x);
-        dragDistSinceLastRelease += std::abs(dragDelta.y);
-
-        // exactly one of these will be true
-        bool isRotate = dragLeft && !io.KeyShift && !io.KeyCtrl;
-        bool isTranslate = (dragLeft && io.KeyShift && !io.KeyCtrl) || dragRight;
-        bool isDragZoom = dragLeft && io.KeyShift && io.KeyCtrl;
-
-        if (isDragZoom) {
-          view::processZoom(dragDelta.y * 5);
-        }
-        if (isRotate) {
-          glm::vec2 currPos{io.MousePos.x / view::windowWidth,
-                            (view::windowHeight - io.MousePos.y) / view::windowHeight};
-          currPos = (currPos * 2.0f) - glm::vec2{1.0, 1.0};
-          if (std::abs(currPos.x) <= 1.0 && std::abs(currPos.y) <= 1.0) {
-            view::processRotate(currPos - 2.0f * dragDelta, currPos);
-          }
-        }
-        if (isTranslate) {
-          view::processTranslate(dragDelta);
-        }
-      }
-
-      // Click picks
-      float dragIgnoreThreshold = 0.01;
-      if (ImGui::IsMouseReleased(0)) {
-
-        // Don't pick at the end of a long drag
-        if (dragDistSinceLastRelease < dragIgnoreThreshold) {
-          ImVec2 p = ImGui::GetMousePos();
-          std::pair<Structure*, size_t> pickResult =
-              pick::evaluatePickQuery(io.DisplayFramebufferScale.x * p.x, io.DisplayFramebufferScale.y * p.y);
-          pick::setSelection(pickResult);
+        bool widgetCapturedMouse = false;
+        for (Widget* w : state::widgets) {
+            widgetCapturedMouse = w->interact();
+            if (widgetCapturedMouse) {
+                break;
+            }
         }
 
-        // Reset the drag distance after any release
-        dragDistSinceLastRelease = 0.0;
-      }
-      // Clear pick
-      if (ImGui::IsMouseReleased(1)) {
-        if (dragDistSinceLastRelease < dragIgnoreThreshold) {
-          pick::resetSelection();
+        // Handle scroll events for 3D view
+        if (state::doDefaultMouseInteraction) {
+            if (!io.WantCaptureMouse && !widgetCapturedMouse) {
+                double xoffset = io.MouseWheelH;
+                double yoffset = io.MouseWheel;
+
+                if (xoffset != 0 || yoffset != 0) {
+                    requestRedraw();
+
+                    // On some setups, shift flips the scroll direction, so take the max
+                    // scrolling in any direction
+                    double maxScroll = xoffset;
+                    if (std::abs(yoffset) > std::abs(xoffset)) {
+                        maxScroll = yoffset;
+                    }
+
+                    // Pass camera commands to the camera
+                    if (maxScroll != 0.0) {
+                        bool scrollClipPlane = io.KeyShift;
+
+                        if (scrollClipPlane) {
+                            view::processClipPlaneShift(maxScroll);
+                        } else {
+                            view::processZoom(maxScroll);
+                        }
+                    }
+                }
+            }
+
+            // === Mouse inputs
+            if (!io.WantCaptureMouse && !widgetCapturedMouse) {
+
+                // Process drags
+                bool dragLeft = ImGui::IsMouseDragging(0);
+                bool dragRight = !dragLeft && ImGui::IsMouseDragging(1); // left takes priority, so only one can be true
+                if (dragLeft || dragRight) {
+
+                    glm::vec2 dragDelta{io.MouseDelta.x / view::windowWidth, -io.MouseDelta.y / view::windowHeight};
+                    dragDistSinceLastRelease += std::abs(dragDelta.x);
+                    dragDistSinceLastRelease += std::abs(dragDelta.y);
+
+                    // exactly one of these will be true
+                    bool isRotate = dragLeft && !io.KeyShift && !io.KeyCtrl;
+                    bool isTranslate = (dragLeft && io.KeyShift && !io.KeyCtrl) || dragRight;
+                    bool isDragZoom = dragLeft && io.KeyShift && io.KeyCtrl;
+
+                    if (isDragZoom) {
+                        view::processZoom(dragDelta.y * 5);
+                    }
+                    if (isRotate) {
+                        glm::vec2 currPos{io.MousePos.x / view::windowWidth,
+                                          (view::windowHeight - io.MousePos.y) / view::windowHeight};
+                        currPos = (currPos * 2.0f) - glm::vec2{1.0, 1.0};
+                        if (std::abs(currPos.x) <= 1.0 && std::abs(currPos.y) <= 1.0) {
+                            view::processRotate(currPos - 2.0f * dragDelta, currPos);
+                        }
+                    }
+                    if (isTranslate) {
+                        view::processTranslate(dragDelta);
+                    }
+                }
+
+                // Click picks
+                float dragIgnoreThreshold = 0.01;
+                if (ImGui::IsMouseReleased(0)) {
+
+                    // Don't pick at the end of a long drag
+                    if (dragDistSinceLastRelease < dragIgnoreThreshold) {
+                        ImVec2 p = ImGui::GetMousePos();
+                        std::pair<Structure*, size_t> pickResult = pick::evaluatePickQuery(
+                            io.DisplayFramebufferScale.x * p.x, io.DisplayFramebufferScale.y * p.y);
+                        pick::setSelection(pickResult);
+                    }
+
+                    // Reset the drag distance after any release
+                    dragDistSinceLastRelease = 0.0;
+                }
+                // Clear pick
+                if (ImGui::IsMouseReleased(1)) {
+                    if (dragDistSinceLastRelease < dragIgnoreThreshold) {
+                        pick::resetSelection();
+                    }
+                    dragDistSinceLastRelease = 0.0;
+                }
+            }
         }
-        dragDistSinceLastRelease = 0.0;
-      }
-    }
-  }
 
-  // === Key-press inputs
-  if (!io.WantCaptureKeyboard) {
+        // === Key-press inputs
+        if (!io.WantCaptureKeyboard) {
 
-    // ctrl-c
-    if (io.KeyCtrl && render::engine->isKeyPressed('c')) {
-      std::string outData = view::getCameraJson();
-      render::engine->setClipboardText(outData);
-    }
+            // ctrl-c
+            if (io.KeyCtrl && render::engine->isKeyPressed('c')) {
+                std::string outData = view::getCameraJson();
+                render::engine->setClipboardText(outData);
+            }
 
-    // ctrl-v
-    if (io.KeyCtrl && render::engine->isKeyPressed('v')) {
-      std::string clipboardData = render::engine->getClipboardText();
-      view::setCameraFromJson(clipboardData, true);
-    }
-  }
-}
-
-
-void renderSlicePlanes() {
-  for (SlicePlane* s : state::slicePlanes) {
-    s->draw();
-  }
-}
-
-void renderScene() {
-  processLazyProperties();
-
-  render::engine->applyTransparencySettings();
-
-  render::engine->sceneBuffer->clearColor = {0., 0., 0.};
-  render::engine->sceneBuffer->clearAlpha = 0.;
-  render::engine->sceneBuffer->clear();
-
-  if (!render::engine->bindSceneBuffer()) return;
-
-  // If a view has never been set, this will set it to the home view
-  view::ensureViewValid();
-
-  if (render::engine->getTransparencyMode() == TransparencyMode::Pretty) {
-    // Special depth peeling case: multiple render passes
-    // We will perform several "peeled" rounds of rendering in to the usual scene buffer. After each, we will manually
-    // composite in to the final scene buffer.
-
-
-    // Clear the final buffer explicitly since we will gradually composite in to it rather than just blitting directly
-    // as in normal rendering.
-    render::engine->sceneBufferFinal->clearColor = glm::vec3{0., 0., 0.};
-    render::engine->sceneBufferFinal->clearAlpha = 0;
-    render::engine->sceneBufferFinal->clear();
-
-    render::engine->setDepthMode(); // we need depth to be enabled for the clear below to do anything
-    render::engine->sceneDepthMinFrame->clear();
-
-
-    for (int iPass = 0; iPass < options::transparencyRenderPasses; iPass++) {
-
-      render::engine->bindSceneBuffer();
-      render::engine->clearSceneBuffer();
-
-      render::engine->applyTransparencySettings();
-      drawStructures();
-
-      // Draw ground plane, slicers, etc
-      bool isRedraw = iPass > 0;
-      render::engine->groundPlane.draw(isRedraw);
-      if (!isRedraw) {
-        // Only on first pass (kinda weird, but works out, and doesn't really matter)
-        renderSlicePlanes();
-      }
-
-      // Composite the result of this pass in to the result buffer
-      render::engine->sceneBufferFinal->bind();
-      render::engine->setDepthMode(DepthMode::Disable);
-      render::engine->setBlendMode(BlendMode::Under);
-      render::engine->compositePeel->draw();
-
-      // Update the minimum depth texture
-      render::engine->updateMinDepthTexture();
+            // ctrl-v
+            if (io.KeyCtrl && render::engine->isKeyPressed('v')) {
+                std::string clipboardData = render::engine->getClipboardText();
+                view::setCameraFromJson(clipboardData, true);
+            }
+        }
     }
 
 
-  } else {
-    // Normal case: single render pass
-    render::engine->applyTransparencySettings();
+    void renderSlicePlanes() {
+        for (SlicePlane* s : state::slicePlanes) {
+            s->draw();
+        }
+    }
 
-    drawStructures();
+    void renderScene() {
+        processLazyProperties();
 
-    render::engine->groundPlane.draw();
-    renderSlicePlanes();
+        render::engine->applyTransparencySettings();
 
-    render::engine->sceneBuffer->blitTo(render::engine->sceneBufferFinal.get());
-  }
-} // namespace
+        render::engine->sceneBuffer->clearColor = {0., 0., 0.};
+        render::engine->sceneBuffer->clearAlpha = 0.;
+        render::engine->sceneBuffer->clear();
 
-void renderSceneToScreen() {
-  render::engine->bindDisplay();
-  if (options::debugDrawPickBuffer) {
-    // special debug draw
-    pick::evaluatePickQuery(-1, -1); // populate the buffer
-    render::engine->pickFramebuffer->blitTo(render::engine->displayBuffer.get());
-  } else {
-    render::engine->applyLightingTransform(render::engine->sceneColorFinal);
-  }
-}
+        if (!render::engine->bindSceneBuffer()) return;
 
-auto lastMainLoopIterTime = std::chrono::steady_clock::now();
+        // If a view has never been set, this will set it to the home view
+        view::ensureViewValid();
+
+        if (render::engine->getTransparencyMode() == TransparencyMode::Pretty) {
+            // Special depth peeling case: multiple render passes
+            // We will perform several "peeled" rounds of rendering in to the usual scene buffer. After each, we will
+            // manually composite in to the final scene buffer.
+
+
+            // Clear the final buffer explicitly since we will gradually composite in to it rather than just blitting
+            // directly as in normal rendering.
+            render::engine->sceneBufferFinal->clearColor = glm::vec3{0., 0., 0.};
+            render::engine->sceneBufferFinal->clearAlpha = 0;
+            render::engine->sceneBufferFinal->clear();
+
+            render::engine->setDepthMode(); // we need depth to be enabled for the clear below to do anything
+            render::engine->sceneDepthMinFrame->clear();
+
+
+            for (int iPass = 0; iPass < options::transparencyRenderPasses; iPass++) {
+
+                render::engine->bindSceneBuffer();
+                render::engine->clearSceneBuffer();
+
+                render::engine->applyTransparencySettings();
+                drawStructures();
+
+                // Draw ground plane, slicers, etc
+                bool isRedraw = iPass > 0;
+                render::engine->groundPlane.draw(isRedraw);
+                if (!isRedraw) {
+                    // Only on first pass (kinda weird, but works out, and doesn't really matter)
+                    renderSlicePlanes();
+                }
+
+                // Composite the result of this pass in to the result buffer
+                render::engine->sceneBufferFinal->bind();
+                render::engine->setDepthMode(DepthMode::Disable);
+                render::engine->setBlendMode(BlendMode::Under);
+                render::engine->compositePeel->draw();
+
+                // Update the minimum depth texture
+                render::engine->updateMinDepthTexture();
+            }
+
+
+        } else {
+            // Normal case: single render pass
+            render::engine->applyTransparencySettings();
+
+            drawStructures();
+
+            render::engine->groundPlane.draw();
+            renderSlicePlanes();
+
+            render::engine->sceneBuffer->blitTo(render::engine->sceneBufferFinal.get());
+        }
+    } // namespace
+
+    void renderSceneToScreen() {
+        render::engine->bindDisplay();
+        if (options::debugDrawPickBuffer) {
+            // special debug draw
+            pick::evaluatePickQuery(-1, -1); // populate the buffer
+            render::engine->pickFramebuffer->blitTo(render::engine->displayBuffer.get());
+        } else {
+            render::engine->applyLightingTransform(render::engine->sceneColorFinal);
+        }
+    }
+
+    auto lastMainLoopIterTime = std::chrono::steady_clock::now();
 
 } // namespace
 
 void buildPolyscopeGui() {
 
-  // Create window
-  static bool showPolyscopeWindow = true;
-  ImGui::SetNextWindowPos(ImVec2(imguiStackMargin, imguiStackMargin));
-  ImGui::SetNextWindowSize(ImVec2(leftWindowsWidth, 0.));
+    // Create window
+    static bool showPolyscopeWindow = true;
+    ImGui::SetNextWindowPos(ImVec2(imguiStackMargin, imguiStackMargin));
+    ImGui::SetNextWindowSize(ImVec2(leftWindowsWidth, 0.));
 
-  ImGui::Begin("Polyscope", &showPolyscopeWindow);
+    ImGui::Begin("Polyscope", &showPolyscopeWindow);
 
-  if (ImGui::Button("Reset View")) {
-    view::flyToHomeView();
-  }
-  ImGui::SameLine();
-  ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(1.0f, 0.0f));
-  if (ImGui::Button("Screenshot")) {
-    screenshot(options::screenshotTransparency);
-  }
-  ImGui::SameLine();
-  if (ImGui::ArrowButton("##Option", ImGuiDir_Down)) {
-    ImGui::OpenPopup("ScreenshotOptionsPopup");
-  }
-  ImGui::PopStyleVar();
-  if (ImGui::BeginPopup("ScreenshotOptionsPopup")) {
+    if (ImGui::Button("Reset View")) {
+        view::flyToHomeView();
+    }
+    ImGui::SameLine();
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing, ImVec2(1.0f, 0.0f));
+    if (ImGui::Button("Screenshot")) {
+        screenshot(options::screenshotTransparency);
+    }
+    ImGui::SameLine();
+    if (ImGui::ArrowButton("##Option", ImGuiDir_Down)) {
+        ImGui::OpenPopup("ScreenshotOptionsPopup");
+    }
+    ImGui::PopStyleVar();
+    if (ImGui::BeginPopup("ScreenshotOptionsPopup")) {
 
-    ImGui::Checkbox("with transparency", &options::screenshotTransparency);
+        ImGui::Checkbox("with transparency", &options::screenshotTransparency);
 
-    if (ImGui::BeginMenu("file format")) {
-      if (ImGui::MenuItem(".png", NULL, options::screenshotExtension == ".png")) options::screenshotExtension = ".png";
-      if (ImGui::MenuItem(".jpg", NULL, options::screenshotExtension == ".jpg")) options::screenshotExtension = ".jpg";
-      ImGui::EndMenu();
+        if (ImGui::BeginMenu("file format")) {
+            if (ImGui::MenuItem(".png", NULL, options::screenshotExtension == ".png"))
+                options::screenshotExtension = ".png";
+            if (ImGui::MenuItem(".jpg", NULL, options::screenshotExtension == ".jpg"))
+                options::screenshotExtension = ".jpg";
+            ImGui::EndMenu();
+        }
+
+        ImGui::EndPopup();
     }
 
-    ImGui::EndPopup();
-  }
 
+    ImGui::SameLine();
+    if (ImGui::Button("Controls")) {
+        // do nothing, just want hover state
+    }
+    if (ImGui::IsItemHovered()) {
 
-  ImGui::SameLine();
-  if (ImGui::Button("Controls")) {
-    // do nothing, just want hover state
-  }
-  if (ImGui::IsItemHovered()) {
+        ImGui::SetNextWindowPos(ImVec2(2 * imguiStackMargin + leftWindowsWidth, imguiStackMargin));
+        ImGui::SetNextWindowSize(ImVec2(0., 0.));
 
-    ImGui::SetNextWindowPos(ImVec2(2 * imguiStackMargin + leftWindowsWidth, imguiStackMargin));
-    ImGui::SetNextWindowSize(ImVec2(0., 0.));
-
-    // clang-format off
+        // clang-format off
 		ImGui::Begin("Controls", NULL, ImGuiWindowFlags_NoTitleBar);
 		ImGui::TextUnformatted("View Navigation:");			
 			ImGui::TextUnformatted("      Rotate: [left click drag]");
@@ -510,578 +517,585 @@ void buildPolyscopeGui() {
 			ImGui::TextUnformatted("     that element will be shown on the right. Use [right click]");
 			ImGui::TextUnformatted("     to clear the selection.");
 		ImGui::End();
-    // clang-format on
-  }
-
-  // View options tree
-  view::buildViewGui();
-
-  // Appearance options tree
-  render::engine->buildEngineGui();
-
-  // Debug options tree
-  ImGui::SetNextTreeNodeOpen(false, ImGuiCond_FirstUseEver);
-  if (ImGui::TreeNode("Debug")) {
-    if (ImGui::Button("Force refresh")) {
-      refresh();
+        // clang-format on
     }
-    ImGui::Checkbox("Show pick buffer", &options::debugDrawPickBuffer);
-    ImGui::Checkbox("Always redraw", &options::alwaysRedraw);
 
-    static bool showDebugTextures = false;
-    ImGui::Checkbox("Show debug textures", &showDebugTextures);
-    if (showDebugTextures) {
-      render::engine->showTextureInImGuiWindow("Scene", render::engine->sceneColor.get());
-      render::engine->showTextureInImGuiWindow("Scene Final", render::engine->sceneColorFinal.get());
+    // View options tree
+    view::buildViewGui();
+
+    // Appearance options tree
+    render::engine->buildEngineGui();
+
+    // Debug options tree
+    ImGui::SetNextTreeNodeOpen(false, ImGuiCond_FirstUseEver);
+    if (ImGui::TreeNode("Debug")) {
+        if (ImGui::Button("Force refresh")) {
+            refresh();
+        }
+        ImGui::Checkbox("Show pick buffer", &options::debugDrawPickBuffer);
+        ImGui::Checkbox("Always redraw", &options::alwaysRedraw);
+
+        static bool showDebugTextures = false;
+        ImGui::Checkbox("Show debug textures", &showDebugTextures);
+        if (showDebugTextures) {
+            render::engine->showTextureInImGuiWindow("Scene", render::engine->sceneColor.get());
+            render::engine->showTextureInImGuiWindow("Scene Final", render::engine->sceneColorFinal.get());
+        }
+        ImGui::TreePop();
     }
-    ImGui::TreePop();
-  }
 
-  // fps
-  ImGui::Text("%.1f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
+    // fps
+    ImGui::Text("%.1f ms/frame (%.1f FPS)", 1000.0f / ImGui::GetIO().Framerate, ImGui::GetIO().Framerate);
 
-  lastWindowHeightPolyscope = imguiStackMargin + ImGui::GetWindowHeight();
-  leftWindowsWidth = ImGui::GetWindowWidth();
+    lastWindowHeightPolyscope = imguiStackMargin + ImGui::GetWindowHeight();
+    leftWindowsWidth = ImGui::GetWindowWidth();
 
-  ImGui::End();
+    ImGui::End();
 }
 
 void buildStructureGui() {
-  // Create window
-  static bool showStructureWindow = true;
+    // Create window
+    static bool showStructureWindow = true;
 
-  ImGui::SetNextWindowPos(ImVec2(imguiStackMargin, lastWindowHeightPolyscope + 2 * imguiStackMargin));
-  ImGui::SetNextWindowSize(
-      ImVec2(leftWindowsWidth, view::windowHeight - lastWindowHeightPolyscope - 3 * imguiStackMargin));
+    ImGui::SetNextWindowPos(ImVec2(imguiStackMargin, lastWindowHeightPolyscope + 2 * imguiStackMargin));
+    ImGui::SetNextWindowSize(
+        ImVec2(leftWindowsWidth, view::windowHeight - lastWindowHeightPolyscope - 3 * imguiStackMargin));
 
-  ImGui::Begin("Structures", &showStructureWindow);
+    ImGui::Begin("Structures", &showStructureWindow);
 
-  for (auto catMapEntry : state::structures) {
-    std::string catName = catMapEntry.first;
+    for (auto catMapEntry : state::structures) {
+        std::string catName = catMapEntry.first;
 
-    std::map<std::string, Structure*>& structureMap = catMapEntry.second;
+        std::map<std::string, Structure*>& structureMap = catMapEntry.second;
 
-    ImGui::PushID(catName.c_str()); // ensure there are no conflicts with
-                                    // identically-named labels
+        ImGui::PushID(catName.c_str()); // ensure there are no conflicts with
+                                        // identically-named labels
 
-    // Build the structure's UI
-    ImGui::SetNextTreeNodeOpen(structureMap.size() > 0, ImGuiCond_FirstUseEver);
-    if (ImGui::CollapsingHeader((catName + " (" + std::to_string(structureMap.size()) + ")").c_str())) {
-      // Draw shared GUI elements for all instances of the structure
-      if (structureMap.size() > 0) {
-        structureMap.begin()->second->buildSharedStructureUI();
-      }
+        // Build the structure's UI
+        ImGui::SetNextTreeNodeOpen(structureMap.size() > 0, ImGuiCond_FirstUseEver);
+        if (ImGui::CollapsingHeader((catName + " (" + std::to_string(structureMap.size()) + ")").c_str())) {
+            // Draw shared GUI elements for all instances of the structure
+            if (structureMap.size() > 0) {
+                structureMap.begin()->second->buildSharedStructureUI();
+            }
 
-      for (auto x : structureMap) {
-        ImGui::SetNextTreeNodeOpen(structureMap.size() <= 8,
-                                   ImGuiCond_FirstUseEver); // closed by default if more than 8
-        x.second->buildUI();
-      }
+            for (auto x : structureMap) {
+                ImGui::SetNextTreeNodeOpen(structureMap.size() <= 8,
+                                           ImGuiCond_FirstUseEver); // closed by default if more than 8
+                x.second->buildUI();
+            }
+        }
+
+        ImGui::PopID();
     }
 
-    ImGui::PopID();
-  }
+    leftWindowsWidth = ImGui::GetWindowWidth();
 
-  leftWindowsWidth = ImGui::GetWindowWidth();
-
-  ImGui::End();
+    ImGui::End();
 }
 
 void buildPickGui() {
-  if (pick::haveSelection()) {
+    if (pick::haveSelection()) {
 
-    ImGui::SetNextWindowPos(ImVec2(view::windowWidth - (rightWindowsWidth + imguiStackMargin),
-                                   2 * imguiStackMargin + lastWindowHeightUser));
-    ImGui::SetNextWindowSize(ImVec2(rightWindowsWidth, 0.));
+        ImGui::SetNextWindowPos(ImVec2(view::windowWidth - (rightWindowsWidth + imguiStackMargin),
+                                       2 * imguiStackMargin + lastWindowHeightUser));
+        ImGui::SetNextWindowSize(ImVec2(rightWindowsWidth, 0.));
 
-    ImGui::Begin("Selection", nullptr);
-    std::pair<Structure*, size_t> selection = pick::getSelection();
+        ImGui::Begin("Selection", nullptr);
+        std::pair<Structure*, size_t> selection = pick::getSelection();
 
-    ImGui::TextUnformatted((selection.first->typeName() + ": " + selection.first->name).c_str());
-    ImGui::Separator();
-    selection.first->buildPickUI(selection.second);
+        ImGui::TextUnformatted((selection.first->typeName() + ": " + selection.first->name).c_str());
+        ImGui::Separator();
+        selection.first->buildPickUI(selection.second);
 
-    rightWindowsWidth = ImGui::GetWindowWidth();
-    ImGui::End();
-  }
+        rightWindowsWidth = ImGui::GetWindowWidth();
+        ImGui::End();
+    }
 }
 
 void buildUserGuiAndInvokeCallback() {
 
-  if (!options::invokeUserCallbackForNestedShow && contextStack.size() > 2) {
-    return;
-  }
-
-  if (state::userCallback) {
-
-    if (options::buildGui && options::openImGuiWindowForUserCallback) {
-      ImGui::PushID("user_callback");
-      ImGui::SetNextWindowPos(ImVec2(view::windowWidth - (rightWindowsWidth + imguiStackMargin), imguiStackMargin));
-      ImGui::SetNextWindowSize(ImVec2(rightWindowsWidth, 0.));
-
-      ImGui::Begin("Command UI", nullptr);
+    if (!options::invokeUserCallbackForNestedShow && contextStack.size() > 2) {
+        return;
     }
 
-    state::userCallback();
+    if (state::userCallback) {
 
-    if (options::buildGui && options::openImGuiWindowForUserCallback) {
-      rightWindowsWidth = ImGui::GetWindowWidth();
-      lastWindowHeightUser = imguiStackMargin + ImGui::GetWindowHeight();
-      ImGui::End();
-      ImGui::PopID();
+        if (options::buildGui && options::openImGuiWindowForUserCallback) {
+            ImGui::PushID("user_callback");
+            ImGui::SetNextWindowPos(
+                ImVec2(view::windowWidth - (rightWindowsWidth + imguiStackMargin), imguiStackMargin));
+            ImGui::SetNextWindowSize(ImVec2(rightWindowsWidth, 0.));
+
+            ImGui::Begin("Command UI", nullptr);
+        }
+
+        state::userCallback();
+
+        if (options::buildGui && options::openImGuiWindowForUserCallback) {
+            rightWindowsWidth = ImGui::GetWindowWidth();
+            lastWindowHeightUser = imguiStackMargin + ImGui::GetWindowHeight();
+            ImGui::End();
+            ImGui::PopID();
+        } else {
+            lastWindowHeightUser = imguiStackMargin;
+        }
+
     } else {
-      lastWindowHeightUser = imguiStackMargin;
+        lastWindowHeightUser = imguiStackMargin;
     }
-
-  } else {
-    lastWindowHeightUser = imguiStackMargin;
-  }
 }
 
 void draw(bool withUI, bool withContextCallback) {
-  processLazyProperties();
+    processLazyProperties();
 
-  // Update buffer and context
-  render::engine->makeContextCurrent();
-  render::engine->bindDisplay();
-  render::engine->setBackgroundColor({view::bgColor[0], view::bgColor[1], view::bgColor[2]});
-  render::engine->setBackgroundAlpha(view::bgColor[3]);
-  render::engine->clearDisplay();
+    // Update buffer and context
+    render::engine->makeContextCurrent();
+    render::engine->bindDisplay();
+    render::engine->setBackgroundColor({view::bgColor[0], view::bgColor[1], view::bgColor[2]});
+    render::engine->setBackgroundAlpha(view::bgColor[3]);
+    render::engine->clearDisplay();
 
-  if (withUI) {
-    render::engine->ImGuiNewFrame();
-  }
+    if (withUI) {
+        render::engine->ImGuiNewFrame();
+    }
 
-  // Build the GUI components
-  if (withUI) {
-    if (contextStack.back().drawDefaultUI) {
+    // Build the GUI components
+    if (withUI) {
+        if (contextStack.back().drawDefaultUI) {
 
-      // Note: It is important to build the user GUI first, because it is likely that callbacks there will modify
-      // polyscope data. If we do these modifications happen later in the render cycle, they might invalidate data which
-      // is necessary when ImGui::Render() happens below.
-      buildUserGuiAndInvokeCallback();
+            // Note: It is important to build the user GUI first, because it is likely that callbacks there will modify
+            // polyscope data. If we do these modifications happen later in the render cycle, they might invalidate data
+            // which is necessary when ImGui::Render() happens below.
+            buildUserGuiAndInvokeCallback();
 
-      if (options::buildGui) {
-        buildPolyscopeGui();
-        buildStructureGui();
-        buildPickGui();
+            if (options::buildGui) {
+                buildPolyscopeGui();
+                buildStructureGui();
+                buildPickGui();
 
-        for (Widget* w : state::widgets) {
-          w->buildGUI();
+                for (Widget* w : state::widgets) {
+                    w->buildGUI();
+                }
+            }
         }
-      }
-    }
-  }
-
-  // Execute the context callback, if there is one.
-  // This callback is Polyscope implementation detail, which is distinct from the userCallback (which gets called below)
-  if (withContextCallback && contextStack.back().callback) {
-    (contextStack.back().callback)();
-  }
-
-  processLazyProperties();
-
-  // Draw structures in the scene
-  if (redrawNextFrame || options::alwaysRedraw) {
-    renderScene();
-    redrawNextFrame = false;
-  }
-  renderSceneToScreen();
-
-  // Draw the GUI
-  if (withUI) {
-    // render widgets
-    render::engine->bindDisplay();
-    for (Widget* w : state::widgets) {
-      w->draw();
     }
 
-    render::engine->bindDisplay();
-    render::engine->ImGuiRender();
-  }
+    // Execute the context callback, if there is one.
+    // This callback is Polyscope implementation detail, which is distinct from the userCallback (which gets called
+    // below)
+    if (withContextCallback && contextStack.back().callback) {
+        (contextStack.back().callback)();
+    }
+
+    processLazyProperties();
+
+    // Draw structures in the scene
+    if (redrawNextFrame || options::alwaysRedraw) {
+        renderScene();
+        redrawNextFrame = false;
+    }
+    renderSceneToScreen();
+
+    // Draw the GUI
+    if (withUI) {
+        // render widgets
+        render::engine->bindDisplay();
+        for (Widget* w : state::widgets) {
+            w->draw();
+        }
+
+        render::engine->bindDisplay();
+        render::engine->ImGuiRender();
+    }
 }
 
 
 void mainLoopIteration() {
 
-  processLazyProperties();
+    processLazyProperties();
 
-  // The windowing system will let this busy-loop in some situations, unfortunately. Make sure that doesn't happen.
-  if (options::maxFPS != -1) {
-    auto currTime = std::chrono::steady_clock::now();
-    long microsecPerLoop = 1000000 / options::maxFPS;
-    microsecPerLoop = (95 * microsecPerLoop) / 100; // give a little slack so we actually hit target fps
-    while (std::chrono::duration_cast<std::chrono::microseconds>(currTime - lastMainLoopIterTime).count() <
-           microsecPerLoop) {
-      std::this_thread::yield();
-      currTime = std::chrono::steady_clock::now();
+    // The windowing system will let this busy-loop in some situations, unfortunately. Make sure that doesn't happen.
+    if (options::maxFPS != -1) {
+        auto currTime = std::chrono::steady_clock::now();
+        long microsecPerLoop = 1000000 / options::maxFPS;
+        microsecPerLoop = (95 * microsecPerLoop) / 100; // give a little slack so we actually hit target fps
+        while (std::chrono::duration_cast<std::chrono::microseconds>(currTime - lastMainLoopIterTime).count() <
+               microsecPerLoop) {
+            std::this_thread::yield();
+            currTime = std::chrono::steady_clock::now();
+        }
     }
-  }
-  lastMainLoopIterTime = std::chrono::steady_clock::now();
+    lastMainLoopIterTime = std::chrono::steady_clock::now();
 
-  render::engine->makeContextCurrent();
-  render::engine->updateWindowSize();
+    render::engine->makeContextCurrent();
+    render::engine->updateWindowSize();
 
-  // Process UI events
-  render::engine->pollEvents();
-  processInputEvents();
-  view::updateFlight();
-  showDelayedWarnings();
+    // Process UI events
+    render::engine->pollEvents();
+    processInputEvents();
+    view::updateFlight();
+    showDelayedWarnings();
 
-  // Rendering
-  draw();
-  render::engine->swapDisplayBuffers();
+    // Rendering
+    draw();
+    render::engine->swapDisplayBuffers();
 }
 
 void show(size_t forFrames) {
 
-  if (!state::initialized) {
-    throw std::logic_error(options::printPrefix +
-                           "must initialize Polyscope with polyscope::init() before calling polyscope::show().");
-  }
-
-  // the popContext() doesn't quit until _after_ the last frame, so we need to decrement by 1 to get the count right
-  if (forFrames > 0) forFrames--;
-
-  auto checkFrames = [&]() {
-    if (forFrames == 0) {
-      popContext();
-    } else {
-      forFrames--;
+    if (!state::initialized) {
+        throw std::logic_error(options::printPrefix +
+                               "must initialize Polyscope with polyscope::init() before calling polyscope::show().");
     }
-  };
 
-  if (options::giveFocusOnShow) {
-    render::engine->focusWindow();
-  }
+    // the popContext() doesn't quit until _after_ the last frame, so we need to decrement by 1 to get the count right
+    if (forFrames > 0) forFrames--;
 
-  pushContext(checkFrames);
+    auto checkFrames = [&]() {
+        if (forFrames == 0) {
+            popContext();
+        } else {
+            forFrames--;
+        }
+    };
 
-  if (options::usePrefsFile) {
-    writePrefsFile();
-  }
+    if (options::giveFocusOnShow) {
+        render::engine->focusWindow();
+    }
 
-  // if this was the outermost show(), hide the window afterward
-  if (contextStack.size() == 1) {
-    render::engine->hideWindow();
-  }
+    pushContext(checkFrames);
+
+    if (options::usePrefsFile) {
+        writePrefsFile();
+    }
+
+    // if this was the outermost show(), hide the window afterward
+    if (contextStack.size() == 1) {
+        render::engine->hideWindow();
+    }
 }
 
 void shutdown() {
 
-  // TODO should we make an effort to destruct everything here?
-  if (options::usePrefsFile) {
-    writePrefsFile();
-  }
+    // TODO should we make an effort to destruct everything here?
+    if (options::usePrefsFile) {
+        writePrefsFile();
+    }
 
-  render::engine->shutdownImGui();
+    render::engine->shutdownImGui();
 }
 
 bool registerStructure(Structure* s, bool replaceIfPresent) {
 
-  // Make sure a map for the type exists
-  std::string typeName = s->typeName();
-  if (state::structures.find(typeName) == state::structures.end()) {
-    state::structures[typeName] = std::map<std::string, Structure*>();
-  }
-  std::map<std::string, Structure*>& sMap = state::structures[typeName];
-
-  // Check if the structure name is in use
-  bool inUse = sMap.find(s->name) != sMap.end();
-  if (inUse) {
-    if (replaceIfPresent) {
-      removeStructure(s->name);
-    } else {
-      polyscope::error("Attempted to register structure with name " + s->name +
-                       ", but a structure with that name already exists");
-      return false;
+    // Make sure a map for the type exists
+    std::string typeName = s->typeName();
+    if (state::structures.find(typeName) == state::structures.end()) {
+        state::structures[typeName] = std::map<std::string, Structure*>();
     }
-  }
+    std::map<std::string, Structure*>& sMap = state::structures[typeName];
 
-  // Center/scale if desired
-  if (options::autocenterStructures) {
-    s->centerBoundingBox();
-  }
-  if (options::autoscaleStructures) {
-    s->rescaleToUnit();
-  }
+    // Check if the structure name is in use
+    bool inUse = sMap.find(s->name) != sMap.end();
+    if (inUse) {
+        if (replaceIfPresent) {
+            removeStructure(s->name);
+        } else {
+            polyscope::error("Attempted to register structure with name " + s->name +
+                             ", but a structure with that name already exists");
+            return false;
+        }
+    }
 
-  // Add the new structure
-  sMap[s->name] = s;
-  updateStructureExtents();
-  requestRedraw();
+    // Center/scale if desired
+    if (options::autocenterStructures) {
+        s->centerBoundingBox();
+    }
+    if (options::autoscaleStructures) {
+        s->rescaleToUnit();
+    }
 
-  return true;
+    // Add the new structure
+    sMap[s->name] = s;
+    updateStructureExtents();
+    requestRedraw();
+
+    return true;
 }
 
 Structure* getStructure(std::string type, std::string name) {
 
-  if (type == "" || name == "") return nullptr;
+    if (type == "" || name == "") return nullptr;
 
-  // If there are no structures of that type it is an automatic fail
-  if (state::structures.find(type) == state::structures.end()) {
-    error("No structures of type " + type + " registered");
-    return nullptr;
-  }
-  std::map<std::string, Structure*>& sMap = state::structures[type];
-
-  // Special automatic case, return any
-  if (name == "") {
-    if (sMap.size() != 1) {
-      error("Cannot use automatic structure get with empty name unless there is exactly one structure of that type "
-            "registered");
-      return nullptr;
+    // If there are no structures of that type it is an automatic fail
+    if (state::structures.find(type) == state::structures.end()) {
+        error("No structures of type " + type + " registered");
+        return nullptr;
     }
-    return sMap.begin()->second;
-  }
+    std::map<std::string, Structure*>& sMap = state::structures[type];
 
-  // General case
-  if (sMap.find(name) == sMap.end()) {
-    error("No structure of type " + type + " with name " + name + " registered");
-    return nullptr;
-  }
-  return sMap[name];
+    // Special automatic case, return any
+    if (name == "") {
+        if (sMap.size() != 1) {
+            error(
+                "Cannot use automatic structure get with empty name unless there is exactly one structure of that type "
+                "registered");
+            return nullptr;
+        }
+        return sMap.begin()->second;
+    }
+
+    // General case
+    if (sMap.find(name) == sMap.end()) {
+        error("No structure of type " + type + " with name " + name + " registered");
+        return nullptr;
+    }
+    return sMap[name];
 }
 
 bool hasStructure(std::string type, std::string name) {
-  // If there are no structures of that type it is an automatic fail
-  if (state::structures.find(type) == state::structures.end()) {
-    return false;
-  }
-  std::map<std::string, Structure*>& sMap = state::structures[type];
-
-  // Special automatic case, return any
-  if (name == "") {
-    if (sMap.size() != 1) {
-      error("Cannot use automatic structure get with empty name unless there is exactly one structure of that type "
-            "registered");
+    // If there are no structures of that type it is an automatic fail
+    if (state::structures.find(type) == state::structures.end()) {
+        return false;
     }
-    return true;
-  }
-  return sMap.find(name) != sMap.end();
+    std::map<std::string, Structure*>& sMap = state::structures[type];
+
+    // Special automatic case, return any
+    if (name == "") {
+        if (sMap.size() != 1) {
+            error(
+                "Cannot use automatic structure get with empty name unless there is exactly one structure of that type "
+                "registered");
+        }
+        return true;
+    }
+    return sMap.find(name) != sMap.end();
 }
 
 
 void removeStructure(std::string type, std::string name, bool errorIfAbsent) {
 
-  // If there are no structures of that type it is an automatic fail
-  if (state::structures.find(type) == state::structures.end()) {
-    if (errorIfAbsent) {
-      error("No structures of type " + type + " registered");
+    // If there are no structures of that type it is an automatic fail
+    if (state::structures.find(type) == state::structures.end()) {
+        if (errorIfAbsent) {
+            error("No structures of type " + type + " registered");
+        }
+        return;
     }
-    return;
-  }
-  std::map<std::string, Structure*>& sMap = state::structures[type];
+    std::map<std::string, Structure*>& sMap = state::structures[type];
 
-  // Check if structure exists
-  if (sMap.find(name) == sMap.end()) {
-    if (errorIfAbsent) {
-      error("No structure of type " + type + " and name " + name + " registered");
+    // Check if structure exists
+    if (sMap.find(name) == sMap.end()) {
+        if (errorIfAbsent) {
+            error("No structure of type " + type + " and name " + name + " registered");
+        }
+        return;
     }
-    return;
-  }
 
-  // Structure exists, remove it
-  Structure* s = sMap[name];
-  pick::resetSelectionIfStructure(s);
-  sMap.erase(s->name);
-  delete s;
-  updateStructureExtents();
-  return;
+    // Structure exists, remove it
+    Structure* s = sMap[name];
+    pick::resetSelectionIfStructure(s);
+    sMap.erase(s->name);
+    delete s;
+    updateStructureExtents();
+    return;
 }
 
 void removeStructure(Structure* structure, bool errorIfAbsent) {
-  removeStructure(structure->typeName(), structure->name, errorIfAbsent);
+    removeStructure(structure->typeName(), structure->name, errorIfAbsent);
 }
 
 void removeStructure(std::string name, bool errorIfAbsent) {
 
-  // Check if we can find exactly one structure matching the name
-  Structure* targetStruct = nullptr;
-  for (auto typeMap : state::structures) {
-    for (auto entry : typeMap.second) {
+    // Check if we can find exactly one structure matching the name
+    Structure* targetStruct = nullptr;
+    for (auto typeMap : state::structures) {
+        for (auto entry : typeMap.second) {
 
-      // Found a matching structure
-      if (entry.first == name) {
-        if (targetStruct == nullptr) {
-          targetStruct = entry.second;
-        } else {
-          error("Cannot use automatic structure remove with empty name unless there is exactly one structure of that "
-                "type registered. Found two structures of different types with that name: " +
-                targetStruct->typeName() + " and " + typeMap.first + ".");
-          return;
+            // Found a matching structure
+            if (entry.first == name) {
+                if (targetStruct == nullptr) {
+                    targetStruct = entry.second;
+                } else {
+                    error("Cannot use automatic structure remove with empty name unless there is exactly one structure "
+                          "of that "
+                          "type registered. Found two structures of different types with that name: " +
+                          targetStruct->typeName() + " and " + typeMap.first + ".");
+                    return;
+                }
+            }
         }
-      }
     }
-  }
 
-  // Error if none found.
-  if (targetStruct == nullptr) {
-    if (errorIfAbsent) {
-      error("No structure named: " + name + " to remove.");
+    // Error if none found.
+    if (targetStruct == nullptr) {
+        if (errorIfAbsent) {
+            error("No structure named: " + name + " to remove.");
+        }
+        return;
     }
-    return;
-  }
 
-  removeStructure(targetStruct->typeName(), targetStruct->name, errorIfAbsent);
-  requestRedraw();
+    removeStructure(targetStruct->typeName(), targetStruct->name, errorIfAbsent);
+    requestRedraw();
 }
 
 void removeAllStructures() {
 
-  for (auto typeMap : state::structures) {
+    for (auto typeMap : state::structures) {
 
-    // dodge iterator invalidation
-    std::vector<std::string> names;
-    for (auto entry : typeMap.second) {
-      names.push_back(entry.first);
+        // dodge iterator invalidation
+        std::vector<std::string> names;
+        for (auto entry : typeMap.second) {
+            names.push_back(entry.first);
+        }
+
+        // remove all
+        for (auto name : names) {
+            removeStructure(typeMap.first, name);
+        }
     }
 
-    // remove all
-    for (auto name : names) {
-      removeStructure(typeMap.first, name);
-    }
-  }
-
-  requestRedraw();
-  pick::resetSelection();
+    requestRedraw();
+    pick::resetSelection();
 }
 
 void refresh() {
 
-  // reset the ground plane
-  render::engine->groundPlane.prepare();
+    // reset the ground plane
+    render::engine->groundPlane.prepare();
 
-  // reset all of the structures
-  for (auto cat : state::structures) {
-    for (auto x : cat.second) {
-      x.second->refresh();
+    // reset all of the structures
+    for (auto cat : state::structures) {
+        for (auto x : cat.second) {
+            x.second->refresh();
+        }
     }
-  }
 
-  requestRedraw();
+    requestRedraw();
 }
 
 // Cached versions of lazy properties used for updates
 namespace lazy {
-TransparencyMode transparencyMode = TransparencyMode::None;
-int transparencyRenderPasses = 8;
-int ssaaFactor = 1;
-bool groundPlaneEnabled = true;
-GroundPlaneMode groundPlaneMode = GroundPlaneMode::TileReflection;
-ScaledValue<float> groundPlaneHeightFactor = 0;
-int shadowBlurIters = 2;
-float shadowDarkness = .4;
+    TransparencyMode transparencyMode = TransparencyMode::None;
+    int transparencyRenderPasses = 8;
+    int ssaaFactor = 1;
+    bool groundPlaneEnabled = true;
+    GroundPlaneMode groundPlaneMode = GroundPlaneMode::TileReflection;
+    ScaledValue<float> groundPlaneHeightFactor = 0;
+    int shadowBlurIters = 2;
+    float shadowDarkness = .4;
 } // namespace lazy
 
 void processLazyProperties() {
 
-  // Note: This function essentially represents lazy software design, and it's an ugly and error-prone part of the
-  // system. The reason for it that some settings require action on a change (e..g re-drawing the scene), but we want to
-  // allow variable-set syntax like `polyscope::setting = newVal;` rather than getters and setters like
-  // `polyscope::setSetting(newVal);`. It might have been better to simple set options with setter from the start, but
-  // that ship has sailed.
-  //
-  // This function is a workaround which polls for changes to options settings, and performs any necessary additional
-  // work.
+    // Note: This function essentially represents lazy software design, and it's an ugly and error-prone part of the
+    // system. The reason for it that some settings require action on a change (e..g re-drawing the scene), but we want
+    // to allow variable-set syntax like `polyscope::setting = newVal;` rather than getters and setters like
+    // `polyscope::setSetting(newVal);`. It might have been better to simple set options with setter from the start, but
+    // that ship has sailed.
+    //
+    // This function is a workaround which polls for changes to options settings, and performs any necessary additional
+    // work.
 
 
-  // transparency mode
-  if (lazy::transparencyMode != options::transparencyMode) {
-    lazy::transparencyMode = options::transparencyMode;
-    render::engine->setTransparencyMode(options::transparencyMode);
-  }
-
-  // transparency render passes
-  if (lazy::transparencyRenderPasses != options::transparencyRenderPasses) {
-    lazy::transparencyRenderPasses = options::transparencyRenderPasses;
-    requestRedraw();
-  }
-
-  // ssaa
-  if (lazy::ssaaFactor != options::ssaaFactor) {
-    lazy::ssaaFactor = options::ssaaFactor;
-    render::engine->setSSAAFactor(options::ssaaFactor);
-  }
-
-  // ground plane
-  if (lazy::groundPlaneEnabled != options::groundPlaneEnabled || lazy::groundPlaneMode != options::groundPlaneMode) {
-    lazy::groundPlaneEnabled = options::groundPlaneEnabled;
-    if (!options::groundPlaneEnabled) {
-      // if the (depecated) groundPlaneEnabled = false, set mode to None, so we only have one variable to check
-      options::groundPlaneMode = GroundPlaneMode::None;
+    // transparency mode
+    if (lazy::transparencyMode != options::transparencyMode) {
+        lazy::transparencyMode = options::transparencyMode;
+        render::engine->setTransparencyMode(options::transparencyMode);
     }
-    lazy::groundPlaneMode = options::groundPlaneMode;
-    render::engine->groundPlane.prepare();
-    requestRedraw();
-  }
-  if (lazy::groundPlaneHeightFactor.asAbsolute() != options::groundPlaneHeightFactor.asAbsolute() ||
-      lazy::groundPlaneHeightFactor.isRelative() != options::groundPlaneHeightFactor.isRelative()) {
-    lazy::groundPlaneHeightFactor = options::groundPlaneHeightFactor;
-    requestRedraw();
-  }
-  if (lazy::shadowBlurIters != options::shadowBlurIters) {
-    lazy::shadowBlurIters = options::shadowBlurIters;
-    requestRedraw();
-  }
-  if (lazy::shadowDarkness != options::shadowDarkness) {
-    lazy::shadowDarkness = options::shadowDarkness;
-    requestRedraw();
-  }
+
+    // transparency render passes
+    if (lazy::transparencyRenderPasses != options::transparencyRenderPasses) {
+        lazy::transparencyRenderPasses = options::transparencyRenderPasses;
+        requestRedraw();
+    }
+
+    // ssaa
+    if (lazy::ssaaFactor != options::ssaaFactor) {
+        lazy::ssaaFactor = options::ssaaFactor;
+        render::engine->setSSAAFactor(options::ssaaFactor);
+    }
+
+    // ground plane
+    if (lazy::groundPlaneEnabled != options::groundPlaneEnabled || lazy::groundPlaneMode != options::groundPlaneMode) {
+        lazy::groundPlaneEnabled = options::groundPlaneEnabled;
+        if (!options::groundPlaneEnabled) {
+            // if the (depecated) groundPlaneEnabled = false, set mode to None, so we only have one variable to check
+            options::groundPlaneMode = GroundPlaneMode::None;
+        }
+        lazy::groundPlaneMode = options::groundPlaneMode;
+        render::engine->groundPlane.prepare();
+        requestRedraw();
+    }
+    if (lazy::groundPlaneHeightFactor.asAbsolute() != options::groundPlaneHeightFactor.asAbsolute() ||
+        lazy::groundPlaneHeightFactor.isRelative() != options::groundPlaneHeightFactor.isRelative()) {
+        lazy::groundPlaneHeightFactor = options::groundPlaneHeightFactor;
+        requestRedraw();
+    }
+    if (lazy::shadowBlurIters != options::shadowBlurIters) {
+        lazy::shadowBlurIters = options::shadowBlurIters;
+        requestRedraw();
+    }
+    if (lazy::shadowDarkness != options::shadowDarkness) {
+        lazy::shadowDarkness = options::shadowDarkness;
+        requestRedraw();
+    }
 };
 
 void updateStructureExtents() {
 
-  if (!options::automaticallyComputeSceneExtents) {
-    return;
-  }
-
-  // Note: the cost multiple calls to this function scales only with the number of structures, not the size of the data
-  // in those structures, because structures internally cache the extents of their data.
-
-  // Compute length scale and bbox as the max of all structures
-  state::lengthScale = 0.0;
-  glm::vec3 minBbox = glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
-  glm::vec3 maxBbox = -glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
-
-  for (auto cat : state::structures) {
-    for (auto x : cat.second) {
-      state::lengthScale = std::max(state::lengthScale, x.second->lengthScale());
-      auto bbox = x.second->boundingBox();
-      minBbox = componentwiseMin(minBbox, std::get<0>(bbox));
-      maxBbox = componentwiseMax(maxBbox, std::get<1>(bbox));
+    if (!options::automaticallyComputeSceneExtents) {
+        return;
     }
-  }
 
-  // If we got a non-finite bounding box, fix it
-  if (!isFinite(minBbox) || !isFinite(maxBbox)) {
-    minBbox = -glm::vec3{1, 1, 1};
-    maxBbox = glm::vec3{1, 1, 1};
-  }
+    // Note: the cost multiple calls to this function scales only with the number of structures, not the size of the
+    // data in those structures, because structures internally cache the extents of their data.
 
-  // If we got a degenerate bounding box, perturb it slightly
-  if (minBbox == maxBbox) {
-    double offsetScale = (state::lengthScale == 0) ? 1e-5 : state::lengthScale * 1e-5;
-    glm::vec3 offset{offsetScale, offsetScale, offsetScale};
-    minBbox = minBbox - offset / 2.f;
-    maxBbox = maxBbox + offset / 2.f;
-  }
+    // Compute length scale and bbox as the max of all structures
+    state::lengthScale = 0.0;
+    glm::vec3 minBbox = glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
+    glm::vec3 maxBbox = -glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
 
-  std::get<0>(state::boundingBox) = minBbox;
-  std::get<1>(state::boundingBox) = maxBbox;
+    for (auto cat : state::structures) {
+        for (auto x : cat.second) {
+            state::lengthScale = std::max(state::lengthScale, x.second->lengthScale());
+            auto bbox = x.second->boundingBox();
+            minBbox = componentwiseMin(minBbox, std::get<0>(bbox));
+            maxBbox = componentwiseMax(maxBbox, std::get<1>(bbox));
+        }
+    }
 
-  // If we got a bounding box but not a length scale we can use the size of the
-  // box as a scale. If we got neither, we'll end up with a constant near 1 due
-  // to the above correction
-  if (state::lengthScale == 0) {
-    state::lengthScale = glm::length(maxBbox - minBbox);
-  }
+    // If we got a non-finite bounding box, fix it
+    if (!isFinite(minBbox) || !isFinite(maxBbox)) {
+        minBbox = -glm::vec3{1, 1, 1};
+        maxBbox = glm::vec3{1, 1, 1};
+    }
 
-  requestRedraw();
+    // If we got a degenerate bounding box, perturb it slightly
+    if (minBbox == maxBbox) {
+        double offsetScale = (state::lengthScale == 0) ? 1e-5 : state::lengthScale * 1e-5;
+        glm::vec3 offset{offsetScale, offsetScale, offsetScale};
+        minBbox = minBbox - offset / 2.f;
+        maxBbox = maxBbox + offset / 2.f;
+    }
+
+    std::get<0>(state::boundingBox) = minBbox;
+    std::get<1>(state::boundingBox) = maxBbox;
+
+    // If we got a bounding box but not a length scale we can use the size of the
+    // box as a scale. If we got neither, we'll end up with a constant near 1 due
+    // to the above correction
+    if (state::lengthScale == 0) {
+        state::lengthScale = glm::length(maxBbox - minBbox);
+    }
+
+    requestRedraw();
 }
 
 namespace state {
-glm::vec3 center() { return 0.5f * (std::get<0>(state::boundingBox) + std::get<1>(state::boundingBox)); }
+    glm::vec3 center() {
+        return 0.5f * (std::get<0>(state::boundingBox) + std::get<1>(state::boundingBox));
+    }
 } // namespace state
 
 } // namespace polyscope

--- a/src/render/opengl/shaders/surface_mesh_shaders.cpp
+++ b/src/render/opengl/shaders/surface_mesh_shaders.cpp
@@ -4,9 +4,9 @@
 
 namespace polyscope {
 namespace render {
-    namespace backend_openGL3_glfw {
+namespace backend_openGL3_glfw {
 
-        // clang-format off
+// clang-format off
 
 const ShaderStageSpecification FLEX_MESH_VERT_SHADER = {
 
@@ -448,8 +448,8 @@ const ShaderReplacementRule MESH_PROPAGATE_PICK (
 );
 
 
-        // clang-format on
+// clang-format on
 
-    } // namespace backend_openGL3_glfw
+} // namespace backend_openGL3_glfw
 } // namespace render
 } // namespace polyscope

--- a/src/render/opengl/shaders/surface_mesh_shaders.cpp
+++ b/src/render/opengl/shaders/surface_mesh_shaders.cpp
@@ -4,9 +4,9 @@
 
 namespace polyscope {
 namespace render {
-namespace backend_openGL3_glfw {
+    namespace backend_openGL3_glfw {
 
-// clang-format off
+        // clang-format off
 
 const ShaderStageSpecification FLEX_MESH_VERT_SHADER = {
 
@@ -373,10 +373,12 @@ const ShaderReplacementRule MESH_PROPAGATE_PICK (
           in vec3 a_vertexColors[3];
           in vec3 a_edgeColors[3];
           in vec3 a_halfedgeColors[3];
+          in vec3 a_cornerColors[3];
           in vec3 a_faceColor;
           flat out vec3 vertexColors[3];
           flat out vec3 edgeColors[3];
           flat out vec3 halfedgeColors[3];
+          flat out vec3 cornerColors[3];
           flat out vec3 faceColor;
         )"},
       {"VERT_ASSIGNMENTS", R"(
@@ -384,6 +386,7 @@ const ShaderReplacementRule MESH_PROPAGATE_PICK (
               vertexColors[i] = a_vertexColors[i];
               edgeColors[i] = a_edgeColors[i];
               halfedgeColors[i] = a_halfedgeColors[i];
+              cornerColors[i] = a_cornerColors[i];
           }
           faceColor = a_faceColor;
         )"},
@@ -391,21 +394,28 @@ const ShaderReplacementRule MESH_PROPAGATE_PICK (
           flat in vec3 vertexColors[3];
           flat in vec3 edgeColors[3];
           flat in vec3 halfedgeColors[3];
+          flat in vec3 cornerColors[3];
           flat in vec3 faceColor;
         )"},
       {"GENERATE_SHADE_VALUE", R"(
           // Parameters defining the pick shape (in barycentric 0-1 units)
           float vertRadius = 0.2;
+          float cornerRadius = 0.3;
           float edgeRadius = 0.1;
           float halfedgeRadius = 0.2;
           
           vec3 shadeColor = faceColor;
           bool colorSet = false;
 
-          // Test vertices
+          // Test vertices and corners
           for(int i = 0; i < 3; i++) {
               if(a_barycoordToFrag[i] > 1.0-vertRadius) {
                 shadeColor = vertexColors[i];
+                colorSet = true;
+                continue;
+              }
+              if(a_barycoordToFrag[i] > 1.0-cornerRadius) {
+                shadeColor = cornerColors[i];
                 colorSet = true;
               }
           }
@@ -431,14 +441,15 @@ const ShaderReplacementRule MESH_PROPAGATE_PICK (
       {"a_vertexColors", DataType::Vector3Float, 3},
       {"a_edgeColors", DataType::Vector3Float, 3},
       {"a_halfedgeColors", DataType::Vector3Float, 3},
+      {"a_cornerColors", DataType::Vector3Float, 3},
       {"a_faceColor", DataType::Vector3Float},
     },
     /* textures */ {}
 );
 
 
-// clang-format on
+        // clang-format on
 
-} // namespace backend_openGL3_glfw
+    } // namespace backend_openGL3_glfw
 } // namespace render
 } // namespace polyscope

--- a/src/surface_mesh.cpp
+++ b/src/surface_mesh.cpp
@@ -27,657 +27,652 @@ SurfaceMesh::SurfaceMesh(std::string name, const std::vector<glm::vec3>& vertexP
       backFacePolicy(uniquePrefix() + "backFacePolicy", BackFacePolicy::Different),
       backFaceColor(uniquePrefix() + "backFaceColor",
                     glm::vec3(1.f - surfaceColor.get().r, 1.f - surfaceColor.get().g, 1.f - surfaceColor.get().b)) {
-    updateObjectSpaceBounds();
-    computeCounts();
-    computeGeometryData();
+  updateObjectSpaceBounds();
+  computeCounts();
+  computeGeometryData();
 }
 
 
 void SurfaceMesh::computeCounts() {
 
-    nFacesTriangulationCount = 0;
-    nCornersCount = 0;
-    nEdgesCount = 0;
-    edgeIndices.resize(nFaces());
-    halfedgeIndices.resize(nFaces());
-    std::unordered_map<std::pair<size_t, size_t>, size_t, polyscope::hash_combine::hash<std::pair<size_t, size_t>>>
-        edgeInds;
-    size_t iF = 0;
-    for (auto& face : faces) {
-        if (face.size() < 3) {
-            warning(name + " has face with degree < 3!");
-            face = {0, 0, 0}; // (just to do _something_ so we don't crash in subsequent code)
+  nFacesTriangulationCount = 0;
+  nCornersCount = 0;
+  nEdgesCount = 0;
+  edgeIndices.resize(nFaces());
+  halfedgeIndices.resize(nFaces());
+  std::unordered_map<std::pair<size_t, size_t>, size_t, polyscope::hash_combine::hash<std::pair<size_t, size_t>>>
+      edgeInds;
+  size_t iF = 0;
+  for (auto& face : faces) {
+    if (face.size() < 3) {
+      warning(name + " has face with degree < 3!");
+      face = {0, 0, 0}; // (just to do _something_ so we don't crash in subsequent code)
+    }
+    nFacesTriangulationCount += std::max(static_cast<int>(face.size()) - 2, 0);
+    edgeIndices[iF].resize(face.size());
+    halfedgeIndices[iF].resize(face.size());
+
+    for (size_t i = 0; i < face.size(); i++) {
+      size_t vA = face[i];
+      size_t vB = face[(i + 1) % face.size()];
+
+      if (vA >= vertices.size()) {
+        warning(name + " has face with vertex index out of vertices range",
+                "face " + std::to_string(iF) + " has vertex index " + std::to_string(vA));
+
+        // zero out the face index
+        // (just to do _something_ so we don't crash in subsequent code)
+        for (size_t j = 0; j < face.size(); j++) {
+          face[j] = 0;
         }
-        nFacesTriangulationCount += std::max(static_cast<int>(face.size()) - 2, 0);
-        edgeIndices[iF].resize(face.size());
-        halfedgeIndices[iF].resize(face.size());
+        vA = face[i];
+        vB = face[(i + 1) % face.size()];
+      }
 
-        for (size_t i = 0; i < face.size(); i++) {
-            size_t vA = face[i];
-            size_t vB = face[(i + 1) % face.size()];
+      std::pair<size_t, size_t> edgeKey(std::min(vA, vB), std::max(vA, vB));
+      auto it = edgeInds.find(edgeKey);
+      size_t edgeInd = 0;
+      if (it == edgeInds.end()) {
+        edgeInd = nEdgesCount;
+        edgeInds.insert(it, {edgeKey, edgeInd});
+        nEdgesCount++;
+      } else {
+        edgeInd = it->second;
+      }
 
-            if (vA >= vertices.size()) {
-                warning(name + " has face with vertex index out of vertices range",
-                        "face " + std::to_string(iF) + " has vertex index " + std::to_string(vA));
-
-                // zero out the face index
-                // (just to do _something_ so we don't crash in subsequent code)
-                for (size_t j = 0; j < face.size(); j++) {
-                    face[j] = 0;
-                }
-                vA = face[i];
-                vB = face[(i + 1) % face.size()];
-            }
-
-            std::pair<size_t, size_t> edgeKey(std::min(vA, vB), std::max(vA, vB));
-            auto it = edgeInds.find(edgeKey);
-            size_t edgeInd = 0;
-            if (it == edgeInds.end()) {
-                edgeInd = nEdgesCount;
-                edgeInds.insert(it, {edgeKey, edgeInd});
-                nEdgesCount++;
-            } else {
-                edgeInd = it->second;
-            }
-
-            edgeIndices[iF][i] = edgeInd;
-            halfedgeIndices[iF][i] = nCornersCount++;
-        }
-
-        iF++;
+      edgeIndices[iF][i] = edgeInd;
+      halfedgeIndices[iF][i] = nCornersCount++;
     }
 
-    // Default data sizes
-    vertexDataSize = nVertices();
-    faceDataSize = nFaces();
-    edgeDataSize = nEdges();
-    halfedgeDataSize = nHalfedges();
-    cornerDataSize = nCorners();
+    iF++;
+  }
+
+  // Default data sizes
+  vertexDataSize = nVertices();
+  faceDataSize = nFaces();
+  edgeDataSize = nEdges();
+  halfedgeDataSize = nHalfedges();
+  cornerDataSize = nCorners();
 }
 
 void SurfaceMesh::computeGeometryData() {
-    const glm::vec3 zero{0., 0., 0.};
+  const glm::vec3 zero{0., 0., 0.};
 
-    // Reset face-valued
-    faceNormals.resize(nFaces());
-    faceAreas.resize(nFaces());
+  // Reset face-valued
+  faceNormals.resize(nFaces());
+  faceAreas.resize(nFaces());
 
-    // Reset vertex-valued
-    vertexNormals.resize(nVertices());
-    std::fill(vertexNormals.begin(), vertexNormals.end(), zero);
-    vertexAreas.resize(nVertices());
-    std::fill(vertexAreas.begin(), vertexAreas.end(), 0);
+  // Reset vertex-valued
+  vertexNormals.resize(nVertices());
+  std::fill(vertexNormals.begin(), vertexNormals.end(), zero);
+  vertexAreas.resize(nVertices());
+  std::fill(vertexAreas.begin(), vertexAreas.end(), 0);
 
-    // Reset edge-valued
-    edgeLengths.resize(nEdges());
+  // Reset edge-valued
+  edgeLengths.resize(nEdges());
 
-    // Loop over faces to compute face-valued quantities
-    for (size_t iF = 0; iF < nFaces(); iF++) {
-        auto& face = faces[iF];
-        size_t D = face.size();
+  // Loop over faces to compute face-valued quantities
+  for (size_t iF = 0; iF < nFaces(); iF++) {
+    auto& face = faces[iF];
+    size_t D = face.size();
 
-        glm::vec3 fN = zero;
-        double fA = 0;
-        if (face.size() == 3) {
-            glm::vec3 pA = vertices[face[0]];
-            glm::vec3 pB = vertices[face[1]];
-            glm::vec3 pC = vertices[face[2]];
+    glm::vec3 fN = zero;
+    double fA = 0;
+    if (face.size() == 3) {
+      glm::vec3 pA = vertices[face[0]];
+      glm::vec3 pB = vertices[face[1]];
+      glm::vec3 pC = vertices[face[2]];
 
-            fN = glm::cross(pB - pA, pC - pA);
-            fA = 0.5 * glm::length(fN);
-        } else if (face.size() > 3) {
+      fN = glm::cross(pB - pA, pC - pA);
+      fA = 0.5 * glm::length(fN);
+    } else if (face.size() > 3) {
 
-            glm::vec3 pRoot = vertices[face[0]];
-            for (size_t j = 0; j < D; j++) {
-                glm::vec3 pA = vertices[face[j]];
-                glm::vec3 pB = vertices[face[(j + 1) % D]];
-                glm::vec3 pC = vertices[face[(j + 2) % D]];
+      glm::vec3 pRoot = vertices[face[0]];
+      for (size_t j = 0; j < D; j++) {
+        glm::vec3 pA = vertices[face[j]];
+        glm::vec3 pB = vertices[face[(j + 1) % D]];
+        glm::vec3 pC = vertices[face[(j + 2) % D]];
 
-                fN += glm::cross(pC - pB, pA - pB);
+        fN += glm::cross(pC - pB, pA - pB);
 
-                // _some_ definition of area for a non-triangular face
-                if (j != 0 && j != (D - 1)) {
-                    fA += 0.5 * glm::length(glm::cross(pA - pRoot, pB - pRoot));
-                }
-            }
+        // _some_ definition of area for a non-triangular face
+        if (j != 0 && j != (D - 1)) {
+          fA += 0.5 * glm::length(glm::cross(pA - pRoot, pB - pRoot));
         }
-
-        // Set face values
-        fN = glm::normalize(fN);
-        faceNormals[iF] = fN;
-        faceAreas[iF] = fA;
-
-        // Update incident vertices
-        for (size_t j = 0; j < D; j++) {
-            glm::vec3 pA = vertices[face[j]];
-            glm::vec3 pB = vertices[face[(j + 1) % D]];
-            glm::vec3 pC = vertices[face[(j + 2) % D]];
-
-            vertexAreas[face[j]] += fA / D;
-
-            // Corner angle for weighting normals
-            double dot = glm::dot(glm::normalize(pB - pA), glm::normalize(pC - pA));
-            float angle = std::acos(glm::clamp(-1., 1., dot));
-            glm::vec3 normalContrib = angle * fN;
-
-            if (std::isfinite(normalContrib.x) && std::isfinite(normalContrib.y) && std::isfinite(normalContrib.z)) {
-                vertexNormals[face[(j + 1) % D]] += normalContrib;
-            }
-
-            // Compute edge lengths while we're at it
-            edgeLengths[edgeIndices[iF][j]] = glm::length(pA - pB);
-        }
+      }
     }
 
+    // Set face values
+    fN = glm::normalize(fN);
+    faceNormals[iF] = fN;
+    faceAreas[iF] = fA;
 
-    // Normalize vertex normals
-    for (auto& vec : vertexNormals) {
-        double L = glm::length(vec);
-        if (L > 0) {
-            vec /= L;
-        }
+    // Update incident vertices
+    for (size_t j = 0; j < D; j++) {
+      glm::vec3 pA = vertices[face[j]];
+      glm::vec3 pB = vertices[face[(j + 1) % D]];
+      glm::vec3 pC = vertices[face[(j + 2) % D]];
+
+      vertexAreas[face[j]] += fA / D;
+
+      // Corner angle for weighting normals
+      double dot = glm::dot(glm::normalize(pB - pA), glm::normalize(pC - pA));
+      float angle = std::acos(glm::clamp(-1., 1., dot));
+      glm::vec3 normalContrib = angle * fN;
+
+      if (std::isfinite(normalContrib.x) && std::isfinite(normalContrib.y) && std::isfinite(normalContrib.z)) {
+        vertexNormals[face[(j + 1) % D]] += normalContrib;
+      }
+
+      // Compute edge lengths while we're at it
+      edgeLengths[edgeIndices[iF][j]] = glm::length(pA - pB);
     }
+  }
+
+
+  // Normalize vertex normals
+  for (auto& vec : vertexNormals) {
+    double L = glm::length(vec);
+    if (L > 0) {
+      vec /= L;
+    }
+  }
 }
 
 void SurfaceMesh::ensureHaveManifoldConnectivity() {
-    if (!faceForHalfedge.empty()) return; // already populated
+  if (!faceForHalfedge.empty()) return; // already populated
 
-    faceForHalfedge.resize(nHalfedges());
-    twinHalfedge.resize(nHalfedges());
+  faceForHalfedge.resize(nHalfedges());
+  twinHalfedge.resize(nHalfedges());
 
-    // Maps from edge (sorted) to all halfedges incident on that edge
-    std::unordered_map<std::pair<size_t, size_t>, std::vector<size_t>,
-                       polyscope::hash_combine::hash<std::pair<size_t, size_t>>>
-        edgeInds;
+  // Maps from edge (sorted) to all halfedges incident on that edge
+  std::unordered_map<std::pair<size_t, size_t>, std::vector<size_t>,
+                     polyscope::hash_combine::hash<std::pair<size_t, size_t>>>
+      edgeInds;
 
-    // Fill out faceForHalfedge and populate edge lookup map
-    for (size_t iF = 0; iF < nFaces(); iF++) {
-        auto& face = faces[iF];
-        size_t D = face.size();
+  // Fill out faceForHalfedge and populate edge lookup map
+  for (size_t iF = 0; iF < nFaces(); iF++) {
+    auto& face = faces[iF];
+    size_t D = face.size();
 
 
-        for (size_t j = 0; j < D; j++) {
-            size_t iV = face[j];
-            size_t iVNext = face[(j + 1) % D];
-            size_t iHe = halfedgeIndices[iF][j];
+    for (size_t j = 0; j < D; j++) {
+      size_t iV = face[j];
+      size_t iVNext = face[(j + 1) % D];
+      size_t iHe = halfedgeIndices[iF][j];
 
-            faceForHalfedge[iHe] = iF;
+      faceForHalfedge[iHe] = iF;
 
-            std::pair<size_t, size_t> edgeKey(std::min(iV, iVNext), std::max(iV, iVNext));
+      std::pair<size_t, size_t> edgeKey(std::min(iV, iVNext), std::max(iV, iVNext));
 
-            // Make sure the key is populated
-            auto it = edgeInds.find(edgeKey);
-            if (it == edgeInds.end()) {
-                it = edgeInds.insert(it, {edgeKey, std::vector<size_t>()});
-            }
+      // Make sure the key is populated
+      auto it = edgeInds.find(edgeKey);
+      if (it == edgeInds.end()) {
+        it = edgeInds.insert(it, {edgeKey, std::vector<size_t>()});
+      }
 
-            // Add this halfedge to the entry
-            it->second.push_back(iHe);
-        }
+      // Add this halfedge to the entry
+      it->second.push_back(iHe);
     }
+  }
 
-    // Second walk through, setting twins
-    for (size_t iF = 0; iF < nFaces(); iF++) {
-        auto& face = faces[iF];
-        size_t D = face.size();
+  // Second walk through, setting twins
+  for (size_t iF = 0; iF < nFaces(); iF++) {
+    auto& face = faces[iF];
+    size_t D = face.size();
 
-        for (size_t j = 0; j < D; j++) {
-            size_t iV = face[j];
-            size_t iVNext = face[(j + 1) % D];
-            size_t iHe = halfedgeIndices[iF][j];
+    for (size_t j = 0; j < D; j++) {
+      size_t iV = face[j];
+      size_t iVNext = face[(j + 1) % D];
+      size_t iHe = halfedgeIndices[iF][j];
 
-            std::pair<size_t, size_t> edgeKey(std::min(iV, iVNext), std::max(iV, iVNext));
-            std::vector<size_t>& edgeHalfedges = edgeInds.find(edgeKey)->second;
+      std::pair<size_t, size_t> edgeKey(std::min(iV, iVNext), std::max(iV, iVNext));
+      std::vector<size_t>& edgeHalfedges = edgeInds.find(edgeKey)->second;
 
-            // Pick the first halfedge we find which is not this one
-            size_t myTwin = INVALID_IND;
-            for (size_t t : edgeHalfedges) {
-                if (t != iHe) {
-                    myTwin = t;
-                    break;
-                }
-            }
-
-            twinHalfedge[iHe] = myTwin;
+      // Pick the first halfedge we find which is not this one
+      size_t myTwin = INVALID_IND;
+      for (size_t t : edgeHalfedges) {
+        if (t != iHe) {
+          myTwin = t;
+          break;
         }
+      }
+
+      twinHalfedge[iHe] = myTwin;
     }
+  }
 }
 
-bool SurfaceMesh::hasFaceTangentSpaces() {
-    return (faceTangentSpaces.size() > 0);
-}
+bool SurfaceMesh::hasFaceTangentSpaces() { return (faceTangentSpaces.size() > 0); }
 
-bool SurfaceMesh::hasVertexTangentSpaces() {
-    return (vertexTangentSpaces.size() > 0);
-}
+bool SurfaceMesh::hasVertexTangentSpaces() { return (vertexTangentSpaces.size() > 0); }
 
 
 void SurfaceMesh::ensureHaveFaceTangentSpaces() {
-    if (hasFaceTangentSpaces()) return;
-    throw std::runtime_error("No face tangent bases registered. see setFaceTangentBasisX()");
+  if (hasFaceTangentSpaces()) return;
+  throw std::runtime_error("No face tangent bases registered. see setFaceTangentBasisX()");
 }
 
 void SurfaceMesh::ensureHaveVertexTangentSpaces() {
-    if (hasVertexTangentSpaces()) return;
-    throw std::runtime_error("No vertex tangent bases registered. see setVertexTangentBasisX()");
+  if (hasVertexTangentSpaces()) return;
+  throw std::runtime_error("No vertex tangent bases registered. see setVertexTangentBasisX()");
 }
 
 void SurfaceMesh::generateDefaultFaceTangentSpaces() {
-    faceTangentSpaces.resize(nFaces());
+  faceTangentSpaces.resize(nFaces());
 
-    for (size_t iF = 0; iF < nFaces(); iF++) {
-        auto& face = faces[iF];
-        size_t D = face.size();
-        if (D < 2) continue;
+  for (size_t iF = 0; iF < nFaces(); iF++) {
+    auto& face = faces[iF];
+    size_t D = face.size();
+    if (D < 2) continue;
 
-        glm::vec3 pA = vertices[face[0]];
-        glm::vec3 pB = vertices[face[1]];
-        glm::vec3 N = faceNormals[iF];
+    glm::vec3 pA = vertices[face[0]];
+    glm::vec3 pB = vertices[face[1]];
+    glm::vec3 N = faceNormals[iF];
 
-        glm::vec3 basisX = pB - pA;
-        basisX = glm::normalize(basisX - N * glm::dot(N, basisX));
+    glm::vec3 basisX = pB - pA;
+    basisX = glm::normalize(basisX - N * glm::dot(N, basisX));
 
-        glm::vec3 basisY = glm::normalize(-glm::cross(basisX, N));
+    glm::vec3 basisY = glm::normalize(-glm::cross(basisX, N));
 
-        faceTangentSpaces[iF][0] = basisX;
-        faceTangentSpaces[iF][1] = basisY;
-    }
+    faceTangentSpaces[iF][0] = basisX;
+    faceTangentSpaces[iF][1] = basisY;
+  }
 }
 
 void SurfaceMesh::generateDefaultVertexTangentSpaces() {
-    vertexTangentSpaces.resize(nVertices());
-    std::vector<char> hasTangent(nVertices(), false);
+  vertexTangentSpaces.resize(nVertices());
+  std::vector<char> hasTangent(nVertices(), false);
 
-    for (size_t iF = 0; iF < nFaces(); iF++) {
-        auto& face = faces[iF];
-        size_t D = face.size();
-        if (D < 2) continue;
+  for (size_t iF = 0; iF < nFaces(); iF++) {
+    auto& face = faces[iF];
+    size_t D = face.size();
+    if (D < 2) continue;
 
-        for (size_t j = 0; j < D; j++) {
+    for (size_t j = 0; j < D; j++) {
 
-            size_t vA = face[j];
-            size_t vB = face[(j + 1) % D];
+      size_t vA = face[j];
+      size_t vB = face[(j + 1) % D];
 
-            if (hasTangent[vA]) continue;
+      if (hasTangent[vA]) continue;
 
-            glm::vec3 pA = vertices[vA];
-            glm::vec3 pB = vertices[vB];
-            glm::vec3 N = vertexNormals[vA];
+      glm::vec3 pA = vertices[vA];
+      glm::vec3 pB = vertices[vB];
+      glm::vec3 N = vertexNormals[vA];
 
-            glm::vec3 basisX = pB - pA;
-            basisX = basisX - N * glm::dot(N, basisX);
+      glm::vec3 basisX = pB - pA;
+      basisX = basisX - N * glm::dot(N, basisX);
 
-            glm::vec3 basisY = -glm::cross(basisX, N);
+      glm::vec3 basisY = -glm::cross(basisX, N);
 
-            vertexTangentSpaces[vA][0] = basisX;
-            vertexTangentSpaces[vA][1] = basisY;
+      vertexTangentSpaces[vA][0] = basisX;
+      vertexTangentSpaces[vA][1] = basisY;
 
-            hasTangent[vA] = true;
-        }
+      hasTangent[vA] = true;
     }
+  }
 }
 
 void SurfaceMesh::draw() {
-    if (!isEnabled()) {
-        return;
+  if (!isEnabled()) {
+    return;
+  }
+
+  render::engine->setBackfaceCull(backFacePolicy.get() == BackFacePolicy::Cull);
+
+  // If no quantity is drawing the surface, we should draw it
+  if (dominantQuantity == nullptr) {
+
+    if (program == nullptr) {
+      prepare();
+
+      // do this now to reduce lag when picking later, etc
+      preparePick();
     }
 
-    render::engine->setBackfaceCull(backFacePolicy.get() == BackFacePolicy::Cull);
+    // Set uniforms
+    setStructureUniforms(*program);
+    setSurfaceMeshUniforms(*program);
+    program->setUniform("u_baseColor", getSurfaceColor());
 
-    // If no quantity is drawing the surface, we should draw it
-    if (dominantQuantity == nullptr) {
+    program->draw();
+  }
 
-        if (program == nullptr) {
-            prepare();
+  // Draw the quantities
+  for (auto& x : quantities) {
+    x.second->draw();
+  }
 
-            // do this now to reduce lag when picking later, etc
-            preparePick();
-        }
-
-        // Set uniforms
-        setStructureUniforms(*program);
-        setSurfaceMeshUniforms(*program);
-        program->setUniform("u_baseColor", getSurfaceColor());
-
-        program->draw();
-    }
-
-    // Draw the quantities
-    for (auto& x : quantities) {
-        x.second->draw();
-    }
-
-    render::engine->setBackfaceCull(); // return to default setting
+  render::engine->setBackfaceCull(); // return to default setting
 }
 
 void SurfaceMesh::drawPick() {
-    if (!isEnabled()) {
-        return;
-    }
+  if (!isEnabled()) {
+    return;
+  }
 
-    if (pickProgram == nullptr) {
-        preparePick();
-    }
+  if (pickProgram == nullptr) {
+    preparePick();
+  }
 
-    render::engine->setBackfaceCull(backFacePolicy.get() == BackFacePolicy::Cull);
+  render::engine->setBackfaceCull(backFacePolicy.get() == BackFacePolicy::Cull);
 
-    // Set uniforms
-    setStructureUniforms(*pickProgram);
+  // Set uniforms
+  setStructureUniforms(*pickProgram);
 
-    pickProgram->draw();
+  pickProgram->draw();
 
-    render::engine->setBackfaceCull(); // return to default setting
+  render::engine->setBackfaceCull(); // return to default setting
 }
 
 void SurfaceMesh::prepare() {
-    program = render::engine->requestShader("MESH", addSurfaceMeshRules({"SHADE_BASECOLOR"}));
+  program = render::engine->requestShader("MESH", addSurfaceMeshRules({"SHADE_BASECOLOR"}));
 
-    // Populate draw buffers
-    fillGeometryBuffers(*program);
-    render::engine->setMaterial(*program, getMaterial());
+  // Populate draw buffers
+  fillGeometryBuffers(*program);
+  render::engine->setMaterial(*program, getMaterial());
 }
 
 void SurfaceMesh::preparePick() {
 
-    // Create a new program
-    pickProgram = render::engine->requestShader("MESH", addSurfaceMeshRules({"MESH_PROPAGATE_PICK"}, true, false),
-                                                render::ShaderReplacementDefaults::Pick);
+  // Create a new program
+  pickProgram = render::engine->requestShader("MESH", addSurfaceMeshRules({"MESH_PROPAGATE_PICK"}, true, false),
+                                              render::ShaderReplacementDefaults::Pick);
 
-    // Get element indices
-    size_t totalPickElements = nVertices() + nFaces() + nEdges() + nHalfedges() + nCorners();
+  // Get element indices
+  size_t totalPickElements = nVertices() + nFaces() + nEdges() + nHalfedges() + nCorners();
 
-    // In "local" indices, indexing elements only within this triMesh, used for reading later
-    facePickIndStart = nVertices();
-    edgePickIndStart = facePickIndStart + nFaces();
-    halfedgePickIndStart = edgePickIndStart + nEdges();
-    cornerPickIndStart = halfedgePickIndStart + nHalfedges();
+  // In "local" indices, indexing elements only within this triMesh, used for reading later
+  facePickIndStart = nVertices();
+  edgePickIndStart = facePickIndStart + nFaces();
+  halfedgePickIndStart = edgePickIndStart + nEdges();
+  cornerPickIndStart = halfedgePickIndStart + nHalfedges();
 
-    // In "global" indices, indexing all elements in the scene, used to fill buffers for drawing here
-    size_t pickStart = pick::requestPickBufferRange(this, totalPickElements);
-    size_t faceGlobalPickIndStart = pickStart + nVertices();
-    size_t edgeGlobalPickIndStart = faceGlobalPickIndStart + nFaces();
-    size_t halfedgeGlobalPickIndStart = edgeGlobalPickIndStart + nEdges();
-    size_t cornerGlobalPickIndStart = halfedgeGlobalPickIndStart + nHalfedges();
+  // In "global" indices, indexing all elements in the scene, used to fill buffers for drawing here
+  size_t pickStart = pick::requestPickBufferRange(this, totalPickElements);
+  size_t faceGlobalPickIndStart = pickStart + nVertices();
+  size_t edgeGlobalPickIndStart = faceGlobalPickIndStart + nFaces();
+  size_t halfedgeGlobalPickIndStart = edgeGlobalPickIndStart + nEdges();
+  size_t cornerGlobalPickIndStart = halfedgeGlobalPickIndStart + nHalfedges();
 
-    // == Fill buffers
-    bool wantsBarycenters = wantsCullPosition();
+  // == Fill buffers
+  bool wantsBarycenters = wantsCullPosition();
 
-    std::vector<glm::vec3> positions;
-    std::vector<glm::vec3> normals;
-    std::vector<glm::vec3> bcoord;
-    std::vector<std::array<glm::vec3, 3>> vertexColors, edgeColors, halfedgeColors, cornerColors;
-    std::vector<glm::vec3> faceColor;
-    std::vector<glm::vec3> barycenters;
+  std::vector<glm::vec3> positions;
+  std::vector<glm::vec3> normals;
+  std::vector<glm::vec3> bcoord;
+  std::vector<std::array<glm::vec3, 3>> vertexColors, edgeColors, halfedgeColors, cornerColors;
+  std::vector<glm::vec3> faceColor;
+  std::vector<glm::vec3> barycenters;
 
-    // Reserve space
-    positions.reserve(3 * nFacesTriangulation());
-    bcoord.reserve(3 * nFacesTriangulation());
-    vertexColors.reserve(3 * nFacesTriangulation());
-    edgeColors.reserve(3 * nFacesTriangulation());
-    halfedgeColors.reserve(3 * nFacesTriangulation());
-    cornerColors.reserve(3 * nFacesTriangulation());
-    faceColor.reserve(3 * nFacesTriangulation());
-    normals.reserve(3 * nFacesTriangulation());
+  // Reserve space
+  positions.reserve(3 * nFacesTriangulation());
+  bcoord.reserve(3 * nFacesTriangulation());
+  vertexColors.reserve(3 * nFacesTriangulation());
+  edgeColors.reserve(3 * nFacesTriangulation());
+  halfedgeColors.reserve(3 * nFacesTriangulation());
+  cornerColors.reserve(3 * nFacesTriangulation());
+  faceColor.reserve(3 * nFacesTriangulation());
+  normals.reserve(3 * nFacesTriangulation());
+  if (wantsBarycenters) {
+    barycenters.reserve(3 * nFacesTriangulation());
+  }
+
+  // Build all quantities in each face
+  for (size_t iF = 0; iF < nFaces(); iF++) {
+    auto& face = faces[iF];
+    size_t D = face.size();
+    glm::vec3 faceN = faceNormals[iF];
+
+    glm::vec3 barycenter;
     if (wantsBarycenters) {
-        barycenters.reserve(3 * nFacesTriangulation());
+      barycenter = faceCenter(iF);
     }
 
-    // Build all quantities in each face
-    for (size_t iF = 0; iF < nFaces(); iF++) {
-        auto& face = faces[iF];
-        size_t D = face.size();
-        glm::vec3 faceN = faceNormals[iF];
+    // implicitly triangulate from root
+    size_t vRoot = face[0];
+    glm::vec3 pRoot = vertices[vRoot];
+    for (size_t j = 1; (j + 1) < D; j++) {
+      size_t vB = face[j];
+      glm::vec3 pB = vertices[vB];
+      size_t vC = face[(j + 1) % D];
+      glm::vec3 pC = vertices[vC];
 
-        glm::vec3 barycenter;
-        if (wantsBarycenters) {
-            barycenter = faceCenter(iF);
-        }
+      glm::vec3 fColor = pick::indToVec(iF + faceGlobalPickIndStart);
+      std::array<size_t, 3> vertexInds = {vRoot, vB, vC};
 
-        // implicitly triangulate from root
-        size_t vRoot = face[0];
-        glm::vec3 pRoot = vertices[vRoot];
-        for (size_t j = 1; (j + 1) < D; j++) {
-            size_t vB = face[j];
-            glm::vec3 pB = vertices[vB];
-            size_t vC = face[(j + 1) % D];
-            glm::vec3 pC = vertices[vC];
+      positions.push_back(pRoot);
+      positions.push_back(pB);
+      positions.push_back(pC);
 
-            glm::vec3 fColor = pick::indToVec(iF + faceGlobalPickIndStart);
-            std::array<size_t, 3> vertexInds = {vRoot, vB, vC};
+      normals.push_back(faceN);
+      normals.push_back(faceN);
+      normals.push_back(faceN);
 
-            positions.push_back(pRoot);
-            positions.push_back(pB);
-            positions.push_back(pC);
+      if (wantsBarycenters) {
+        barycenters.push_back(barycenter);
+        barycenters.push_back(barycenter);
+        barycenters.push_back(barycenter);
+      }
 
-            normals.push_back(faceN);
-            normals.push_back(faceN);
-            normals.push_back(faceN);
+      // Build all quantities
+      std::array<glm::vec3, 3> vColor;
 
-            if (wantsBarycenters) {
-                barycenters.push_back(barycenter);
-                barycenters.push_back(barycenter);
-                barycenters.push_back(barycenter);
-            }
+      for (size_t i = 0; i < 3; i++) {
+        // Want just one copy of face color, so we can build it in the usual way
+        faceColor.push_back(fColor);
 
-            // Build all quantities
-            std::array<glm::vec3, 3> vColor;
+        // Vertex index color
+        vColor[i] = pick::indToVec(vertexInds[i] + pickStart);
+      }
 
-            for (size_t i = 0; i < 3; i++) {
-                // Want just one copy of face color, so we can build it in the usual way
-                faceColor.push_back(fColor);
+      std::array<glm::vec3, 3> eColor = {fColor, pick::indToVec(edgeIndices[iF][j] + edgeGlobalPickIndStart), fColor};
+      std::array<glm::vec3, 3> heColor = {fColor, pick::indToVec(halfedgeIndices[iF][j] + halfedgeGlobalPickIndStart),
+                                          fColor};
+      std::array<glm::vec3, 3> cColor = {fColor, pick::indToVec(halfedgeIndices[iF][j] + cornerGlobalPickIndStart),
+                                         fColor};
 
-                // Vertex index color
-                vColor[i] = pick::indToVec(vertexInds[i] + pickStart);
-            }
+      // First edge is a real edge
+      if (j == 1) {
+        eColor[0] = pick::indToVec(edgeIndices[iF][0] + edgeGlobalPickIndStart);
+        heColor[0] = pick::indToVec(halfedgeIndices[iF][0] + halfedgeGlobalPickIndStart);
+        cColor[0] = pick::indToVec(halfedgeIndices[iF][0] + cornerGlobalPickIndStart);
+      }
+      // Last is a real edge
+      if (j + 2 == D) {
+        eColor[2] = pick::indToVec(edgeIndices[iF].back() + edgeGlobalPickIndStart);
+        heColor[2] = pick::indToVec(halfedgeIndices[iF].back() + halfedgeGlobalPickIndStart);
+        cColor[2] = pick::indToVec(halfedgeIndices[iF].back() + cornerGlobalPickIndStart);
+      }
 
-            std::array<glm::vec3, 3> eColor = {fColor, pick::indToVec(edgeIndices[iF][j] + edgeGlobalPickIndStart),
-                                               fColor};
-            std::array<glm::vec3, 3> heColor = {
-                fColor, pick::indToVec(halfedgeIndices[iF][j] + halfedgeGlobalPickIndStart), fColor};
-            std::array<glm::vec3, 3> cColor = {
-                fColor, pick::indToVec(halfedgeIndices[iF][j] + cornerGlobalPickIndStart), fColor};
+      // Push three copies of the values needed at each vertex
+      for (int j = 0; j < 3; j++) {
+        vertexColors.push_back(vColor);
+        edgeColors.push_back(eColor);
+        halfedgeColors.push_back(heColor);
+        cornerColors.push_back(cColor);
+      }
 
-            // First edge is a real edge
-            if (j == 1) {
-                eColor[0] = pick::indToVec(edgeIndices[iF][0] + edgeGlobalPickIndStart);
-                heColor[0] = pick::indToVec(halfedgeIndices[iF][0] + halfedgeGlobalPickIndStart);
-                cColor[0] = pick::indToVec(halfedgeIndices[iF][0] + cornerGlobalPickIndStart);
-            }
-            // Last is a real edge
-            if (j + 2 == D) {
-                eColor[2] = pick::indToVec(edgeIndices[iF].back() + edgeGlobalPickIndStart);
-                heColor[2] = pick::indToVec(halfedgeIndices[iF].back() + halfedgeGlobalPickIndStart);
-                cColor[2] = pick::indToVec(halfedgeIndices[iF].back() + cornerGlobalPickIndStart);
-            }
-
-            // Push three copies of the values needed at each vertex
-            for (int j = 0; j < 3; j++) {
-                vertexColors.push_back(vColor);
-                edgeColors.push_back(eColor);
-                halfedgeColors.push_back(heColor);
-                cornerColors.push_back(cColor);
-            }
-
-            // Barycoords
-            bcoord.push_back(glm::vec3{1.0, 0.0, 0.0});
-            bcoord.push_back(glm::vec3{0.0, 1.0, 0.0});
-            bcoord.push_back(glm::vec3{0.0, 0.0, 1.0});
-        }
+      // Barycoords
+      bcoord.push_back(glm::vec3{1.0, 0.0, 0.0});
+      bcoord.push_back(glm::vec3{0.0, 1.0, 0.0});
+      bcoord.push_back(glm::vec3{0.0, 0.0, 1.0});
     }
+  }
 
-    // Store data in buffers
-    pickProgram->setAttribute("a_position", positions);
-    pickProgram->setAttribute("a_barycoord", bcoord);
-    pickProgram->setAttribute("a_normal", normals);
-    pickProgram->setAttribute<glm::vec3, 3>("a_vertexColors", vertexColors);
-    pickProgram->setAttribute<glm::vec3, 3>("a_edgeColors", edgeColors);
-    pickProgram->setAttribute<glm::vec3, 3>("a_halfedgeColors", halfedgeColors);
-    pickProgram->setAttribute<glm::vec3, 3>("a_cornerColors", cornerColors);
-    pickProgram->setAttribute("a_faceColor", faceColor);
-    if (wantsCullPosition()) {
-        pickProgram->setAttribute("a_cullPos", barycenters);
-    }
+  // Store data in buffers
+  pickProgram->setAttribute("a_position", positions);
+  pickProgram->setAttribute("a_barycoord", bcoord);
+  pickProgram->setAttribute("a_normal", normals);
+  pickProgram->setAttribute<glm::vec3, 3>("a_vertexColors", vertexColors);
+  pickProgram->setAttribute<glm::vec3, 3>("a_edgeColors", edgeColors);
+  pickProgram->setAttribute<glm::vec3, 3>("a_halfedgeColors", halfedgeColors);
+  pickProgram->setAttribute<glm::vec3, 3>("a_cornerColors", cornerColors);
+  pickProgram->setAttribute("a_faceColor", faceColor);
+  if (wantsCullPosition()) {
+    pickProgram->setAttribute("a_cullPos", barycenters);
+  }
 }
 
 std::vector<std::string> SurfaceMesh::addSurfaceMeshRules(std::vector<std::string> initRules, bool withMesh,
                                                           bool withSurfaceShade) {
-    initRules = addStructureRules(initRules);
+  initRules = addStructureRules(initRules);
 
-    if (withMesh) {
+  if (withMesh) {
 
-        if (withSurfaceShade) {
-            // rules that only get used when we're shading the surface of the mesh
-            if (getEdgeWidth() > 0) {
-                initRules.push_back("MESH_WIREFRAME");
-            }
-            if (backFacePolicy.get() == BackFacePolicy::Different) {
-                initRules.push_back("MESH_BACKFACE_DARKEN");
-            }
-            if (backFacePolicy.get() == BackFacePolicy::Custom) {
-                initRules.push_back("MESH_BACKFACE_DIFFERENT");
-            }
-        }
-
-        if (backFacePolicy.get() == BackFacePolicy::Identical) {
-            initRules.push_back("MESH_BACKFACE_NORMAL_FLIP");
-        }
-
-        if (backFacePolicy.get() == BackFacePolicy::Different) {
-            initRules.push_back("MESH_BACKFACE_NORMAL_FLIP");
-        }
-
-        if (backFacePolicy.get() == BackFacePolicy::Custom) {
-            initRules.push_back("MESH_BACKFACE_NORMAL_FLIP");
-        }
-
-        if (wantsCullPosition()) {
-            initRules.push_back("MESH_PROPAGATE_CULLPOS");
-        }
+    if (withSurfaceShade) {
+      // rules that only get used when we're shading the surface of the mesh
+      if (getEdgeWidth() > 0) {
+        initRules.push_back("MESH_WIREFRAME");
+      }
+      if (backFacePolicy.get() == BackFacePolicy::Different) {
+        initRules.push_back("MESH_BACKFACE_DARKEN");
+      }
+      if (backFacePolicy.get() == BackFacePolicy::Custom) {
+        initRules.push_back("MESH_BACKFACE_DIFFERENT");
+      }
     }
-    return initRules;
+
+    if (backFacePolicy.get() == BackFacePolicy::Identical) {
+      initRules.push_back("MESH_BACKFACE_NORMAL_FLIP");
+    }
+
+    if (backFacePolicy.get() == BackFacePolicy::Different) {
+      initRules.push_back("MESH_BACKFACE_NORMAL_FLIP");
+    }
+
+    if (backFacePolicy.get() == BackFacePolicy::Custom) {
+      initRules.push_back("MESH_BACKFACE_NORMAL_FLIP");
+    }
+
+    if (wantsCullPosition()) {
+      initRules.push_back("MESH_PROPAGATE_CULLPOS");
+    }
+  }
+  return initRules;
 }
 
 void SurfaceMesh::setSurfaceMeshUniforms(render::ShaderProgram& p) {
-    if (getEdgeWidth() > 0) {
-        p.setUniform("u_edgeWidth", getEdgeWidth() * render::engine->getCurrentPixelScaling());
-        p.setUniform("u_edgeColor", getEdgeColor());
-    }
-    if (backFacePolicy.get() == BackFacePolicy::Custom) {
-        p.setUniform("u_backfaceColor", getBackFaceColor());
-    }
+  if (getEdgeWidth() > 0) {
+    p.setUniform("u_edgeWidth", getEdgeWidth() * render::engine->getCurrentPixelScaling());
+    p.setUniform("u_edgeColor", getEdgeColor());
+  }
+  if (backFacePolicy.get() == BackFacePolicy::Custom) {
+    p.setUniform("u_backfaceColor", getBackFaceColor());
+  }
 }
 
 void SurfaceMesh::fillGeometryBuffers(render::ShaderProgram& p) {
-    std::vector<glm::vec3> positions;
-    std::vector<glm::vec3> normals;
-    std::vector<glm::vec3> bcoord;
-    std::vector<glm::vec3> edgeReal;
-    std::vector<glm::vec3> barycenters;
+  std::vector<glm::vec3> positions;
+  std::vector<glm::vec3> normals;
+  std::vector<glm::vec3> bcoord;
+  std::vector<glm::vec3> edgeReal;
+  std::vector<glm::vec3> barycenters;
 
-    bool wantsBary = p.hasAttribute("a_barycoord");
-    bool wantsEdge = p.hasAttribute("a_edgeIsReal");
-    bool wantsBarycenters = wantsCullPosition();
+  bool wantsBary = p.hasAttribute("a_barycoord");
+  bool wantsEdge = p.hasAttribute("a_edgeIsReal");
+  bool wantsBarycenters = wantsCullPosition();
 
-    positions.reserve(3 * nFacesTriangulation());
-    normals.reserve(3 * nFacesTriangulation());
-    if (wantsBary) {
-        bcoord.reserve(3 * nFacesTriangulation());
-    }
-    if (wantsEdge) {
-        edgeReal.reserve(3 * nFacesTriangulation());
-    }
+  positions.reserve(3 * nFacesTriangulation());
+  normals.reserve(3 * nFacesTriangulation());
+  if (wantsBary) {
+    bcoord.reserve(3 * nFacesTriangulation());
+  }
+  if (wantsEdge) {
+    edgeReal.reserve(3 * nFacesTriangulation());
+  }
+  if (wantsBarycenters) {
+    barycenters.reserve(3 * nFacesTriangulation());
+  }
+
+  for (size_t iF = 0; iF < nFaces(); iF++) {
+    auto& face = faces[iF];
+    size_t D = face.size();
+    glm::vec3 faceN = faceNormals[iF];
+
+    glm::vec3 barycenter;
     if (wantsBarycenters) {
-        barycenters.reserve(3 * nFacesTriangulation());
+      barycenter = faceCenter(iF);
     }
 
-    for (size_t iF = 0; iF < nFaces(); iF++) {
-        auto& face = faces[iF];
-        size_t D = face.size();
-        glm::vec3 faceN = faceNormals[iF];
+    // implicitly triangulate from root
+    size_t vRoot = face[0];
+    glm::vec3 pRoot = vertices[vRoot];
+    for (size_t j = 1; (j + 1) < D; j++) {
+      size_t vB = face[j];
+      glm::vec3 pB = vertices[vB];
+      size_t vC = face[(j + 1) % D];
+      glm::vec3 pC = vertices[vC];
 
-        glm::vec3 barycenter;
-        if (wantsBarycenters) {
-            barycenter = faceCenter(iF);
+      positions.push_back(pRoot);
+      positions.push_back(pB);
+      positions.push_back(pC);
+
+      if (isSmoothShade()) {
+        normals.push_back(vertexNormals[vRoot]);
+        normals.push_back(vertexNormals[vB]);
+        normals.push_back(vertexNormals[vC]);
+      } else {
+        normals.push_back(faceN);
+        normals.push_back(faceN);
+        normals.push_back(faceN);
+      }
+
+      if (wantsBary) {
+        bcoord.push_back(glm::vec3{1., 0., 0.});
+        bcoord.push_back(glm::vec3{0., 1., 0.});
+        bcoord.push_back(glm::vec3{0., 0., 1.});
+      }
+
+      if (wantsBarycenters) {
+        barycenters.push_back(barycenter);
+        barycenters.push_back(barycenter);
+        barycenters.push_back(barycenter);
+      }
+
+      if (wantsEdge) {
+        glm::vec3 edgeRealV{0., 1., 0.};
+        if (j == 1) {
+          edgeRealV.x = 1.;
         }
-
-        // implicitly triangulate from root
-        size_t vRoot = face[0];
-        glm::vec3 pRoot = vertices[vRoot];
-        for (size_t j = 1; (j + 1) < D; j++) {
-            size_t vB = face[j];
-            glm::vec3 pB = vertices[vB];
-            size_t vC = face[(j + 1) % D];
-            glm::vec3 pC = vertices[vC];
-
-            positions.push_back(pRoot);
-            positions.push_back(pB);
-            positions.push_back(pC);
-
-            if (isSmoothShade()) {
-                normals.push_back(vertexNormals[vRoot]);
-                normals.push_back(vertexNormals[vB]);
-                normals.push_back(vertexNormals[vC]);
-            } else {
-                normals.push_back(faceN);
-                normals.push_back(faceN);
-                normals.push_back(faceN);
-            }
-
-            if (wantsBary) {
-                bcoord.push_back(glm::vec3{1., 0., 0.});
-                bcoord.push_back(glm::vec3{0., 1., 0.});
-                bcoord.push_back(glm::vec3{0., 0., 1.});
-            }
-
-            if (wantsBarycenters) {
-                barycenters.push_back(barycenter);
-                barycenters.push_back(barycenter);
-                barycenters.push_back(barycenter);
-            }
-
-            if (wantsEdge) {
-                glm::vec3 edgeRealV{0., 1., 0.};
-                if (j == 1) {
-                    edgeRealV.x = 1.;
-                }
-                if (j + 2 == D) {
-                    edgeRealV.z = 1.;
-                }
-                edgeReal.push_back(edgeRealV);
-                edgeReal.push_back(edgeRealV);
-                edgeReal.push_back(edgeRealV);
-            }
+        if (j + 2 == D) {
+          edgeRealV.z = 1.;
         }
+        edgeReal.push_back(edgeRealV);
+        edgeReal.push_back(edgeRealV);
+        edgeReal.push_back(edgeRealV);
+      }
     }
+  }
 
-    // Store data in buffers
-    p.setAttribute("a_position", positions);
-    p.setAttribute("a_normal", normals);
-    if (wantsBary) {
-        p.setAttribute("a_barycoord", bcoord);
-    }
-    if (wantsEdge) {
-        p.setAttribute("a_edgeIsReal", edgeReal);
-    }
-    if (wantsCullPosition()) {
-        p.setAttribute("a_cullPos", barycenters);
-    }
+  // Store data in buffers
+  p.setAttribute("a_position", positions);
+  p.setAttribute("a_normal", normals);
+  if (wantsBary) {
+    p.setAttribute("a_barycoord", bcoord);
+  }
+  if (wantsEdge) {
+    p.setAttribute("a_edgeIsReal", edgeReal);
+  }
+  if (wantsCullPosition()) {
+    p.setAttribute("a_cullPos", barycenters);
+  }
 }
 
 void SurfaceMesh::buildPickUI(size_t localPickID) {
 
-    // Selection type
-    if (localPickID < facePickIndStart) {
-        buildVertexInfoGui(localPickID);
-    } else if (localPickID < edgePickIndStart) {
-        buildFaceInfoGui(localPickID - facePickIndStart);
-    } else if (localPickID < halfedgePickIndStart) {
-        buildEdgeInfoGui(localPickID - edgePickIndStart);
-    } else if (localPickID < cornerPickIndStart) {
-        buildHalfedgeInfoGui(localPickID - halfedgePickIndStart);
-    } else {
-        buildCornerInfoGui(localPickID - cornerPickIndStart);
-    }
+  // Selection type
+  if (localPickID < facePickIndStart) {
+    buildVertexInfoGui(localPickID);
+  } else if (localPickID < edgePickIndStart) {
+    buildFaceInfoGui(localPickID - facePickIndStart);
+  } else if (localPickID < halfedgePickIndStart) {
+    buildEdgeInfoGui(localPickID - edgePickIndStart);
+  } else if (localPickID < cornerPickIndStart) {
+    buildHalfedgeInfoGui(localPickID - halfedgePickIndStart);
+  } else {
+    buildCornerInfoGui(localPickID - cornerPickIndStart);
+  }
 }
 
 // void SurfaceMesh::getPickedElement(size_t localPickID, VertexPtr& vOut, FacePtr& fOut, EdgePtr& eOut,
@@ -702,12 +697,12 @@ void SurfaceMesh::buildPickUI(size_t localPickID) {
 
 glm::vec2 SurfaceMesh::projectToScreenSpace(glm::vec3 coord) {
 
-    glm::mat4 viewMat = getModelView();
-    glm::mat4 projMat = view::getCameraPerspectiveMatrix();
-    glm::vec4 coord4(coord.x, coord.y, coord.z, 1.0);
-    glm::vec4 screenPoint = projMat * viewMat * coord4;
+  glm::mat4 viewMat = getModelView();
+  glm::mat4 projMat = view::getCameraPerspectiveMatrix();
+  glm::vec4 coord4(coord.x, coord.y, coord.z, 1.0);
+  glm::vec4 screenPoint = projMat * viewMat * coord4;
 
-    return glm::vec2{screenPoint.x, screenPoint.y} / screenPoint.w;
+  return glm::vec2{screenPoint.x, screenPoint.y} / screenPoint.w;
 }
 
 // TODO fix up all of these
@@ -752,311 +747,309 @@ glm::vec2 SurfaceMesh::projectToScreenSpace(glm::vec3 coord) {
 
 void SurfaceMesh::buildVertexInfoGui(size_t vInd) {
 
-    size_t displayInd = vInd;
-    if (vertexPerm.size() > 0) {
-        displayInd = vertexPerm[vInd];
-    }
-    ImGui::TextUnformatted(("Vertex #" + std::to_string(displayInd)).c_str());
+  size_t displayInd = vInd;
+  if (vertexPerm.size() > 0) {
+    displayInd = vertexPerm[vInd];
+  }
+  ImGui::TextUnformatted(("Vertex #" + std::to_string(displayInd)).c_str());
 
-    std::stringstream buffer;
-    buffer << vertices[vInd];
-    ImGui::TextUnformatted(("Position: " + buffer.str()).c_str());
+  std::stringstream buffer;
+  buffer << vertices[vInd];
+  ImGui::TextUnformatted(("Position: " + buffer.str()).c_str());
 
-    ImGui::Spacing();
-    ImGui::Spacing();
-    ImGui::Spacing();
-    ImGui::Indent(20.);
+  ImGui::Spacing();
+  ImGui::Spacing();
+  ImGui::Spacing();
+  ImGui::Indent(20.);
 
-    // Build GUI to show the quantities
-    ImGui::Columns(2);
-    ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
-    for (auto& x : quantities) {
-        x.second->buildVertexInfoGUI(vInd);
-    }
+  // Build GUI to show the quantities
+  ImGui::Columns(2);
+  ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
+  for (auto& x : quantities) {
+    x.second->buildVertexInfoGUI(vInd);
+  }
 
-    ImGui::Indent(-20.);
+  ImGui::Indent(-20.);
 }
 
 void SurfaceMesh::buildFaceInfoGui(size_t fInd) {
-    size_t displayInd = fInd;
-    if (facePerm.size() > 0) {
-        displayInd = facePerm[fInd];
-    }
-    ImGui::TextUnformatted(("Face #" + std::to_string(displayInd)).c_str());
+  size_t displayInd = fInd;
+  if (facePerm.size() > 0) {
+    displayInd = facePerm[fInd];
+  }
+  ImGui::TextUnformatted(("Face #" + std::to_string(displayInd)).c_str());
 
-    ImGui::Spacing();
-    ImGui::Spacing();
-    ImGui::Spacing();
-    ImGui::Indent(20.);
+  ImGui::Spacing();
+  ImGui::Spacing();
+  ImGui::Spacing();
+  ImGui::Indent(20.);
 
-    // Build GUI to show the quantities
-    ImGui::Columns(2);
-    ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
-    for (auto& x : quantities) {
-        x.second->buildFaceInfoGUI(fInd);
-    }
+  // Build GUI to show the quantities
+  ImGui::Columns(2);
+  ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
+  for (auto& x : quantities) {
+    x.second->buildFaceInfoGUI(fInd);
+  }
 
-    ImGui::Indent(-20.);
+  ImGui::Indent(-20.);
 }
 
 void SurfaceMesh::buildEdgeInfoGui(size_t eInd) {
-    size_t displayInd = eInd;
-    if (edgePerm.size() > 0) {
-        displayInd = edgePerm[eInd];
-    }
-    ImGui::TextUnformatted(("Edge #" + std::to_string(displayInd)).c_str());
+  size_t displayInd = eInd;
+  if (edgePerm.size() > 0) {
+    displayInd = edgePerm[eInd];
+  }
+  ImGui::TextUnformatted(("Edge #" + std::to_string(displayInd)).c_str());
 
-    ImGui::Spacing();
-    ImGui::Spacing();
-    ImGui::Spacing();
-    ImGui::Indent(20.);
+  ImGui::Spacing();
+  ImGui::Spacing();
+  ImGui::Spacing();
+  ImGui::Indent(20.);
 
-    // Build GUI to show the quantities
-    ImGui::Columns(2);
-    ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
-    for (auto& x : quantities) {
-        x.second->buildEdgeInfoGUI(eInd);
-    }
+  // Build GUI to show the quantities
+  ImGui::Columns(2);
+  ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
+  for (auto& x : quantities) {
+    x.second->buildEdgeInfoGUI(eInd);
+  }
 
-    ImGui::Indent(-20.);
+  ImGui::Indent(-20.);
 }
 
 void SurfaceMesh::buildHalfedgeInfoGui(size_t heInd) {
-    size_t displayInd = heInd;
-    if (halfedgePerm.size() > 0) {
-        displayInd = halfedgePerm[heInd];
-    }
-    ImGui::TextUnformatted(("Halfedge #" + std::to_string(displayInd)).c_str());
+  size_t displayInd = heInd;
+  if (halfedgePerm.size() > 0) {
+    displayInd = halfedgePerm[heInd];
+  }
+  ImGui::TextUnformatted(("Halfedge #" + std::to_string(displayInd)).c_str());
 
-    ImGui::Spacing();
-    ImGui::Spacing();
-    ImGui::Spacing();
-    ImGui::Indent(20.);
+  ImGui::Spacing();
+  ImGui::Spacing();
+  ImGui::Spacing();
+  ImGui::Indent(20.);
 
-    // Build GUI to show the quantities
-    ImGui::Columns(2);
-    ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
-    for (auto& x : quantities) {
-        x.second->buildHalfedgeInfoGUI(heInd);
-    }
+  // Build GUI to show the quantities
+  ImGui::Columns(2);
+  ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
+  for (auto& x : quantities) {
+    x.second->buildHalfedgeInfoGUI(heInd);
+  }
 
-    ImGui::Indent(-20.);
+  ImGui::Indent(-20.);
 }
 
 void SurfaceMesh::buildCornerInfoGui(size_t cInd) {
-    size_t displayInd = cInd;
-    if (cornerPerm.size() > 0) {
-        displayInd = cornerPerm[cInd];
-    }
-    ImGui::TextUnformatted(("Corner #" + std::to_string(displayInd)).c_str());
+  size_t displayInd = cInd;
+  if (cornerPerm.size() > 0) {
+    displayInd = cornerPerm[cInd];
+  }
+  ImGui::TextUnformatted(("Corner #" + std::to_string(displayInd)).c_str());
 
-    ImGui::Spacing();
-    ImGui::Spacing();
-    ImGui::Spacing();
-    ImGui::Indent(20.);
+  ImGui::Spacing();
+  ImGui::Spacing();
+  ImGui::Spacing();
+  ImGui::Indent(20.);
 
-    // Build GUI to show the quantities
-    ImGui::Columns(2);
-    ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
-    for (auto& x : quantities) {
-        x.second->buildCornerInfoGUI(cInd);
-    }
+  // Build GUI to show the quantities
+  ImGui::Columns(2);
+  ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
+  for (auto& x : quantities) {
+    x.second->buildCornerInfoGUI(cInd);
+  }
 
-    ImGui::Indent(-20.);
+  ImGui::Indent(-20.);
 }
 
 
 void SurfaceMesh::buildCustomUI() {
 
-    // Print stats
-    long long int nVertsL = static_cast<long long int>(nVertices());
-    long long int nFacesL = static_cast<long long int>(nFaces());
-    ImGui::Text("#verts: %lld  #faces: %lld", nVertsL, nFacesL);
+  // Print stats
+  long long int nVertsL = static_cast<long long int>(nVertices());
+  long long int nFacesL = static_cast<long long int>(nFaces());
+  ImGui::Text("#verts: %lld  #faces: %lld", nVertsL, nFacesL);
 
-    { // colors
-        if (ImGui::ColorEdit3("Color", &surfaceColor.get()[0], ImGuiColorEditFlags_NoInputs))
-            setSurfaceColor(surfaceColor.get());
-        ImGui::SameLine();
-    }
-
-    { // Flat shading or smooth shading?
-        ImGui::SameLine();
-        if (ImGui::Checkbox("Smooth", &shadeSmooth.get())) setSmoothShade(shadeSmooth.get());
-    }
-
+  { // colors
+    if (ImGui::ColorEdit3("Color", &surfaceColor.get()[0], ImGuiColorEditFlags_NoInputs))
+      setSurfaceColor(surfaceColor.get());
     ImGui::SameLine();
-    { // Edge options
-        ImGui::PushItemWidth(100);
-        if (edgeWidth.get() == 0.) {
-            bool showEdges = false;
-            if (ImGui::Checkbox("Edges", &showEdges)) {
-                setEdgeWidth(1.);
-            }
-        } else {
-            bool showEdges = true;
-            if (ImGui::Checkbox("Edges", &showEdges)) {
-                setEdgeWidth(0.);
-            }
+  }
 
-            // Edge color
-            ImGui::PushItemWidth(100);
-            if (ImGui::ColorEdit3("Edge Color", &edgeColor.get()[0], ImGuiColorEditFlags_NoInputs))
-                setEdgeColor(edgeColor.get());
-            ImGui::PopItemWidth();
+  { // Flat shading or smooth shading?
+    ImGui::SameLine();
+    if (ImGui::Checkbox("Smooth", &shadeSmooth.get())) setSmoothShade(shadeSmooth.get());
+  }
 
-            // Edge width
-            ImGui::SameLine();
-            ImGui::PushItemWidth(60);
-            if (ImGui::SliderFloat("Width", &edgeWidth.get(), 0.001, 2.)) {
-                // NOTE: this intentionally circumvents the setEdgeWidth() setter to avoid repopulating the buffer as
-                // the slider is dragged---otherwise we repopulate the buffer on every change, which mostly works fine.
-                // This is a lazy solution instead of better state/buffer management. setEdgeWidth(getEdgeWidth());
-                edgeWidth.manuallyChanged();
-                requestRedraw();
-            }
-            ImGui::PopItemWidth();
-        }
-        ImGui::PopItemWidth();
+  ImGui::SameLine();
+  { // Edge options
+    ImGui::PushItemWidth(100);
+    if (edgeWidth.get() == 0.) {
+      bool showEdges = false;
+      if (ImGui::Checkbox("Edges", &showEdges)) {
+        setEdgeWidth(1.);
+      }
+    } else {
+      bool showEdges = true;
+      if (ImGui::Checkbox("Edges", &showEdges)) {
+        setEdgeWidth(0.);
+      }
+
+      // Edge color
+      ImGui::PushItemWidth(100);
+      if (ImGui::ColorEdit3("Edge Color", &edgeColor.get()[0], ImGuiColorEditFlags_NoInputs))
+        setEdgeColor(edgeColor.get());
+      ImGui::PopItemWidth();
+
+      // Edge width
+      ImGui::SameLine();
+      ImGui::PushItemWidth(60);
+      if (ImGui::SliderFloat("Width", &edgeWidth.get(), 0.001, 2.)) {
+        // NOTE: this intentionally circumvents the setEdgeWidth() setter to avoid repopulating the buffer as
+        // the slider is dragged---otherwise we repopulate the buffer on every change, which mostly works fine.
+        // This is a lazy solution instead of better state/buffer management. setEdgeWidth(getEdgeWidth());
+        edgeWidth.manuallyChanged();
+        requestRedraw();
+      }
+      ImGui::PopItemWidth();
     }
-    if (backFacePolicy.get() == BackFacePolicy::Custom) {
-        if (ImGui::ColorEdit3("Backface Color", &backFaceColor.get()[0], ImGuiColorEditFlags_NoInputs))
-            setBackFaceColor(backFaceColor.get());
-    }
+    ImGui::PopItemWidth();
+  }
+  if (backFacePolicy.get() == BackFacePolicy::Custom) {
+    if (ImGui::ColorEdit3("Backface Color", &backFaceColor.get()[0], ImGuiColorEditFlags_NoInputs))
+      setBackFaceColor(backFaceColor.get());
+  }
 }
 
 
 void SurfaceMesh::buildCustomOptionsUI() {
-    if (render::buildMaterialOptionsGui(material.get())) {
-        material.manuallyChanged();
-        setMaterial(material.get()); // trigger the other updates that happen on set()
-    }
+  if (render::buildMaterialOptionsGui(material.get())) {
+    material.manuallyChanged();
+    setMaterial(material.get()); // trigger the other updates that happen on set()
+  }
 
-    // backfaces
-    if (ImGui::BeginMenu("Back Face Policy")) {
-        if (ImGui::MenuItem("identical shading", NULL, backFacePolicy.get() == BackFacePolicy::Identical))
-            setBackFacePolicy(BackFacePolicy::Identical);
-        if (ImGui::MenuItem("different shading", NULL, backFacePolicy.get() == BackFacePolicy::Different))
-            setBackFacePolicy(BackFacePolicy::Different);
-        if (ImGui::MenuItem("custom shading", NULL, backFacePolicy.get() == BackFacePolicy::Custom))
-            setBackFacePolicy(BackFacePolicy::Custom);
-        if (ImGui::MenuItem("cull", NULL, backFacePolicy.get() == BackFacePolicy::Cull))
-            setBackFacePolicy(BackFacePolicy::Cull);
-        ImGui::EndMenu();
-    }
+  // backfaces
+  if (ImGui::BeginMenu("Back Face Policy")) {
+    if (ImGui::MenuItem("identical shading", NULL, backFacePolicy.get() == BackFacePolicy::Identical))
+      setBackFacePolicy(BackFacePolicy::Identical);
+    if (ImGui::MenuItem("different shading", NULL, backFacePolicy.get() == BackFacePolicy::Different))
+      setBackFacePolicy(BackFacePolicy::Different);
+    if (ImGui::MenuItem("custom shading", NULL, backFacePolicy.get() == BackFacePolicy::Custom))
+      setBackFacePolicy(BackFacePolicy::Custom);
+    if (ImGui::MenuItem("cull", NULL, backFacePolicy.get() == BackFacePolicy::Cull))
+      setBackFacePolicy(BackFacePolicy::Cull);
+    ImGui::EndMenu();
+  }
 }
 
 
 void SurfaceMesh::refresh() {
-    computeGeometryData();
-    program.reset();
-    pickProgram.reset();
-    requestRedraw();
-    QuantityStructure<SurfaceMesh>::refresh(); // call base class version, which refreshes quantities
+  computeGeometryData();
+  program.reset();
+  pickProgram.reset();
+  requestRedraw();
+  QuantityStructure<SurfaceMesh>::refresh(); // call base class version, which refreshes quantities
 }
 
 void SurfaceMesh::geometryChanged() {
 
-    computeGeometryData();
-    if (program) {
-        fillGeometryBuffers(*program);
-    }
-    if (pickProgram) {
-        fillGeometryBuffers(*pickProgram);
-    }
-    requestRedraw();
-    QuantityStructure<SurfaceMesh>::refresh();
+  computeGeometryData();
+  if (program) {
+    fillGeometryBuffers(*program);
+  }
+  if (pickProgram) {
+    fillGeometryBuffers(*pickProgram);
+  }
+  requestRedraw();
+  QuantityStructure<SurfaceMesh>::refresh();
 }
 
 void SurfaceMesh::updateObjectSpaceBounds() {
-    // bounding box
-    glm::vec3 min = glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
-    glm::vec3 max = -glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
-    for (const glm::vec3& p : vertices) {
-        min = componentwiseMin(min, p);
-        max = componentwiseMax(max, p);
-    }
-    objectSpaceBoundingBox = std::make_tuple(min, max);
+  // bounding box
+  glm::vec3 min = glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
+  glm::vec3 max = -glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
+  for (const glm::vec3& p : vertices) {
+    min = componentwiseMin(min, p);
+    max = componentwiseMax(max, p);
+  }
+  objectSpaceBoundingBox = std::make_tuple(min, max);
 
-    // length scale, as twice the radius from the center of the bounding box
-    glm::vec3 center = 0.5f * (min + max);
-    float lengthScale = 0.0;
-    for (const glm::vec3& p : vertices) {
-        lengthScale = std::max(lengthScale, glm::length2(p - center));
-    }
-    objectSpaceLengthScale = 2 * std::sqrt(lengthScale);
+  // length scale, as twice the radius from the center of the bounding box
+  glm::vec3 center = 0.5f * (min + max);
+  float lengthScale = 0.0;
+  for (const glm::vec3& p : vertices) {
+    lengthScale = std::max(lengthScale, glm::length2(p - center));
+  }
+  objectSpaceLengthScale = 2 * std::sqrt(lengthScale);
 }
 
-std::string SurfaceMesh::typeName() {
-    return structureTypeName;
-}
+std::string SurfaceMesh::typeName() { return structureTypeName; }
 
 long long int SurfaceMesh::selectVertex() {
 
-    // Make sure we can see edges
-    float oldEdgeWidth = getEdgeWidth();
-    setEdgeWidth(1.);
-    this->setEnabled(true);
+  // Make sure we can see edges
+  float oldEdgeWidth = getEdgeWidth();
+  setEdgeWidth(1.);
+  this->setEnabled(true);
 
-    long long int returnVertInd = -1;
+  long long int returnVertInd = -1;
 
-    // Register the callback which creates the UI and does the hard work
-    auto focusedPopupUI = [&]() {
-        { // Create a window with instruction and a close button.
-            static bool showWindow = true;
-            ImGui::SetNextWindowSize(ImVec2(300, 0), ImGuiCond_Once);
-            ImGui::Begin("Select vertex", &showWindow);
+  // Register the callback which creates the UI and does the hard work
+  auto focusedPopupUI = [&]() {
+    { // Create a window with instruction and a close button.
+      static bool showWindow = true;
+      ImGui::SetNextWindowSize(ImVec2(300, 0), ImGuiCond_Once);
+      ImGui::Begin("Select vertex", &showWindow);
 
-            ImGui::PushItemWidth(300);
-            ImGui::TextUnformatted("Hold ctrl and left-click to select a vertex");
-            ImGui::Separator();
+      ImGui::PushItemWidth(300);
+      ImGui::TextUnformatted("Hold ctrl and left-click to select a vertex");
+      ImGui::Separator();
 
-            // Choose by number
-            ImGui::PushItemWidth(300);
-            static int iV = -1;
-            ImGui::InputInt("index", &iV);
-            if (ImGui::Button("Select by index")) {
-                if (iV >= 0 && (size_t)iV < nVertices()) {
-                    returnVertInd = iV;
-                    popContext();
-                }
-            }
-            ImGui::PopItemWidth();
-
-            ImGui::Separator();
-            if (ImGui::Button("Abort")) {
-                popContext();
-            }
-
-            ImGui::End();
+      // Choose by number
+      ImGui::PushItemWidth(300);
+      static int iV = -1;
+      ImGui::InputInt("index", &iV);
+      if (ImGui::Button("Select by index")) {
+        if (iV >= 0 && (size_t)iV < nVertices()) {
+          returnVertInd = iV;
+          popContext();
         }
+      }
+      ImGui::PopItemWidth();
 
-        ImGuiIO& io = ImGui::GetIO();
-        if (io.KeyCtrl && !io.WantCaptureMouse && ImGui::IsMouseClicked(0)) {
+      ImGui::Separator();
+      if (ImGui::Button("Abort")) {
+        popContext();
+      }
 
-            ImGuiIO& io = ImGui::GetIO();
+      ImGui::End();
+    }
 
-            // API is a giant mess..
-            size_t pickInd;
-            ImVec2 p = ImGui::GetMousePos();
-            std::pair<Structure*, size_t> pickVal =
-                pick::evaluatePickQuery(io.DisplayFramebufferScale.x * p.x, io.DisplayFramebufferScale.y * p.y);
+    ImGuiIO& io = ImGui::GetIO();
+    if (io.KeyCtrl && !io.WantCaptureMouse && ImGui::IsMouseClicked(0)) {
 
-            if (pickVal.first == this) {
+      ImGuiIO& io = ImGui::GetIO();
 
-                if (pickVal.second < nVertices()) {
-                    returnVertInd = pickVal.second;
-                    popContext();
-                }
-            }
+      // API is a giant mess..
+      size_t pickInd;
+      ImVec2 p = ImGui::GetMousePos();
+      std::pair<Structure*, size_t> pickVal =
+          pick::evaluatePickQuery(io.DisplayFramebufferScale.x * p.x, io.DisplayFramebufferScale.y * p.y);
+
+      if (pickVal.first == this) {
+
+        if (pickVal.second < nVertices()) {
+          returnVertInd = pickVal.second;
+          popContext();
         }
-    };
+      }
+    }
+  };
 
-    // Pass control to the context we just created
-    pushContext(focusedPopupUI);
+  // Pass control to the context we just created
+  pushContext(focusedPopupUI);
 
-    setEdgeWidth(oldEdgeWidth); // restore edge setting
+  setEdgeWidth(oldEdgeWidth); // restore edge setting
 
-    return returnVertInd;
+  return returnVertInd;
 }
 
 /*
@@ -1145,252 +1138,238 @@ FacePtr SurfaceMesh::selectFace() {
 // === Option getters and setters
 
 SurfaceMesh* SurfaceMesh::setSmoothShade(bool isSmooth) {
-    shadeSmooth = isSmooth;
-    refresh();
-    requestRedraw();
-    return this;
+  shadeSmooth = isSmooth;
+  refresh();
+  requestRedraw();
+  return this;
 }
-bool SurfaceMesh::isSmoothShade() {
-    return shadeSmooth.get();
-}
+bool SurfaceMesh::isSmoothShade() { return shadeSmooth.get(); }
 
 SurfaceMesh* SurfaceMesh::setBackFaceColor(glm::vec3 val) {
-    backFaceColor.set(val);
-    requestRedraw();
-    return this;
+  backFaceColor.set(val);
+  requestRedraw();
+  return this;
 }
 
-glm::vec3 SurfaceMesh::getBackFaceColor() {
-    return backFaceColor.get();
-}
+glm::vec3 SurfaceMesh::getBackFaceColor() { return backFaceColor.get(); }
 
 SurfaceMesh* SurfaceMesh::setSurfaceColor(glm::vec3 val) {
-    surfaceColor = val;
-    requestRedraw();
-    return this;
+  surfaceColor = val;
+  requestRedraw();
+  return this;
 }
-glm::vec3 SurfaceMesh::getSurfaceColor() {
-    return surfaceColor.get();
-}
+glm::vec3 SurfaceMesh::getSurfaceColor() { return surfaceColor.get(); }
 
 SurfaceMesh* SurfaceMesh::setEdgeColor(glm::vec3 val) {
-    edgeColor = val;
-    requestRedraw();
-    return this;
+  edgeColor = val;
+  requestRedraw();
+  return this;
 }
-glm::vec3 SurfaceMesh::getEdgeColor() {
-    return edgeColor.get();
-}
+glm::vec3 SurfaceMesh::getEdgeColor() { return edgeColor.get(); }
 
 SurfaceMesh* SurfaceMesh::setMaterial(std::string m) {
-    material = m;
-    refresh(); // (serves the purpose of re-initializing everything, though this is a bit overkill)
-    requestRedraw();
-    return this;
+  material = m;
+  refresh(); // (serves the purpose of re-initializing everything, though this is a bit overkill)
+  requestRedraw();
+  return this;
 }
-std::string SurfaceMesh::getMaterial() {
-    return material.get();
-}
+std::string SurfaceMesh::getMaterial() { return material.get(); }
 
 SurfaceMesh* SurfaceMesh::setEdgeWidth(double newVal) {
-    edgeWidth = newVal;
-    refresh();
-    requestRedraw();
-    return this;
+  edgeWidth = newVal;
+  refresh();
+  requestRedraw();
+  return this;
 }
-double SurfaceMesh::getEdgeWidth() {
-    return edgeWidth.get();
-}
+double SurfaceMesh::getEdgeWidth() { return edgeWidth.get(); }
 
 SurfaceMesh* SurfaceMesh::setBackFacePolicy(BackFacePolicy newPolicy) {
-    backFacePolicy = newPolicy;
-    refresh();
-    requestRedraw();
-    return this;
+  backFacePolicy = newPolicy;
+  refresh();
+  requestRedraw();
+  return this;
 }
-BackFacePolicy SurfaceMesh::getBackFacePolicy() {
-    return backFacePolicy.get();
-}
+BackFacePolicy SurfaceMesh::getBackFacePolicy() { return backFacePolicy.get(); }
 
 // === Quantity adders
 
 
 SurfaceVertexColorQuantity* SurfaceMesh::addVertexColorQuantityImpl(std::string name,
                                                                     const std::vector<glm::vec3>& colors) {
-    SurfaceVertexColorQuantity* q = new SurfaceVertexColorQuantity(name, applyPermutation(colors, vertexPerm), *this);
-    addQuantity(q);
-    return q;
+  SurfaceVertexColorQuantity* q = new SurfaceVertexColorQuantity(name, applyPermutation(colors, vertexPerm), *this);
+  addQuantity(q);
+  return q;
 }
 
 SurfaceFaceColorQuantity* SurfaceMesh::addFaceColorQuantityImpl(std::string name,
                                                                 const std::vector<glm::vec3>& colors) {
-    SurfaceFaceColorQuantity* q = new SurfaceFaceColorQuantity(name, applyPermutation(colors, facePerm), *this);
-    addQuantity(q);
-    return q;
+  SurfaceFaceColorQuantity* q = new SurfaceFaceColorQuantity(name, applyPermutation(colors, facePerm), *this);
+  addQuantity(q);
+  return q;
 }
 
 SurfaceVertexScalarQuantity* SurfaceMesh::addVertexDistanceQuantityImpl(std::string name,
                                                                         const std::vector<double>& data) {
-    SurfaceVertexScalarQuantity* q =
-        new SurfaceVertexScalarQuantity(name, applyPermutation(data, vertexPerm), *this, DataType::MAGNITUDE);
+  SurfaceVertexScalarQuantity* q =
+      new SurfaceVertexScalarQuantity(name, applyPermutation(data, vertexPerm), *this, DataType::MAGNITUDE);
 
-    q->setIsolinesEnabled(true);
-    q->setIsolineWidth(0.02, true);
+  q->setIsolinesEnabled(true);
+  q->setIsolineWidth(0.02, true);
 
-    addQuantity(q);
-    return q;
+  addQuantity(q);
+  return q;
 }
 
 SurfaceVertexScalarQuantity* SurfaceMesh::addVertexSignedDistanceQuantityImpl(std::string name,
                                                                               const std::vector<double>& data) {
-    SurfaceVertexScalarQuantity* q =
-        new SurfaceVertexScalarQuantity(name, applyPermutation(data, vertexPerm), *this, DataType::SYMMETRIC);
+  SurfaceVertexScalarQuantity* q =
+      new SurfaceVertexScalarQuantity(name, applyPermutation(data, vertexPerm), *this, DataType::SYMMETRIC);
 
-    q->setIsolinesEnabled(true);
-    q->setIsolineWidth(0.02, true);
+  q->setIsolinesEnabled(true);
+  q->setIsolineWidth(0.02, true);
 
-    addQuantity(q);
-    return q;
+  addQuantity(q);
+  return q;
 }
 
 SurfaceCornerParameterizationQuantity*
 SurfaceMesh::addParameterizationQuantityImpl(std::string name, const std::vector<glm::vec2>& coords,
                                              ParamCoordsType type) {
-    SurfaceCornerParameterizationQuantity* q = new SurfaceCornerParameterizationQuantity(
-        name, applyPermutation(coords, cornerPerm), type, ParamVizStyle::CHECKER, *this);
-    addQuantity(q);
+  SurfaceCornerParameterizationQuantity* q = new SurfaceCornerParameterizationQuantity(
+      name, applyPermutation(coords, cornerPerm), type, ParamVizStyle::CHECKER, *this);
+  addQuantity(q);
 
-    return q;
+  return q;
 }
 
 SurfaceVertexParameterizationQuantity*
 SurfaceMesh::addVertexParameterizationQuantityImpl(std::string name, const std::vector<glm::vec2>& coords,
                                                    ParamCoordsType type) {
-    SurfaceVertexParameterizationQuantity* q = new SurfaceVertexParameterizationQuantity(
-        name, applyPermutation(coords, vertexPerm), type, ParamVizStyle::CHECKER, *this);
-    addQuantity(q);
+  SurfaceVertexParameterizationQuantity* q = new SurfaceVertexParameterizationQuantity(
+      name, applyPermutation(coords, vertexPerm), type, ParamVizStyle::CHECKER, *this);
+  addQuantity(q);
 
-    return q;
+  return q;
 }
 
 SurfaceVertexParameterizationQuantity*
 SurfaceMesh::addLocalParameterizationQuantityImpl(std::string name, const std::vector<glm::vec2>& coords,
                                                   ParamCoordsType type) {
-    SurfaceVertexParameterizationQuantity* q = new SurfaceVertexParameterizationQuantity(
-        name, applyPermutation(coords, vertexPerm), type, ParamVizStyle::LOCAL_CHECK, *this);
-    addQuantity(q);
+  SurfaceVertexParameterizationQuantity* q = new SurfaceVertexParameterizationQuantity(
+      name, applyPermutation(coords, vertexPerm), type, ParamVizStyle::LOCAL_CHECK, *this);
+  addQuantity(q);
 
-    return q;
+  return q;
 }
 
 
 SurfaceVertexCountQuantity* SurfaceMesh::addVertexCountQuantityImpl(std::string name,
                                                                     const std::vector<std::pair<size_t, int>>& values) {
 
-    SurfaceVertexCountQuantity* q = new SurfaceVertexCountQuantity(name, values, *this);
-    addQuantity(q);
-    return q;
+  SurfaceVertexCountQuantity* q = new SurfaceVertexCountQuantity(name, values, *this);
+  addQuantity(q);
+  return q;
 }
 
 SurfaceVertexIsolatedScalarQuantity*
 SurfaceMesh::addVertexIsolatedScalarQuantityImpl(std::string name,
                                                  const std::vector<std::pair<size_t, double>>& values) {
-    SurfaceVertexIsolatedScalarQuantity* q = new SurfaceVertexIsolatedScalarQuantity(name, values, *this);
-    addQuantity(q);
-    return q;
+  SurfaceVertexIsolatedScalarQuantity* q = new SurfaceVertexIsolatedScalarQuantity(name, values, *this);
+  addQuantity(q);
+  return q;
 }
 
 SurfaceFaceCountQuantity* SurfaceMesh::addFaceCountQuantityImpl(std::string name,
                                                                 const std::vector<std::pair<size_t, int>>& values) {
-    SurfaceFaceCountQuantity* q = new SurfaceFaceCountQuantity(name, values, *this);
-    addQuantity(q);
-    return q;
+  SurfaceFaceCountQuantity* q = new SurfaceFaceCountQuantity(name, values, *this);
+  addQuantity(q);
+  return q;
 }
 
 SurfaceGraphQuantity* SurfaceMesh::addSurfaceGraphQuantityImpl(std::string name, const std::vector<glm::vec3>& nodes,
                                                                const std::vector<std::array<size_t, 2>>& edges) {
-    SurfaceGraphQuantity* q = new SurfaceGraphQuantity(name, nodes, edges, *this);
-    addQuantity(q);
-    return q;
+  SurfaceGraphQuantity* q = new SurfaceGraphQuantity(name, nodes, edges, *this);
+  addQuantity(q);
+  return q;
 }
 
 
 SurfaceVertexScalarQuantity* SurfaceMesh::addVertexScalarQuantityImpl(std::string name, const std::vector<double>& data,
                                                                       DataType type) {
-    SurfaceVertexScalarQuantity* q =
-        new SurfaceVertexScalarQuantity(name, applyPermutation(data, vertexPerm), *this, type);
-    addQuantity(q);
-    return q;
+  SurfaceVertexScalarQuantity* q =
+      new SurfaceVertexScalarQuantity(name, applyPermutation(data, vertexPerm), *this, type);
+  addQuantity(q);
+  return q;
 }
 
 SurfaceFaceScalarQuantity* SurfaceMesh::addFaceScalarQuantityImpl(std::string name, const std::vector<double>& data,
                                                                   DataType type) {
-    SurfaceFaceScalarQuantity* q = new SurfaceFaceScalarQuantity(name, applyPermutation(data, facePerm), *this, type);
-    addQuantity(q);
-    return q;
+  SurfaceFaceScalarQuantity* q = new SurfaceFaceScalarQuantity(name, applyPermutation(data, facePerm), *this, type);
+  addQuantity(q);
+  return q;
 }
 
 
 SurfaceEdgeScalarQuantity* SurfaceMesh::addEdgeScalarQuantityImpl(std::string name, const std::vector<double>& data,
                                                                   DataType type) {
-    SurfaceEdgeScalarQuantity* q = new SurfaceEdgeScalarQuantity(name, applyPermutation(data, edgePerm), *this, type);
-    addQuantity(q);
-    return q;
+  SurfaceEdgeScalarQuantity* q = new SurfaceEdgeScalarQuantity(name, applyPermutation(data, edgePerm), *this, type);
+  addQuantity(q);
+  return q;
 }
 
 SurfaceHalfedgeScalarQuantity*
 SurfaceMesh::addHalfedgeScalarQuantityImpl(std::string name, const std::vector<double>& data, DataType type) {
-    SurfaceHalfedgeScalarQuantity* q =
-        new SurfaceHalfedgeScalarQuantity(name, applyPermutation(data, halfedgePerm), *this, type);
-    addQuantity(q);
-    return q;
+  SurfaceHalfedgeScalarQuantity* q =
+      new SurfaceHalfedgeScalarQuantity(name, applyPermutation(data, halfedgePerm), *this, type);
+  addQuantity(q);
+  return q;
 }
 
 SurfaceCornerScalarQuantity* SurfaceMesh::addCornerScalarQuantityImpl(std::string name, const std::vector<double>& data,
                                                                       DataType type) {
-    SurfaceCornerScalarQuantity* q =
-        new SurfaceCornerScalarQuantity(name, applyPermutation(data, cornerPerm), *this, type);
-    addQuantity(q);
-    return q;
+  SurfaceCornerScalarQuantity* q =
+      new SurfaceCornerScalarQuantity(name, applyPermutation(data, cornerPerm), *this, type);
+  addQuantity(q);
+  return q;
 }
 
 
 SurfaceVertexVectorQuantity* SurfaceMesh::addVertexVectorQuantityImpl(std::string name,
                                                                       const std::vector<glm::vec3>& vectors,
                                                                       VectorType vectorType) {
-    SurfaceVertexVectorQuantity* q =
-        new SurfaceVertexVectorQuantity(name, applyPermutation(vectors, vertexPerm), *this, vectorType);
-    addQuantity(q);
-    return q;
+  SurfaceVertexVectorQuantity* q =
+      new SurfaceVertexVectorQuantity(name, applyPermutation(vectors, vertexPerm), *this, vectorType);
+  addQuantity(q);
+  return q;
 }
 
 SurfaceFaceVectorQuantity*
 SurfaceMesh::addFaceVectorQuantityImpl(std::string name, const std::vector<glm::vec3>& vectors, VectorType vectorType) {
 
-    SurfaceFaceVectorQuantity* q =
-        new SurfaceFaceVectorQuantity(name, applyPermutation(vectors, facePerm), *this, vectorType);
-    addQuantity(q);
-    return q;
+  SurfaceFaceVectorQuantity* q =
+      new SurfaceFaceVectorQuantity(name, applyPermutation(vectors, facePerm), *this, vectorType);
+  addQuantity(q);
+  return q;
 }
 
 SurfaceFaceIntrinsicVectorQuantity*
 SurfaceMesh::addFaceIntrinsicVectorQuantityImpl(std::string name, const std::vector<glm::vec2>& vectors, int nSym,
                                                 VectorType vectorType) {
 
-    SurfaceFaceIntrinsicVectorQuantity* q =
-        new SurfaceFaceIntrinsicVectorQuantity(name, applyPermutation(vectors, facePerm), *this, nSym, vectorType);
-    addQuantity(q);
-    return q;
+  SurfaceFaceIntrinsicVectorQuantity* q =
+      new SurfaceFaceIntrinsicVectorQuantity(name, applyPermutation(vectors, facePerm), *this, nSym, vectorType);
+  addQuantity(q);
+  return q;
 }
 
 
 SurfaceVertexIntrinsicVectorQuantity*
 SurfaceMesh::addVertexIntrinsicVectorQuantityImpl(std::string name, const std::vector<glm::vec2>& vectors, int nSym,
                                                   VectorType vectorType) {
-    SurfaceVertexIntrinsicVectorQuantity* q =
-        new SurfaceVertexIntrinsicVectorQuantity(name, applyPermutation(vectors, vertexPerm), *this, nSym, vectorType);
-    addQuantity(q);
-    return q;
+  SurfaceVertexIntrinsicVectorQuantity* q =
+      new SurfaceVertexIntrinsicVectorQuantity(name, applyPermutation(vectors, vertexPerm), *this, nSym, vectorType);
+  addQuantity(q);
+  return q;
 }
 
 // Orientations is `true` if the canonical orientation of the edge points from the lower-indexed vertex to the
@@ -1398,61 +1377,61 @@ SurfaceMesh::addVertexIntrinsicVectorQuantityImpl(std::string name, const std::v
 SurfaceOneFormIntrinsicVectorQuantity*
 SurfaceMesh::addOneFormIntrinsicVectorQuantityImpl(std::string name, const std::vector<double>& data,
                                                    const std::vector<char>& orientations) {
-    SurfaceOneFormIntrinsicVectorQuantity* q = new SurfaceOneFormIntrinsicVectorQuantity(
-        name, applyPermutation(data, edgePerm), applyPermutation(orientations, edgePerm), *this);
-    addQuantity(q);
-    return q;
+  SurfaceOneFormIntrinsicVectorQuantity* q = new SurfaceOneFormIntrinsicVectorQuantity(
+      name, applyPermutation(data, edgePerm), applyPermutation(orientations, edgePerm), *this);
+  addQuantity(q);
+  return q;
 }
 
 
 void SurfaceMesh::setVertexTangentBasisXImpl(const std::vector<glm::vec3>& vectors) {
 
-    std::vector<glm::vec3> inputBasisX = applyPermutation(vectors, vertexPerm);
-    vertexTangentSpaces.resize(nVertices());
+  std::vector<glm::vec3> inputBasisX = applyPermutation(vectors, vertexPerm);
+  vertexTangentSpaces.resize(nVertices());
 
-    for (size_t iV = 0; iV < nVertices(); iV++) {
+  for (size_t iV = 0; iV < nVertices(); iV++) {
 
-        glm::vec3 basisX = inputBasisX[iV];
-        glm::vec3 normal = vertexNormals[iV];
+    glm::vec3 basisX = inputBasisX[iV];
+    glm::vec3 normal = vertexNormals[iV];
 
-        // Project in to tangent defined by our normals
-        basisX = glm::normalize(basisX - normal * glm::dot(normal, basisX));
+    // Project in to tangent defined by our normals
+    basisX = glm::normalize(basisX - normal * glm::dot(normal, basisX));
 
-        // Let basis Y complete the frame
-        glm::vec3 basisY = glm::cross(normal, basisX);
+    // Let basis Y complete the frame
+    glm::vec3 basisY = glm::cross(normal, basisX);
 
-        vertexTangentSpaces[iV][0] = basisX;
-        vertexTangentSpaces[iV][1] = basisY;
-    }
+    vertexTangentSpaces[iV][0] = basisX;
+    vertexTangentSpaces[iV][1] = basisY;
+  }
 
-    // Regenerate all data, in case stored data depends on tangent spaces.
-    // NOTE: This is overkill. We really only need to regenrate the handful of things which depend on tangent spaces.
-    refresh();
+  // Regenerate all data, in case stored data depends on tangent spaces.
+  // NOTE: This is overkill. We really only need to regenrate the handful of things which depend on tangent spaces.
+  refresh();
 }
 
 void SurfaceMesh::setFaceTangentBasisXImpl(const std::vector<glm::vec3>& vectors) {
 
-    std::vector<glm::vec3> inputBasisX = applyPermutation(vectors, facePerm);
-    faceTangentSpaces.resize(nFaces());
+  std::vector<glm::vec3> inputBasisX = applyPermutation(vectors, facePerm);
+  faceTangentSpaces.resize(nFaces());
 
-    for (size_t iF = 0; iF < nFaces(); iF++) {
+  for (size_t iF = 0; iF < nFaces(); iF++) {
 
-        glm::vec3 basisX = inputBasisX[iF];
-        glm::vec3 normal = faceNormals[iF];
+    glm::vec3 basisX = inputBasisX[iF];
+    glm::vec3 normal = faceNormals[iF];
 
-        // Project in to tangent defined by our normals
-        basisX = glm::normalize(basisX - normal * glm::dot(normal, basisX));
+    // Project in to tangent defined by our normals
+    basisX = glm::normalize(basisX - normal * glm::dot(normal, basisX));
 
-        // Let basis Y complete the frame
-        glm::vec3 basisY = glm::cross(normal, basisX);
+    // Let basis Y complete the frame
+    glm::vec3 basisY = glm::cross(normal, basisX);
 
-        faceTangentSpaces[iF][0] = basisX;
-        faceTangentSpaces[iF][1] = basisY;
-    }
+    faceTangentSpaces[iF][0] = basisX;
+    faceTangentSpaces[iF][1] = basisY;
+  }
 
-    // Regenerate all data, in case stored data depends on tangent spaces.
-    // NOTE: This is overkill. We really only need to regenrate the handful of things which depend on tangent spaces.
-    refresh();
+  // Regenerate all data, in case stored data depends on tangent spaces.
+  // NOTE: This is overkill. We really only need to regenrate the handful of things which depend on tangent spaces.
+  refresh();
 }
 
 

--- a/src/surface_mesh.cpp
+++ b/src/surface_mesh.cpp
@@ -27,641 +27,657 @@ SurfaceMesh::SurfaceMesh(std::string name, const std::vector<glm::vec3>& vertexP
       backFacePolicy(uniquePrefix() + "backFacePolicy", BackFacePolicy::Different),
       backFaceColor(uniquePrefix() + "backFaceColor",
                     glm::vec3(1.f - surfaceColor.get().r, 1.f - surfaceColor.get().g, 1.f - surfaceColor.get().b)) {
-  updateObjectSpaceBounds();
-  computeCounts();
-  computeGeometryData();
+    updateObjectSpaceBounds();
+    computeCounts();
+    computeGeometryData();
 }
 
 
 void SurfaceMesh::computeCounts() {
 
-  nFacesTriangulationCount = 0;
-  nCornersCount = 0;
-  nEdgesCount = 0;
-  edgeIndices.resize(nFaces());
-  halfedgeIndices.resize(nFaces());
-  std::unordered_map<std::pair<size_t, size_t>, size_t, polyscope::hash_combine::hash<std::pair<size_t, size_t>>>
-      edgeInds;
-  size_t iF = 0;
-  for (auto& face : faces) {
-    if (face.size() < 3) {
-      warning(name + " has face with degree < 3!");
-      face = {0, 0, 0}; // (just to do _something_ so we don't crash in subsequent code)
-    }
-    nFacesTriangulationCount += std::max(static_cast<int>(face.size()) - 2, 0);
-    edgeIndices[iF].resize(face.size());
-    halfedgeIndices[iF].resize(face.size());
-
-    for (size_t i = 0; i < face.size(); i++) {
-      size_t vA = face[i];
-      size_t vB = face[(i + 1) % face.size()];
-
-      if (vA >= vertices.size()) {
-        warning(name + " has face with vertex index out of vertices range",
-                "face " + std::to_string(iF) + " has vertex index " + std::to_string(vA));
-
-        // zero out the face index
-        // (just to do _something_ so we don't crash in subsequent code)
-        for (size_t j = 0; j < face.size(); j++) {
-          face[j] = 0;
+    nFacesTriangulationCount = 0;
+    nCornersCount = 0;
+    nEdgesCount = 0;
+    edgeIndices.resize(nFaces());
+    halfedgeIndices.resize(nFaces());
+    std::unordered_map<std::pair<size_t, size_t>, size_t, polyscope::hash_combine::hash<std::pair<size_t, size_t>>>
+        edgeInds;
+    size_t iF = 0;
+    for (auto& face : faces) {
+        if (face.size() < 3) {
+            warning(name + " has face with degree < 3!");
+            face = {0, 0, 0}; // (just to do _something_ so we don't crash in subsequent code)
         }
-        vA = face[i];
-        vB = face[(i + 1) % face.size()];
-      }
+        nFacesTriangulationCount += std::max(static_cast<int>(face.size()) - 2, 0);
+        edgeIndices[iF].resize(face.size());
+        halfedgeIndices[iF].resize(face.size());
 
-      std::pair<size_t, size_t> edgeKey(std::min(vA, vB), std::max(vA, vB));
-      auto it = edgeInds.find(edgeKey);
-      size_t edgeInd = 0;
-      if (it == edgeInds.end()) {
-        edgeInd = nEdgesCount;
-        edgeInds.insert(it, {edgeKey, edgeInd});
-        nEdgesCount++;
-      } else {
-        edgeInd = it->second;
-      }
+        for (size_t i = 0; i < face.size(); i++) {
+            size_t vA = face[i];
+            size_t vB = face[(i + 1) % face.size()];
 
-      edgeIndices[iF][i] = edgeInd;
-      halfedgeIndices[iF][i] = nCornersCount++;
+            if (vA >= vertices.size()) {
+                warning(name + " has face with vertex index out of vertices range",
+                        "face " + std::to_string(iF) + " has vertex index " + std::to_string(vA));
+
+                // zero out the face index
+                // (just to do _something_ so we don't crash in subsequent code)
+                for (size_t j = 0; j < face.size(); j++) {
+                    face[j] = 0;
+                }
+                vA = face[i];
+                vB = face[(i + 1) % face.size()];
+            }
+
+            std::pair<size_t, size_t> edgeKey(std::min(vA, vB), std::max(vA, vB));
+            auto it = edgeInds.find(edgeKey);
+            size_t edgeInd = 0;
+            if (it == edgeInds.end()) {
+                edgeInd = nEdgesCount;
+                edgeInds.insert(it, {edgeKey, edgeInd});
+                nEdgesCount++;
+            } else {
+                edgeInd = it->second;
+            }
+
+            edgeIndices[iF][i] = edgeInd;
+            halfedgeIndices[iF][i] = nCornersCount++;
+        }
+
+        iF++;
     }
 
-    iF++;
-  }
-
-  // Default data sizes
-  vertexDataSize = nVertices();
-  faceDataSize = nFaces();
-  edgeDataSize = nEdges();
-  halfedgeDataSize = nHalfedges();
-  cornerDataSize = nCorners();
+    // Default data sizes
+    vertexDataSize = nVertices();
+    faceDataSize = nFaces();
+    edgeDataSize = nEdges();
+    halfedgeDataSize = nHalfedges();
+    cornerDataSize = nCorners();
 }
 
 void SurfaceMesh::computeGeometryData() {
-  const glm::vec3 zero{0., 0., 0.};
+    const glm::vec3 zero{0., 0., 0.};
 
-  // Reset face-valued
-  faceNormals.resize(nFaces());
-  faceAreas.resize(nFaces());
+    // Reset face-valued
+    faceNormals.resize(nFaces());
+    faceAreas.resize(nFaces());
 
-  // Reset vertex-valued
-  vertexNormals.resize(nVertices());
-  std::fill(vertexNormals.begin(), vertexNormals.end(), zero);
-  vertexAreas.resize(nVertices());
-  std::fill(vertexAreas.begin(), vertexAreas.end(), 0);
+    // Reset vertex-valued
+    vertexNormals.resize(nVertices());
+    std::fill(vertexNormals.begin(), vertexNormals.end(), zero);
+    vertexAreas.resize(nVertices());
+    std::fill(vertexAreas.begin(), vertexAreas.end(), 0);
 
-  // Reset edge-valued
-  edgeLengths.resize(nEdges());
+    // Reset edge-valued
+    edgeLengths.resize(nEdges());
 
-  // Loop over faces to compute face-valued quantities
-  for (size_t iF = 0; iF < nFaces(); iF++) {
-    auto& face = faces[iF];
-    size_t D = face.size();
+    // Loop over faces to compute face-valued quantities
+    for (size_t iF = 0; iF < nFaces(); iF++) {
+        auto& face = faces[iF];
+        size_t D = face.size();
 
-    glm::vec3 fN = zero;
-    double fA = 0;
-    if (face.size() == 3) {
-      glm::vec3 pA = vertices[face[0]];
-      glm::vec3 pB = vertices[face[1]];
-      glm::vec3 pC = vertices[face[2]];
+        glm::vec3 fN = zero;
+        double fA = 0;
+        if (face.size() == 3) {
+            glm::vec3 pA = vertices[face[0]];
+            glm::vec3 pB = vertices[face[1]];
+            glm::vec3 pC = vertices[face[2]];
 
-      fN = glm::cross(pB - pA, pC - pA);
-      fA = 0.5 * glm::length(fN);
-    } else if (face.size() > 3) {
+            fN = glm::cross(pB - pA, pC - pA);
+            fA = 0.5 * glm::length(fN);
+        } else if (face.size() > 3) {
 
-      glm::vec3 pRoot = vertices[face[0]];
-      for (size_t j = 0; j < D; j++) {
-        glm::vec3 pA = vertices[face[j]];
-        glm::vec3 pB = vertices[face[(j + 1) % D]];
-        glm::vec3 pC = vertices[face[(j + 2) % D]];
+            glm::vec3 pRoot = vertices[face[0]];
+            for (size_t j = 0; j < D; j++) {
+                glm::vec3 pA = vertices[face[j]];
+                glm::vec3 pB = vertices[face[(j + 1) % D]];
+                glm::vec3 pC = vertices[face[(j + 2) % D]];
 
-        fN += glm::cross(pC - pB, pA - pB);
+                fN += glm::cross(pC - pB, pA - pB);
 
-        // _some_ definition of area for a non-triangular face
-        if (j != 0 && j != (D - 1)) {
-          fA += 0.5 * glm::length(glm::cross(pA - pRoot, pB - pRoot));
+                // _some_ definition of area for a non-triangular face
+                if (j != 0 && j != (D - 1)) {
+                    fA += 0.5 * glm::length(glm::cross(pA - pRoot, pB - pRoot));
+                }
+            }
         }
-      }
+
+        // Set face values
+        fN = glm::normalize(fN);
+        faceNormals[iF] = fN;
+        faceAreas[iF] = fA;
+
+        // Update incident vertices
+        for (size_t j = 0; j < D; j++) {
+            glm::vec3 pA = vertices[face[j]];
+            glm::vec3 pB = vertices[face[(j + 1) % D]];
+            glm::vec3 pC = vertices[face[(j + 2) % D]];
+
+            vertexAreas[face[j]] += fA / D;
+
+            // Corner angle for weighting normals
+            double dot = glm::dot(glm::normalize(pB - pA), glm::normalize(pC - pA));
+            float angle = std::acos(glm::clamp(-1., 1., dot));
+            glm::vec3 normalContrib = angle * fN;
+
+            if (std::isfinite(normalContrib.x) && std::isfinite(normalContrib.y) && std::isfinite(normalContrib.z)) {
+                vertexNormals[face[(j + 1) % D]] += normalContrib;
+            }
+
+            // Compute edge lengths while we're at it
+            edgeLengths[edgeIndices[iF][j]] = glm::length(pA - pB);
+        }
     }
 
-    // Set face values
-    fN = glm::normalize(fN);
-    faceNormals[iF] = fN;
-    faceAreas[iF] = fA;
 
-    // Update incident vertices
-    for (size_t j = 0; j < D; j++) {
-      glm::vec3 pA = vertices[face[j]];
-      glm::vec3 pB = vertices[face[(j + 1) % D]];
-      glm::vec3 pC = vertices[face[(j + 2) % D]];
-
-      vertexAreas[face[j]] += fA / D;
-
-      // Corner angle for weighting normals
-      double dot = glm::dot(glm::normalize(pB - pA), glm::normalize(pC - pA));
-      float angle = std::acos(glm::clamp(-1., 1., dot));
-      glm::vec3 normalContrib = angle * fN;
-
-      if (std::isfinite(normalContrib.x) && std::isfinite(normalContrib.y) && std::isfinite(normalContrib.z)) {
-        vertexNormals[face[(j + 1) % D]] += normalContrib;
-      }
-
-      // Compute edge lengths while we're at it
-      edgeLengths[edgeIndices[iF][j]] = glm::length(pA - pB);
+    // Normalize vertex normals
+    for (auto& vec : vertexNormals) {
+        double L = glm::length(vec);
+        if (L > 0) {
+            vec /= L;
+        }
     }
-  }
-
-
-  // Normalize vertex normals
-  for (auto& vec : vertexNormals) {
-    double L = glm::length(vec);
-    if (L > 0) {
-      vec /= L;
-    }
-  }
 }
 
 void SurfaceMesh::ensureHaveManifoldConnectivity() {
-  if (!faceForHalfedge.empty()) return; // already populated
+    if (!faceForHalfedge.empty()) return; // already populated
 
-  faceForHalfedge.resize(nHalfedges());
-  twinHalfedge.resize(nHalfedges());
+    faceForHalfedge.resize(nHalfedges());
+    twinHalfedge.resize(nHalfedges());
 
-  // Maps from edge (sorted) to all halfedges incident on that edge
-  std::unordered_map<std::pair<size_t, size_t>, std::vector<size_t>,
-                     polyscope::hash_combine::hash<std::pair<size_t, size_t>>>
-      edgeInds;
+    // Maps from edge (sorted) to all halfedges incident on that edge
+    std::unordered_map<std::pair<size_t, size_t>, std::vector<size_t>,
+                       polyscope::hash_combine::hash<std::pair<size_t, size_t>>>
+        edgeInds;
 
-  // Fill out faceForHalfedge and populate edge lookup map
-  for (size_t iF = 0; iF < nFaces(); iF++) {
-    auto& face = faces[iF];
-    size_t D = face.size();
+    // Fill out faceForHalfedge and populate edge lookup map
+    for (size_t iF = 0; iF < nFaces(); iF++) {
+        auto& face = faces[iF];
+        size_t D = face.size();
 
 
-    for (size_t j = 0; j < D; j++) {
-      size_t iV = face[j];
-      size_t iVNext = face[(j + 1) % D];
-      size_t iHe = halfedgeIndices[iF][j];
+        for (size_t j = 0; j < D; j++) {
+            size_t iV = face[j];
+            size_t iVNext = face[(j + 1) % D];
+            size_t iHe = halfedgeIndices[iF][j];
 
-      faceForHalfedge[iHe] = iF;
+            faceForHalfedge[iHe] = iF;
 
-      std::pair<size_t, size_t> edgeKey(std::min(iV, iVNext), std::max(iV, iVNext));
+            std::pair<size_t, size_t> edgeKey(std::min(iV, iVNext), std::max(iV, iVNext));
 
-      // Make sure the key is populated
-      auto it = edgeInds.find(edgeKey);
-      if (it == edgeInds.end()) {
-        it = edgeInds.insert(it, {edgeKey, std::vector<size_t>()});
-      }
+            // Make sure the key is populated
+            auto it = edgeInds.find(edgeKey);
+            if (it == edgeInds.end()) {
+                it = edgeInds.insert(it, {edgeKey, std::vector<size_t>()});
+            }
 
-      // Add this halfedge to the entry
-      it->second.push_back(iHe);
-    }
-  }
-
-  // Second walk through, setting twins
-  for (size_t iF = 0; iF < nFaces(); iF++) {
-    auto& face = faces[iF];
-    size_t D = face.size();
-
-    for (size_t j = 0; j < D; j++) {
-      size_t iV = face[j];
-      size_t iVNext = face[(j + 1) % D];
-      size_t iHe = halfedgeIndices[iF][j];
-
-      std::pair<size_t, size_t> edgeKey(std::min(iV, iVNext), std::max(iV, iVNext));
-      std::vector<size_t>& edgeHalfedges = edgeInds.find(edgeKey)->second;
-
-      // Pick the first halfedge we find which is not this one
-      size_t myTwin = INVALID_IND;
-      for (size_t t : edgeHalfedges) {
-        if (t != iHe) {
-          myTwin = t;
-          break;
+            // Add this halfedge to the entry
+            it->second.push_back(iHe);
         }
-      }
-
-      twinHalfedge[iHe] = myTwin;
     }
-  }
+
+    // Second walk through, setting twins
+    for (size_t iF = 0; iF < nFaces(); iF++) {
+        auto& face = faces[iF];
+        size_t D = face.size();
+
+        for (size_t j = 0; j < D; j++) {
+            size_t iV = face[j];
+            size_t iVNext = face[(j + 1) % D];
+            size_t iHe = halfedgeIndices[iF][j];
+
+            std::pair<size_t, size_t> edgeKey(std::min(iV, iVNext), std::max(iV, iVNext));
+            std::vector<size_t>& edgeHalfedges = edgeInds.find(edgeKey)->second;
+
+            // Pick the first halfedge we find which is not this one
+            size_t myTwin = INVALID_IND;
+            for (size_t t : edgeHalfedges) {
+                if (t != iHe) {
+                    myTwin = t;
+                    break;
+                }
+            }
+
+            twinHalfedge[iHe] = myTwin;
+        }
+    }
 }
 
-bool SurfaceMesh::hasFaceTangentSpaces() { return (faceTangentSpaces.size() > 0); }
+bool SurfaceMesh::hasFaceTangentSpaces() {
+    return (faceTangentSpaces.size() > 0);
+}
 
-bool SurfaceMesh::hasVertexTangentSpaces() { return (vertexTangentSpaces.size() > 0); }
+bool SurfaceMesh::hasVertexTangentSpaces() {
+    return (vertexTangentSpaces.size() > 0);
+}
 
 
 void SurfaceMesh::ensureHaveFaceTangentSpaces() {
-  if (hasFaceTangentSpaces()) return;
-  throw std::runtime_error("No face tangent bases registered. see setFaceTangentBasisX()");
+    if (hasFaceTangentSpaces()) return;
+    throw std::runtime_error("No face tangent bases registered. see setFaceTangentBasisX()");
 }
 
 void SurfaceMesh::ensureHaveVertexTangentSpaces() {
-  if (hasVertexTangentSpaces()) return;
-  throw std::runtime_error("No vertex tangent bases registered. see setVertexTangentBasisX()");
+    if (hasVertexTangentSpaces()) return;
+    throw std::runtime_error("No vertex tangent bases registered. see setVertexTangentBasisX()");
 }
 
 void SurfaceMesh::generateDefaultFaceTangentSpaces() {
-  faceTangentSpaces.resize(nFaces());
+    faceTangentSpaces.resize(nFaces());
 
-  for (size_t iF = 0; iF < nFaces(); iF++) {
-    auto& face = faces[iF];
-    size_t D = face.size();
-    if (D < 2) continue;
+    for (size_t iF = 0; iF < nFaces(); iF++) {
+        auto& face = faces[iF];
+        size_t D = face.size();
+        if (D < 2) continue;
 
-    glm::vec3 pA = vertices[face[0]];
-    glm::vec3 pB = vertices[face[1]];
-    glm::vec3 N = faceNormals[iF];
+        glm::vec3 pA = vertices[face[0]];
+        glm::vec3 pB = vertices[face[1]];
+        glm::vec3 N = faceNormals[iF];
 
-    glm::vec3 basisX = pB - pA;
-    basisX = glm::normalize(basisX - N * glm::dot(N, basisX));
+        glm::vec3 basisX = pB - pA;
+        basisX = glm::normalize(basisX - N * glm::dot(N, basisX));
 
-    glm::vec3 basisY = glm::normalize(-glm::cross(basisX, N));
+        glm::vec3 basisY = glm::normalize(-glm::cross(basisX, N));
 
-    faceTangentSpaces[iF][0] = basisX;
-    faceTangentSpaces[iF][1] = basisY;
-  }
+        faceTangentSpaces[iF][0] = basisX;
+        faceTangentSpaces[iF][1] = basisY;
+    }
 }
 
 void SurfaceMesh::generateDefaultVertexTangentSpaces() {
-  vertexTangentSpaces.resize(nVertices());
-  std::vector<char> hasTangent(nVertices(), false);
+    vertexTangentSpaces.resize(nVertices());
+    std::vector<char> hasTangent(nVertices(), false);
 
-  for (size_t iF = 0; iF < nFaces(); iF++) {
-    auto& face = faces[iF];
-    size_t D = face.size();
-    if (D < 2) continue;
+    for (size_t iF = 0; iF < nFaces(); iF++) {
+        auto& face = faces[iF];
+        size_t D = face.size();
+        if (D < 2) continue;
 
-    for (size_t j = 0; j < D; j++) {
+        for (size_t j = 0; j < D; j++) {
 
-      size_t vA = face[j];
-      size_t vB = face[(j + 1) % D];
+            size_t vA = face[j];
+            size_t vB = face[(j + 1) % D];
 
-      if (hasTangent[vA]) continue;
+            if (hasTangent[vA]) continue;
 
-      glm::vec3 pA = vertices[vA];
-      glm::vec3 pB = vertices[vB];
-      glm::vec3 N = vertexNormals[vA];
+            glm::vec3 pA = vertices[vA];
+            glm::vec3 pB = vertices[vB];
+            glm::vec3 N = vertexNormals[vA];
 
-      glm::vec3 basisX = pB - pA;
-      basisX = basisX - N * glm::dot(N, basisX);
+            glm::vec3 basisX = pB - pA;
+            basisX = basisX - N * glm::dot(N, basisX);
 
-      glm::vec3 basisY = -glm::cross(basisX, N);
+            glm::vec3 basisY = -glm::cross(basisX, N);
 
-      vertexTangentSpaces[vA][0] = basisX;
-      vertexTangentSpaces[vA][1] = basisY;
+            vertexTangentSpaces[vA][0] = basisX;
+            vertexTangentSpaces[vA][1] = basisY;
 
-      hasTangent[vA] = true;
+            hasTangent[vA] = true;
+        }
     }
-  }
 }
 
 void SurfaceMesh::draw() {
-  if (!isEnabled()) {
-    return;
-  }
-
-  render::engine->setBackfaceCull(backFacePolicy.get() == BackFacePolicy::Cull);
-
-  // If no quantity is drawing the surface, we should draw it
-  if (dominantQuantity == nullptr) {
-
-    if (program == nullptr) {
-      prepare();
-
-      // do this now to reduce lag when picking later, etc
-      preparePick();
+    if (!isEnabled()) {
+        return;
     }
 
-    // Set uniforms
-    setStructureUniforms(*program);
-    setSurfaceMeshUniforms(*program);
-    program->setUniform("u_baseColor", getSurfaceColor());
+    render::engine->setBackfaceCull(backFacePolicy.get() == BackFacePolicy::Cull);
 
-    program->draw();
-  }
+    // If no quantity is drawing the surface, we should draw it
+    if (dominantQuantity == nullptr) {
 
-  // Draw the quantities
-  for (auto& x : quantities) {
-    x.second->draw();
-  }
+        if (program == nullptr) {
+            prepare();
 
-  render::engine->setBackfaceCull(); // return to default setting
+            // do this now to reduce lag when picking later, etc
+            preparePick();
+        }
+
+        // Set uniforms
+        setStructureUniforms(*program);
+        setSurfaceMeshUniforms(*program);
+        program->setUniform("u_baseColor", getSurfaceColor());
+
+        program->draw();
+    }
+
+    // Draw the quantities
+    for (auto& x : quantities) {
+        x.second->draw();
+    }
+
+    render::engine->setBackfaceCull(); // return to default setting
 }
 
 void SurfaceMesh::drawPick() {
-  if (!isEnabled()) {
-    return;
-  }
+    if (!isEnabled()) {
+        return;
+    }
 
-  if (pickProgram == nullptr) {
-    preparePick();
-  }
+    if (pickProgram == nullptr) {
+        preparePick();
+    }
 
-  render::engine->setBackfaceCull(backFacePolicy.get() == BackFacePolicy::Cull);
+    render::engine->setBackfaceCull(backFacePolicy.get() == BackFacePolicy::Cull);
 
-  // Set uniforms
-  setStructureUniforms(*pickProgram);
+    // Set uniforms
+    setStructureUniforms(*pickProgram);
 
-  pickProgram->draw();
+    pickProgram->draw();
 
-  render::engine->setBackfaceCull(); // return to default setting
+    render::engine->setBackfaceCull(); // return to default setting
 }
 
 void SurfaceMesh::prepare() {
-  program = render::engine->requestShader("MESH", addSurfaceMeshRules({"SHADE_BASECOLOR"}));
+    program = render::engine->requestShader("MESH", addSurfaceMeshRules({"SHADE_BASECOLOR"}));
 
-  // Populate draw buffers
-  fillGeometryBuffers(*program);
-  render::engine->setMaterial(*program, getMaterial());
+    // Populate draw buffers
+    fillGeometryBuffers(*program);
+    render::engine->setMaterial(*program, getMaterial());
 }
 
 void SurfaceMesh::preparePick() {
 
-  // Create a new program
-  pickProgram = render::engine->requestShader("MESH", addSurfaceMeshRules({"MESH_PROPAGATE_PICK"}, true, false),
-                                              render::ShaderReplacementDefaults::Pick);
+    // Create a new program
+    pickProgram = render::engine->requestShader("MESH", addSurfaceMeshRules({"MESH_PROPAGATE_PICK"}, true, false),
+                                                render::ShaderReplacementDefaults::Pick);
 
-  // Get element indices
-  size_t totalPickElements = nVertices() + nFaces() + nEdges() + nHalfedges();
+    // Get element indices
+    size_t totalPickElements = nVertices() + nFaces() + nEdges() + nHalfedges() + nCorners();
 
-  // In "local" indices, indexing elements only within this triMesh, used for reading later
-  facePickIndStart = nVertices();
-  edgePickIndStart = facePickIndStart + nFaces();
-  halfedgePickIndStart = edgePickIndStart + nEdges();
+    // In "local" indices, indexing elements only within this triMesh, used for reading later
+    facePickIndStart = nVertices();
+    edgePickIndStart = facePickIndStart + nFaces();
+    halfedgePickIndStart = edgePickIndStart + nEdges();
+    cornerPickIndStart = halfedgePickIndStart + nHalfedges();
 
-  // In "global" indices, indexing all elements in the scene, used to fill buffers for drawing here
-  size_t pickStart = pick::requestPickBufferRange(this, totalPickElements);
-  size_t faceGlobalPickIndStart = pickStart + nVertices();
-  size_t edgeGlobalPickIndStart = faceGlobalPickIndStart + nFaces();
-  size_t halfedgeGlobalPickIndStart = edgeGlobalPickIndStart + nEdges();
+    // In "global" indices, indexing all elements in the scene, used to fill buffers for drawing here
+    size_t pickStart = pick::requestPickBufferRange(this, totalPickElements);
+    size_t faceGlobalPickIndStart = pickStart + nVertices();
+    size_t edgeGlobalPickIndStart = faceGlobalPickIndStart + nFaces();
+    size_t halfedgeGlobalPickIndStart = edgeGlobalPickIndStart + nEdges();
+    size_t cornerGlobalPickIndStart = halfedgeGlobalPickIndStart + nHalfedges();
 
-  // == Fill buffers
-  bool wantsBarycenters = wantsCullPosition();
+    // == Fill buffers
+    bool wantsBarycenters = wantsCullPosition();
 
-  std::vector<glm::vec3> positions;
-  std::vector<glm::vec3> normals;
-  std::vector<glm::vec3> bcoord;
-  std::vector<std::array<glm::vec3, 3>> vertexColors, edgeColors, halfedgeColors;
-  std::vector<glm::vec3> faceColor;
-  std::vector<glm::vec3> barycenters;
+    std::vector<glm::vec3> positions;
+    std::vector<glm::vec3> normals;
+    std::vector<glm::vec3> bcoord;
+    std::vector<std::array<glm::vec3, 3>> vertexColors, edgeColors, halfedgeColors, cornerColors;
+    std::vector<glm::vec3> faceColor;
+    std::vector<glm::vec3> barycenters;
 
-  // Reserve space
-  positions.reserve(3 * nFacesTriangulation());
-  bcoord.reserve(3 * nFacesTriangulation());
-  vertexColors.reserve(3 * nFacesTriangulation());
-  edgeColors.reserve(3 * nFacesTriangulation());
-  halfedgeColors.reserve(3 * nFacesTriangulation());
-  faceColor.reserve(3 * nFacesTriangulation());
-  normals.reserve(3 * nFacesTriangulation());
-  if (wantsBarycenters) {
-    barycenters.reserve(3 * nFacesTriangulation());
-  }
-
-  // Build all quantities in each face
-  for (size_t iF = 0; iF < nFaces(); iF++) {
-    auto& face = faces[iF];
-    size_t D = face.size();
-    glm::vec3 faceN = faceNormals[iF];
-
-    glm::vec3 barycenter;
+    // Reserve space
+    positions.reserve(3 * nFacesTriangulation());
+    bcoord.reserve(3 * nFacesTriangulation());
+    vertexColors.reserve(3 * nFacesTriangulation());
+    edgeColors.reserve(3 * nFacesTriangulation());
+    halfedgeColors.reserve(3 * nFacesTriangulation());
+    cornerColors.reserve(3 * nFacesTriangulation());
+    faceColor.reserve(3 * nFacesTriangulation());
+    normals.reserve(3 * nFacesTriangulation());
     if (wantsBarycenters) {
-      barycenter = faceCenter(iF);
+        barycenters.reserve(3 * nFacesTriangulation());
     }
 
-    // implicitly triangulate from root
-    size_t vRoot = face[0];
-    glm::vec3 pRoot = vertices[vRoot];
-    for (size_t j = 1; (j + 1) < D; j++) {
-      size_t vB = face[j];
-      glm::vec3 pB = vertices[vB];
-      size_t vC = face[(j + 1) % D];
-      glm::vec3 pC = vertices[vC];
+    // Build all quantities in each face
+    for (size_t iF = 0; iF < nFaces(); iF++) {
+        auto& face = faces[iF];
+        size_t D = face.size();
+        glm::vec3 faceN = faceNormals[iF];
 
-      glm::vec3 fColor = pick::indToVec(iF + faceGlobalPickIndStart);
-      std::array<size_t, 3> vertexInds = {vRoot, vB, vC};
+        glm::vec3 barycenter;
+        if (wantsBarycenters) {
+            barycenter = faceCenter(iF);
+        }
 
-      positions.push_back(pRoot);
-      positions.push_back(pB);
-      positions.push_back(pC);
+        // implicitly triangulate from root
+        size_t vRoot = face[0];
+        glm::vec3 pRoot = vertices[vRoot];
+        for (size_t j = 1; (j + 1) < D; j++) {
+            size_t vB = face[j];
+            glm::vec3 pB = vertices[vB];
+            size_t vC = face[(j + 1) % D];
+            glm::vec3 pC = vertices[vC];
 
-      normals.push_back(faceN);
-      normals.push_back(faceN);
-      normals.push_back(faceN);
+            glm::vec3 fColor = pick::indToVec(iF + faceGlobalPickIndStart);
+            std::array<size_t, 3> vertexInds = {vRoot, vB, vC};
 
-      if (wantsBarycenters) {
-        barycenters.push_back(barycenter);
-        barycenters.push_back(barycenter);
-        barycenters.push_back(barycenter);
-      }
+            positions.push_back(pRoot);
+            positions.push_back(pB);
+            positions.push_back(pC);
 
-      // Build all quantities
-      std::array<glm::vec3, 3> vColor;
+            normals.push_back(faceN);
+            normals.push_back(faceN);
+            normals.push_back(faceN);
 
-      for (size_t i = 0; i < 3; i++) {
-        // Want just one copy of face color, so we can build it in the usual way
-        faceColor.push_back(fColor);
+            if (wantsBarycenters) {
+                barycenters.push_back(barycenter);
+                barycenters.push_back(barycenter);
+                barycenters.push_back(barycenter);
+            }
 
-        // Vertex index color
-        vColor[i] = pick::indToVec(vertexInds[i] + pickStart);
-      }
+            // Build all quantities
+            std::array<glm::vec3, 3> vColor;
 
-      std::array<glm::vec3, 3> eColor = {fColor, pick::indToVec(edgeIndices[iF][j] + edgeGlobalPickIndStart), fColor};
-      std::array<glm::vec3, 3> heColor = {fColor, pick::indToVec(halfedgeIndices[iF][j] + halfedgeGlobalPickIndStart),
-                                          fColor};
+            for (size_t i = 0; i < 3; i++) {
+                // Want just one copy of face color, so we can build it in the usual way
+                faceColor.push_back(fColor);
 
-      // First edge is a real edge
-      if (j == 1) {
-        eColor[0] = pick::indToVec(edgeIndices[iF][0] + edgeGlobalPickIndStart);
-        heColor[0] = pick::indToVec(halfedgeIndices[iF][0] + halfedgeGlobalPickIndStart);
-      }
-      // Last is a real edge
-      if (j + 2 == D) {
-        eColor[2] = pick::indToVec(edgeIndices[iF].back() + edgeGlobalPickIndStart);
-        heColor[2] = pick::indToVec(halfedgeIndices[iF].back() + halfedgeGlobalPickIndStart);
-      }
+                // Vertex index color
+                vColor[i] = pick::indToVec(vertexInds[i] + pickStart);
+            }
 
-      // Push three copies of the values needed at each vertex
-      for (int j = 0; j < 3; j++) {
-        vertexColors.push_back(vColor);
-        edgeColors.push_back(eColor);
-        halfedgeColors.push_back(heColor);
-      }
+            std::array<glm::vec3, 3> eColor = {fColor, pick::indToVec(edgeIndices[iF][j] + edgeGlobalPickIndStart),
+                                               fColor};
+            std::array<glm::vec3, 3> heColor = {
+                fColor, pick::indToVec(halfedgeIndices[iF][j] + halfedgeGlobalPickIndStart), fColor};
+            std::array<glm::vec3, 3> cColor = {
+                fColor, pick::indToVec(halfedgeIndices[iF][j] + cornerGlobalPickIndStart), fColor};
 
-      // Barycoords
-      bcoord.push_back(glm::vec3{1.0, 0.0, 0.0});
-      bcoord.push_back(glm::vec3{0.0, 1.0, 0.0});
-      bcoord.push_back(glm::vec3{0.0, 0.0, 1.0});
+            // First edge is a real edge
+            if (j == 1) {
+                eColor[0] = pick::indToVec(edgeIndices[iF][0] + edgeGlobalPickIndStart);
+                heColor[0] = pick::indToVec(halfedgeIndices[iF][0] + halfedgeGlobalPickIndStart);
+                cColor[0] = pick::indToVec(halfedgeIndices[iF][0] + cornerGlobalPickIndStart);
+            }
+            // Last is a real edge
+            if (j + 2 == D) {
+                eColor[2] = pick::indToVec(edgeIndices[iF].back() + edgeGlobalPickIndStart);
+                heColor[2] = pick::indToVec(halfedgeIndices[iF].back() + halfedgeGlobalPickIndStart);
+                cColor[2] = pick::indToVec(halfedgeIndices[iF].back() + cornerGlobalPickIndStart);
+            }
+
+            // Push three copies of the values needed at each vertex
+            for (int j = 0; j < 3; j++) {
+                vertexColors.push_back(vColor);
+                edgeColors.push_back(eColor);
+                halfedgeColors.push_back(heColor);
+                cornerColors.push_back(cColor);
+            }
+
+            // Barycoords
+            bcoord.push_back(glm::vec3{1.0, 0.0, 0.0});
+            bcoord.push_back(glm::vec3{0.0, 1.0, 0.0});
+            bcoord.push_back(glm::vec3{0.0, 0.0, 1.0});
+        }
     }
-  }
 
-  // Store data in buffers
-  pickProgram->setAttribute("a_position", positions);
-  pickProgram->setAttribute("a_barycoord", bcoord);
-  pickProgram->setAttribute("a_normal", normals);
-  pickProgram->setAttribute<glm::vec3, 3>("a_vertexColors", vertexColors);
-  pickProgram->setAttribute<glm::vec3, 3>("a_edgeColors", edgeColors);
-  pickProgram->setAttribute<glm::vec3, 3>("a_halfedgeColors", halfedgeColors);
-  pickProgram->setAttribute("a_faceColor", faceColor);
-  if (wantsCullPosition()) {
-    pickProgram->setAttribute("a_cullPos", barycenters);
-  }
+    // Store data in buffers
+    pickProgram->setAttribute("a_position", positions);
+    pickProgram->setAttribute("a_barycoord", bcoord);
+    pickProgram->setAttribute("a_normal", normals);
+    pickProgram->setAttribute<glm::vec3, 3>("a_vertexColors", vertexColors);
+    pickProgram->setAttribute<glm::vec3, 3>("a_edgeColors", edgeColors);
+    pickProgram->setAttribute<glm::vec3, 3>("a_halfedgeColors", halfedgeColors);
+    pickProgram->setAttribute<glm::vec3, 3>("a_cornerColors", cornerColors);
+    pickProgram->setAttribute("a_faceColor", faceColor);
+    if (wantsCullPosition()) {
+        pickProgram->setAttribute("a_cullPos", barycenters);
+    }
 }
 
 std::vector<std::string> SurfaceMesh::addSurfaceMeshRules(std::vector<std::string> initRules, bool withMesh,
                                                           bool withSurfaceShade) {
-  initRules = addStructureRules(initRules);
+    initRules = addStructureRules(initRules);
 
-  if (withMesh) {
+    if (withMesh) {
 
-    if (withSurfaceShade) {
-      // rules that only get used when we're shading the surface of the mesh
-      if (getEdgeWidth() > 0) {
-        initRules.push_back("MESH_WIREFRAME");
-      }
-      if (backFacePolicy.get() == BackFacePolicy::Different) {
-        initRules.push_back("MESH_BACKFACE_DARKEN");
-      }
-      if (backFacePolicy.get() == BackFacePolicy::Custom) {
-        initRules.push_back("MESH_BACKFACE_DIFFERENT");
-      }
+        if (withSurfaceShade) {
+            // rules that only get used when we're shading the surface of the mesh
+            if (getEdgeWidth() > 0) {
+                initRules.push_back("MESH_WIREFRAME");
+            }
+            if (backFacePolicy.get() == BackFacePolicy::Different) {
+                initRules.push_back("MESH_BACKFACE_DARKEN");
+            }
+            if (backFacePolicy.get() == BackFacePolicy::Custom) {
+                initRules.push_back("MESH_BACKFACE_DIFFERENT");
+            }
+        }
+
+        if (backFacePolicy.get() == BackFacePolicy::Identical) {
+            initRules.push_back("MESH_BACKFACE_NORMAL_FLIP");
+        }
+
+        if (backFacePolicy.get() == BackFacePolicy::Different) {
+            initRules.push_back("MESH_BACKFACE_NORMAL_FLIP");
+        }
+
+        if (backFacePolicy.get() == BackFacePolicy::Custom) {
+            initRules.push_back("MESH_BACKFACE_NORMAL_FLIP");
+        }
+
+        if (wantsCullPosition()) {
+            initRules.push_back("MESH_PROPAGATE_CULLPOS");
+        }
     }
-
-    if (backFacePolicy.get() == BackFacePolicy::Identical) {
-      initRules.push_back("MESH_BACKFACE_NORMAL_FLIP");
-    }
-
-    if (backFacePolicy.get() == BackFacePolicy::Different) {
-      initRules.push_back("MESH_BACKFACE_NORMAL_FLIP");
-    }
-
-    if (backFacePolicy.get() == BackFacePolicy::Custom) {
-      initRules.push_back("MESH_BACKFACE_NORMAL_FLIP");
-    }
-
-    if (wantsCullPosition()) {
-      initRules.push_back("MESH_PROPAGATE_CULLPOS");
-    }
-  }
-  return initRules;
+    return initRules;
 }
 
 void SurfaceMesh::setSurfaceMeshUniforms(render::ShaderProgram& p) {
-  if (getEdgeWidth() > 0) {
-    p.setUniform("u_edgeWidth", getEdgeWidth() * render::engine->getCurrentPixelScaling());
-    p.setUniform("u_edgeColor", getEdgeColor());
-  }
-  if (backFacePolicy.get() == BackFacePolicy::Custom) {
-    p.setUniform("u_backfaceColor", getBackFaceColor());
-  }
+    if (getEdgeWidth() > 0) {
+        p.setUniform("u_edgeWidth", getEdgeWidth() * render::engine->getCurrentPixelScaling());
+        p.setUniform("u_edgeColor", getEdgeColor());
+    }
+    if (backFacePolicy.get() == BackFacePolicy::Custom) {
+        p.setUniform("u_backfaceColor", getBackFaceColor());
+    }
 }
 
 void SurfaceMesh::fillGeometryBuffers(render::ShaderProgram& p) {
-  std::vector<glm::vec3> positions;
-  std::vector<glm::vec3> normals;
-  std::vector<glm::vec3> bcoord;
-  std::vector<glm::vec3> edgeReal;
-  std::vector<glm::vec3> barycenters;
+    std::vector<glm::vec3> positions;
+    std::vector<glm::vec3> normals;
+    std::vector<glm::vec3> bcoord;
+    std::vector<glm::vec3> edgeReal;
+    std::vector<glm::vec3> barycenters;
 
-  bool wantsBary = p.hasAttribute("a_barycoord");
-  bool wantsEdge = p.hasAttribute("a_edgeIsReal");
-  bool wantsBarycenters = wantsCullPosition();
+    bool wantsBary = p.hasAttribute("a_barycoord");
+    bool wantsEdge = p.hasAttribute("a_edgeIsReal");
+    bool wantsBarycenters = wantsCullPosition();
 
-  positions.reserve(3 * nFacesTriangulation());
-  normals.reserve(3 * nFacesTriangulation());
-  if (wantsBary) {
-    bcoord.reserve(3 * nFacesTriangulation());
-  }
-  if (wantsEdge) {
-    edgeReal.reserve(3 * nFacesTriangulation());
-  }
-  if (wantsBarycenters) {
-    barycenters.reserve(3 * nFacesTriangulation());
-  }
-
-  for (size_t iF = 0; iF < nFaces(); iF++) {
-    auto& face = faces[iF];
-    size_t D = face.size();
-    glm::vec3 faceN = faceNormals[iF];
-
-    glm::vec3 barycenter;
+    positions.reserve(3 * nFacesTriangulation());
+    normals.reserve(3 * nFacesTriangulation());
+    if (wantsBary) {
+        bcoord.reserve(3 * nFacesTriangulation());
+    }
+    if (wantsEdge) {
+        edgeReal.reserve(3 * nFacesTriangulation());
+    }
     if (wantsBarycenters) {
-      barycenter = faceCenter(iF);
+        barycenters.reserve(3 * nFacesTriangulation());
     }
 
-    // implicitly triangulate from root
-    size_t vRoot = face[0];
-    glm::vec3 pRoot = vertices[vRoot];
-    for (size_t j = 1; (j + 1) < D; j++) {
-      size_t vB = face[j];
-      glm::vec3 pB = vertices[vB];
-      size_t vC = face[(j + 1) % D];
-      glm::vec3 pC = vertices[vC];
+    for (size_t iF = 0; iF < nFaces(); iF++) {
+        auto& face = faces[iF];
+        size_t D = face.size();
+        glm::vec3 faceN = faceNormals[iF];
 
-      positions.push_back(pRoot);
-      positions.push_back(pB);
-      positions.push_back(pC);
-
-      if (isSmoothShade()) {
-        normals.push_back(vertexNormals[vRoot]);
-        normals.push_back(vertexNormals[vB]);
-        normals.push_back(vertexNormals[vC]);
-      } else {
-        normals.push_back(faceN);
-        normals.push_back(faceN);
-        normals.push_back(faceN);
-      }
-
-      if (wantsBary) {
-        bcoord.push_back(glm::vec3{1., 0., 0.});
-        bcoord.push_back(glm::vec3{0., 1., 0.});
-        bcoord.push_back(glm::vec3{0., 0., 1.});
-      }
-
-      if (wantsBarycenters) {
-        barycenters.push_back(barycenter);
-        barycenters.push_back(barycenter);
-        barycenters.push_back(barycenter);
-      }
-
-      if (wantsEdge) {
-        glm::vec3 edgeRealV{0., 1., 0.};
-        if (j == 1) {
-          edgeRealV.x = 1.;
+        glm::vec3 barycenter;
+        if (wantsBarycenters) {
+            barycenter = faceCenter(iF);
         }
-        if (j + 2 == D) {
-          edgeRealV.z = 1.;
+
+        // implicitly triangulate from root
+        size_t vRoot = face[0];
+        glm::vec3 pRoot = vertices[vRoot];
+        for (size_t j = 1; (j + 1) < D; j++) {
+            size_t vB = face[j];
+            glm::vec3 pB = vertices[vB];
+            size_t vC = face[(j + 1) % D];
+            glm::vec3 pC = vertices[vC];
+
+            positions.push_back(pRoot);
+            positions.push_back(pB);
+            positions.push_back(pC);
+
+            if (isSmoothShade()) {
+                normals.push_back(vertexNormals[vRoot]);
+                normals.push_back(vertexNormals[vB]);
+                normals.push_back(vertexNormals[vC]);
+            } else {
+                normals.push_back(faceN);
+                normals.push_back(faceN);
+                normals.push_back(faceN);
+            }
+
+            if (wantsBary) {
+                bcoord.push_back(glm::vec3{1., 0., 0.});
+                bcoord.push_back(glm::vec3{0., 1., 0.});
+                bcoord.push_back(glm::vec3{0., 0., 1.});
+            }
+
+            if (wantsBarycenters) {
+                barycenters.push_back(barycenter);
+                barycenters.push_back(barycenter);
+                barycenters.push_back(barycenter);
+            }
+
+            if (wantsEdge) {
+                glm::vec3 edgeRealV{0., 1., 0.};
+                if (j == 1) {
+                    edgeRealV.x = 1.;
+                }
+                if (j + 2 == D) {
+                    edgeRealV.z = 1.;
+                }
+                edgeReal.push_back(edgeRealV);
+                edgeReal.push_back(edgeRealV);
+                edgeReal.push_back(edgeRealV);
+            }
         }
-        edgeReal.push_back(edgeRealV);
-        edgeReal.push_back(edgeRealV);
-        edgeReal.push_back(edgeRealV);
-      }
     }
-  }
 
-  // Store data in buffers
-  p.setAttribute("a_position", positions);
-  p.setAttribute("a_normal", normals);
-  if (wantsBary) {
-    p.setAttribute("a_barycoord", bcoord);
-  }
-  if (wantsEdge) {
-    p.setAttribute("a_edgeIsReal", edgeReal);
-  }
-  if (wantsCullPosition()) {
-    p.setAttribute("a_cullPos", barycenters);
-  }
+    // Store data in buffers
+    p.setAttribute("a_position", positions);
+    p.setAttribute("a_normal", normals);
+    if (wantsBary) {
+        p.setAttribute("a_barycoord", bcoord);
+    }
+    if (wantsEdge) {
+        p.setAttribute("a_edgeIsReal", edgeReal);
+    }
+    if (wantsCullPosition()) {
+        p.setAttribute("a_cullPos", barycenters);
+    }
 }
 
 void SurfaceMesh::buildPickUI(size_t localPickID) {
 
-  // Selection type
-  if (localPickID < facePickIndStart) {
-    buildVertexInfoGui(localPickID);
-  } else if (localPickID < edgePickIndStart) {
-    buildFaceInfoGui(localPickID - facePickIndStart);
-  } else if (localPickID < halfedgePickIndStart) {
-    buildEdgeInfoGui(localPickID - edgePickIndStart);
-  } else {
-    buildHalfedgeInfoGui(localPickID - halfedgePickIndStart);
-  }
+    // Selection type
+    if (localPickID < facePickIndStart) {
+        buildVertexInfoGui(localPickID);
+    } else if (localPickID < edgePickIndStart) {
+        buildFaceInfoGui(localPickID - facePickIndStart);
+    } else if (localPickID < halfedgePickIndStart) {
+        buildEdgeInfoGui(localPickID - edgePickIndStart);
+    } else if (localPickID < cornerPickIndStart) {
+        buildHalfedgeInfoGui(localPickID - halfedgePickIndStart);
+    } else {
+        buildCornerInfoGui(localPickID - cornerPickIndStart);
+    }
 }
 
 // void SurfaceMesh::getPickedElement(size_t localPickID, VertexPtr& vOut, FacePtr& fOut, EdgePtr& eOut,
@@ -686,12 +702,12 @@ void SurfaceMesh::buildPickUI(size_t localPickID) {
 
 glm::vec2 SurfaceMesh::projectToScreenSpace(glm::vec3 coord) {
 
-  glm::mat4 viewMat = getModelView();
-  glm::mat4 projMat = view::getCameraPerspectiveMatrix();
-  glm::vec4 coord4(coord.x, coord.y, coord.z, 1.0);
-  glm::vec4 screenPoint = projMat * viewMat * coord4;
+    glm::mat4 viewMat = getModelView();
+    glm::mat4 projMat = view::getCameraPerspectiveMatrix();
+    glm::vec4 coord4(coord.x, coord.y, coord.z, 1.0);
+    glm::vec4 screenPoint = projMat * viewMat * coord4;
 
-  return glm::vec2{screenPoint.x, screenPoint.y} / screenPoint.w;
+    return glm::vec2{screenPoint.x, screenPoint.y} / screenPoint.w;
 }
 
 // TODO fix up all of these
@@ -736,288 +752,311 @@ glm::vec2 SurfaceMesh::projectToScreenSpace(glm::vec3 coord) {
 
 void SurfaceMesh::buildVertexInfoGui(size_t vInd) {
 
-  size_t displayInd = vInd;
-  if (vertexPerm.size() > 0) {
-    displayInd = vertexPerm[vInd];
-  }
-  ImGui::TextUnformatted(("Vertex #" + std::to_string(displayInd)).c_str());
+    size_t displayInd = vInd;
+    if (vertexPerm.size() > 0) {
+        displayInd = vertexPerm[vInd];
+    }
+    ImGui::TextUnformatted(("Vertex #" + std::to_string(displayInd)).c_str());
 
-  std::stringstream buffer;
-  buffer << vertices[vInd];
-  ImGui::TextUnformatted(("Position: " + buffer.str()).c_str());
+    std::stringstream buffer;
+    buffer << vertices[vInd];
+    ImGui::TextUnformatted(("Position: " + buffer.str()).c_str());
 
-  ImGui::Spacing();
-  ImGui::Spacing();
-  ImGui::Spacing();
-  ImGui::Indent(20.);
+    ImGui::Spacing();
+    ImGui::Spacing();
+    ImGui::Spacing();
+    ImGui::Indent(20.);
 
-  // Build GUI to show the quantities
-  ImGui::Columns(2);
-  ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
-  for (auto& x : quantities) {
-    x.second->buildVertexInfoGUI(vInd);
-  }
+    // Build GUI to show the quantities
+    ImGui::Columns(2);
+    ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
+    for (auto& x : quantities) {
+        x.second->buildVertexInfoGUI(vInd);
+    }
 
-  ImGui::Indent(-20.);
+    ImGui::Indent(-20.);
 }
 
 void SurfaceMesh::buildFaceInfoGui(size_t fInd) {
-  size_t displayInd = fInd;
-  if (facePerm.size() > 0) {
-    displayInd = facePerm[fInd];
-  }
-  ImGui::TextUnformatted(("Face #" + std::to_string(displayInd)).c_str());
+    size_t displayInd = fInd;
+    if (facePerm.size() > 0) {
+        displayInd = facePerm[fInd];
+    }
+    ImGui::TextUnformatted(("Face #" + std::to_string(displayInd)).c_str());
 
-  ImGui::Spacing();
-  ImGui::Spacing();
-  ImGui::Spacing();
-  ImGui::Indent(20.);
+    ImGui::Spacing();
+    ImGui::Spacing();
+    ImGui::Spacing();
+    ImGui::Indent(20.);
 
-  // Build GUI to show the quantities
-  ImGui::Columns(2);
-  ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
-  for (auto& x : quantities) {
-    x.second->buildFaceInfoGUI(fInd);
-  }
+    // Build GUI to show the quantities
+    ImGui::Columns(2);
+    ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
+    for (auto& x : quantities) {
+        x.second->buildFaceInfoGUI(fInd);
+    }
 
-  ImGui::Indent(-20.);
+    ImGui::Indent(-20.);
 }
 
 void SurfaceMesh::buildEdgeInfoGui(size_t eInd) {
-  size_t displayInd = eInd;
-  if (edgePerm.size() > 0) {
-    displayInd = edgePerm[eInd];
-  }
-  ImGui::TextUnformatted(("Edge #" + std::to_string(displayInd)).c_str());
+    size_t displayInd = eInd;
+    if (edgePerm.size() > 0) {
+        displayInd = edgePerm[eInd];
+    }
+    ImGui::TextUnformatted(("Edge #" + std::to_string(displayInd)).c_str());
 
-  ImGui::Spacing();
-  ImGui::Spacing();
-  ImGui::Spacing();
-  ImGui::Indent(20.);
+    ImGui::Spacing();
+    ImGui::Spacing();
+    ImGui::Spacing();
+    ImGui::Indent(20.);
 
-  // Build GUI to show the quantities
-  ImGui::Columns(2);
-  ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
-  for (auto& x : quantities) {
-    x.second->buildEdgeInfoGUI(eInd);
-  }
+    // Build GUI to show the quantities
+    ImGui::Columns(2);
+    ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
+    for (auto& x : quantities) {
+        x.second->buildEdgeInfoGUI(eInd);
+    }
 
-  ImGui::Indent(-20.);
+    ImGui::Indent(-20.);
 }
 
 void SurfaceMesh::buildHalfedgeInfoGui(size_t heInd) {
-  size_t displayInd = heInd;
-  if (halfedgePerm.size() > 0) {
-    displayInd = halfedgePerm[heInd];
-  }
-  ImGui::TextUnformatted(("Halfedge #" + std::to_string(displayInd)).c_str());
+    size_t displayInd = heInd;
+    if (halfedgePerm.size() > 0) {
+        displayInd = halfedgePerm[heInd];
+    }
+    ImGui::TextUnformatted(("Halfedge #" + std::to_string(displayInd)).c_str());
 
-  ImGui::Spacing();
-  ImGui::Spacing();
-  ImGui::Spacing();
-  ImGui::Indent(20.);
+    ImGui::Spacing();
+    ImGui::Spacing();
+    ImGui::Spacing();
+    ImGui::Indent(20.);
 
-  // Build GUI to show the quantities
-  ImGui::Columns(2);
-  ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
-  for (auto& x : quantities) {
-    x.second->buildHalfedgeInfoGUI(heInd);
-  }
+    // Build GUI to show the quantities
+    ImGui::Columns(2);
+    ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
+    for (auto& x : quantities) {
+        x.second->buildHalfedgeInfoGUI(heInd);
+    }
 
-  ImGui::Indent(-20.);
+    ImGui::Indent(-20.);
+}
+
+void SurfaceMesh::buildCornerInfoGui(size_t cInd) {
+    size_t displayInd = cInd;
+    if (cornerPerm.size() > 0) {
+        displayInd = cornerPerm[cInd];
+    }
+    ImGui::TextUnformatted(("Corner #" + std::to_string(displayInd)).c_str());
+
+    ImGui::Spacing();
+    ImGui::Spacing();
+    ImGui::Spacing();
+    ImGui::Indent(20.);
+
+    // Build GUI to show the quantities
+    ImGui::Columns(2);
+    ImGui::SetColumnWidth(0, ImGui::GetWindowWidth() / 3);
+    for (auto& x : quantities) {
+        x.second->buildCornerInfoGUI(cInd);
+    }
+
+    ImGui::Indent(-20.);
 }
 
 
 void SurfaceMesh::buildCustomUI() {
 
-  // Print stats
-  long long int nVertsL = static_cast<long long int>(nVertices());
-  long long int nFacesL = static_cast<long long int>(nFaces());
-  ImGui::Text("#verts: %lld  #faces: %lld", nVertsL, nFacesL);
+    // Print stats
+    long long int nVertsL = static_cast<long long int>(nVertices());
+    long long int nFacesL = static_cast<long long int>(nFaces());
+    ImGui::Text("#verts: %lld  #faces: %lld", nVertsL, nFacesL);
 
-  { // colors
-    if (ImGui::ColorEdit3("Color", &surfaceColor.get()[0], ImGuiColorEditFlags_NoInputs))
-      setSurfaceColor(surfaceColor.get());
-    ImGui::SameLine();
-  }
-
-  { // Flat shading or smooth shading?
-    ImGui::SameLine();
-    if (ImGui::Checkbox("Smooth", &shadeSmooth.get())) setSmoothShade(shadeSmooth.get());
-  }
-
-  ImGui::SameLine();
-  { // Edge options
-    ImGui::PushItemWidth(100);
-    if (edgeWidth.get() == 0.) {
-      bool showEdges = false;
-      if (ImGui::Checkbox("Edges", &showEdges)) {
-        setEdgeWidth(1.);
-      }
-    } else {
-      bool showEdges = true;
-      if (ImGui::Checkbox("Edges", &showEdges)) {
-        setEdgeWidth(0.);
-      }
-
-      // Edge color
-      ImGui::PushItemWidth(100);
-      if (ImGui::ColorEdit3("Edge Color", &edgeColor.get()[0], ImGuiColorEditFlags_NoInputs))
-        setEdgeColor(edgeColor.get());
-      ImGui::PopItemWidth();
-
-      // Edge width
-      ImGui::SameLine();
-      ImGui::PushItemWidth(60);
-      if (ImGui::SliderFloat("Width", &edgeWidth.get(), 0.001, 2.)) {
-        // NOTE: this intentionally circumvents the setEdgeWidth() setter to avoid repopulating the buffer as the slider
-        // is dragged---otherwise we repopulate the buffer on every change, which mostly works fine. This is a lazy
-        // solution instead of better state/buffer management.
-        // setEdgeWidth(getEdgeWidth());
-        edgeWidth.manuallyChanged();
-        requestRedraw();
-      }
-      ImGui::PopItemWidth();
+    { // colors
+        if (ImGui::ColorEdit3("Color", &surfaceColor.get()[0], ImGuiColorEditFlags_NoInputs))
+            setSurfaceColor(surfaceColor.get());
+        ImGui::SameLine();
     }
-    ImGui::PopItemWidth();
-  }
-  if (backFacePolicy.get() == BackFacePolicy::Custom) {
-    if (ImGui::ColorEdit3("Backface Color", &backFaceColor.get()[0], ImGuiColorEditFlags_NoInputs))
-      setBackFaceColor(backFaceColor.get());
-  }
+
+    { // Flat shading or smooth shading?
+        ImGui::SameLine();
+        if (ImGui::Checkbox("Smooth", &shadeSmooth.get())) setSmoothShade(shadeSmooth.get());
+    }
+
+    ImGui::SameLine();
+    { // Edge options
+        ImGui::PushItemWidth(100);
+        if (edgeWidth.get() == 0.) {
+            bool showEdges = false;
+            if (ImGui::Checkbox("Edges", &showEdges)) {
+                setEdgeWidth(1.);
+            }
+        } else {
+            bool showEdges = true;
+            if (ImGui::Checkbox("Edges", &showEdges)) {
+                setEdgeWidth(0.);
+            }
+
+            // Edge color
+            ImGui::PushItemWidth(100);
+            if (ImGui::ColorEdit3("Edge Color", &edgeColor.get()[0], ImGuiColorEditFlags_NoInputs))
+                setEdgeColor(edgeColor.get());
+            ImGui::PopItemWidth();
+
+            // Edge width
+            ImGui::SameLine();
+            ImGui::PushItemWidth(60);
+            if (ImGui::SliderFloat("Width", &edgeWidth.get(), 0.001, 2.)) {
+                // NOTE: this intentionally circumvents the setEdgeWidth() setter to avoid repopulating the buffer as
+                // the slider is dragged---otherwise we repopulate the buffer on every change, which mostly works fine.
+                // This is a lazy solution instead of better state/buffer management. setEdgeWidth(getEdgeWidth());
+                edgeWidth.manuallyChanged();
+                requestRedraw();
+            }
+            ImGui::PopItemWidth();
+        }
+        ImGui::PopItemWidth();
+    }
+    if (backFacePolicy.get() == BackFacePolicy::Custom) {
+        if (ImGui::ColorEdit3("Backface Color", &backFaceColor.get()[0], ImGuiColorEditFlags_NoInputs))
+            setBackFaceColor(backFaceColor.get());
+    }
 }
 
 
 void SurfaceMesh::buildCustomOptionsUI() {
-  if (render::buildMaterialOptionsGui(material.get())) {
-    material.manuallyChanged();
-    setMaterial(material.get()); // trigger the other updates that happen on set()
-  }
+    if (render::buildMaterialOptionsGui(material.get())) {
+        material.manuallyChanged();
+        setMaterial(material.get()); // trigger the other updates that happen on set()
+    }
 
-  // backfaces
-  if (ImGui::BeginMenu("Back Face Policy")) {
-    if (ImGui::MenuItem("identical shading", NULL, backFacePolicy.get() == BackFacePolicy::Identical))
-      setBackFacePolicy(BackFacePolicy::Identical);
-    if (ImGui::MenuItem("different shading", NULL, backFacePolicy.get() == BackFacePolicy::Different))
-      setBackFacePolicy(BackFacePolicy::Different);
-    if (ImGui::MenuItem("custom shading", NULL, backFacePolicy.get() == BackFacePolicy::Custom))
-      setBackFacePolicy(BackFacePolicy::Custom);
-    if (ImGui::MenuItem("cull", NULL, backFacePolicy.get() == BackFacePolicy::Cull))
-      setBackFacePolicy(BackFacePolicy::Cull);
-    ImGui::EndMenu();
-  }
+    // backfaces
+    if (ImGui::BeginMenu("Back Face Policy")) {
+        if (ImGui::MenuItem("identical shading", NULL, backFacePolicy.get() == BackFacePolicy::Identical))
+            setBackFacePolicy(BackFacePolicy::Identical);
+        if (ImGui::MenuItem("different shading", NULL, backFacePolicy.get() == BackFacePolicy::Different))
+            setBackFacePolicy(BackFacePolicy::Different);
+        if (ImGui::MenuItem("custom shading", NULL, backFacePolicy.get() == BackFacePolicy::Custom))
+            setBackFacePolicy(BackFacePolicy::Custom);
+        if (ImGui::MenuItem("cull", NULL, backFacePolicy.get() == BackFacePolicy::Cull))
+            setBackFacePolicy(BackFacePolicy::Cull);
+        ImGui::EndMenu();
+    }
 }
 
 
 void SurfaceMesh::refresh() {
-  computeGeometryData();
-  program.reset();
-  pickProgram.reset();
-  requestRedraw();
-  QuantityStructure<SurfaceMesh>::refresh(); // call base class version, which refreshes quantities
+    computeGeometryData();
+    program.reset();
+    pickProgram.reset();
+    requestRedraw();
+    QuantityStructure<SurfaceMesh>::refresh(); // call base class version, which refreshes quantities
 }
 
 void SurfaceMesh::geometryChanged() {
 
-  computeGeometryData();
-  if (program) {
-    fillGeometryBuffers(*program);
-  }
-  if (pickProgram) {
-    fillGeometryBuffers(*pickProgram);
-  }
-  requestRedraw();
-  QuantityStructure<SurfaceMesh>::refresh();
+    computeGeometryData();
+    if (program) {
+        fillGeometryBuffers(*program);
+    }
+    if (pickProgram) {
+        fillGeometryBuffers(*pickProgram);
+    }
+    requestRedraw();
+    QuantityStructure<SurfaceMesh>::refresh();
 }
 
 void SurfaceMesh::updateObjectSpaceBounds() {
-  // bounding box
-  glm::vec3 min = glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
-  glm::vec3 max = -glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
-  for (const glm::vec3& p : vertices) {
-    min = componentwiseMin(min, p);
-    max = componentwiseMax(max, p);
-  }
-  objectSpaceBoundingBox = std::make_tuple(min, max);
+    // bounding box
+    glm::vec3 min = glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
+    glm::vec3 max = -glm::vec3{1, 1, 1} * std::numeric_limits<float>::infinity();
+    for (const glm::vec3& p : vertices) {
+        min = componentwiseMin(min, p);
+        max = componentwiseMax(max, p);
+    }
+    objectSpaceBoundingBox = std::make_tuple(min, max);
 
-  // length scale, as twice the radius from the center of the bounding box
-  glm::vec3 center = 0.5f * (min + max);
-  float lengthScale = 0.0;
-  for (const glm::vec3& p : vertices) {
-    lengthScale = std::max(lengthScale, glm::length2(p - center));
-  }
-  objectSpaceLengthScale = 2 * std::sqrt(lengthScale);
+    // length scale, as twice the radius from the center of the bounding box
+    glm::vec3 center = 0.5f * (min + max);
+    float lengthScale = 0.0;
+    for (const glm::vec3& p : vertices) {
+        lengthScale = std::max(lengthScale, glm::length2(p - center));
+    }
+    objectSpaceLengthScale = 2 * std::sqrt(lengthScale);
 }
 
-std::string SurfaceMesh::typeName() { return structureTypeName; }
+std::string SurfaceMesh::typeName() {
+    return structureTypeName;
+}
 
 long long int SurfaceMesh::selectVertex() {
 
-  // Make sure we can see edges
-  float oldEdgeWidth = getEdgeWidth();
-  setEdgeWidth(1.);
-  this->setEnabled(true);
+    // Make sure we can see edges
+    float oldEdgeWidth = getEdgeWidth();
+    setEdgeWidth(1.);
+    this->setEnabled(true);
 
-  long long int returnVertInd = -1;
+    long long int returnVertInd = -1;
 
-  // Register the callback which creates the UI and does the hard work
-  auto focusedPopupUI = [&]() {
-    { // Create a window with instruction and a close button.
-      static bool showWindow = true;
-      ImGui::SetNextWindowSize(ImVec2(300, 0), ImGuiCond_Once);
-      ImGui::Begin("Select vertex", &showWindow);
+    // Register the callback which creates the UI and does the hard work
+    auto focusedPopupUI = [&]() {
+        { // Create a window with instruction and a close button.
+            static bool showWindow = true;
+            ImGui::SetNextWindowSize(ImVec2(300, 0), ImGuiCond_Once);
+            ImGui::Begin("Select vertex", &showWindow);
 
-      ImGui::PushItemWidth(300);
-      ImGui::TextUnformatted("Hold ctrl and left-click to select a vertex");
-      ImGui::Separator();
+            ImGui::PushItemWidth(300);
+            ImGui::TextUnformatted("Hold ctrl and left-click to select a vertex");
+            ImGui::Separator();
 
-      // Choose by number
-      ImGui::PushItemWidth(300);
-      static int iV = -1;
-      ImGui::InputInt("index", &iV);
-      if (ImGui::Button("Select by index")) {
-        if (iV >= 0 && (size_t)iV < nVertices()) {
-          returnVertInd = iV;
-          popContext();
+            // Choose by number
+            ImGui::PushItemWidth(300);
+            static int iV = -1;
+            ImGui::InputInt("index", &iV);
+            if (ImGui::Button("Select by index")) {
+                if (iV >= 0 && (size_t)iV < nVertices()) {
+                    returnVertInd = iV;
+                    popContext();
+                }
+            }
+            ImGui::PopItemWidth();
+
+            ImGui::Separator();
+            if (ImGui::Button("Abort")) {
+                popContext();
+            }
+
+            ImGui::End();
         }
-      }
-      ImGui::PopItemWidth();
 
-      ImGui::Separator();
-      if (ImGui::Button("Abort")) {
-        popContext();
-      }
+        ImGuiIO& io = ImGui::GetIO();
+        if (io.KeyCtrl && !io.WantCaptureMouse && ImGui::IsMouseClicked(0)) {
 
-      ImGui::End();
-    }
+            ImGuiIO& io = ImGui::GetIO();
 
-    ImGuiIO& io = ImGui::GetIO();
-    if (io.KeyCtrl && !io.WantCaptureMouse && ImGui::IsMouseClicked(0)) {
+            // API is a giant mess..
+            size_t pickInd;
+            ImVec2 p = ImGui::GetMousePos();
+            std::pair<Structure*, size_t> pickVal =
+                pick::evaluatePickQuery(io.DisplayFramebufferScale.x * p.x, io.DisplayFramebufferScale.y * p.y);
 
-      ImGuiIO& io = ImGui::GetIO();
+            if (pickVal.first == this) {
 
-      // API is a giant mess..
-      size_t pickInd;
-      ImVec2 p = ImGui::GetMousePos();
-      std::pair<Structure*, size_t> pickVal =
-          pick::evaluatePickQuery(io.DisplayFramebufferScale.x * p.x, io.DisplayFramebufferScale.y * p.y);
-
-      if (pickVal.first == this) {
-
-        if (pickVal.second < nVertices()) {
-          returnVertInd = pickVal.second;
-          popContext();
+                if (pickVal.second < nVertices()) {
+                    returnVertInd = pickVal.second;
+                    popContext();
+                }
+            }
         }
-      }
-    }
-  };
+    };
 
-  // Pass control to the context we just created
-  pushContext(focusedPopupUI);
+    // Pass control to the context we just created
+    pushContext(focusedPopupUI);
 
-  setEdgeWidth(oldEdgeWidth); // restore edge setting
+    setEdgeWidth(oldEdgeWidth); // restore edge setting
 
-  return returnVertInd;
+    return returnVertInd;
 }
 
 /*
@@ -1106,230 +1145,252 @@ FacePtr SurfaceMesh::selectFace() {
 // === Option getters and setters
 
 SurfaceMesh* SurfaceMesh::setSmoothShade(bool isSmooth) {
-  shadeSmooth = isSmooth;
-  refresh();
-  requestRedraw();
-  return this;
+    shadeSmooth = isSmooth;
+    refresh();
+    requestRedraw();
+    return this;
 }
-bool SurfaceMesh::isSmoothShade() { return shadeSmooth.get(); }
+bool SurfaceMesh::isSmoothShade() {
+    return shadeSmooth.get();
+}
 
 SurfaceMesh* SurfaceMesh::setBackFaceColor(glm::vec3 val) {
-  backFaceColor.set(val);
-  requestRedraw();
-  return this;
+    backFaceColor.set(val);
+    requestRedraw();
+    return this;
 }
 
-glm::vec3 SurfaceMesh::getBackFaceColor() { return backFaceColor.get(); }
+glm::vec3 SurfaceMesh::getBackFaceColor() {
+    return backFaceColor.get();
+}
 
 SurfaceMesh* SurfaceMesh::setSurfaceColor(glm::vec3 val) {
-  surfaceColor = val;
-  requestRedraw();
-  return this;
+    surfaceColor = val;
+    requestRedraw();
+    return this;
 }
-glm::vec3 SurfaceMesh::getSurfaceColor() { return surfaceColor.get(); }
+glm::vec3 SurfaceMesh::getSurfaceColor() {
+    return surfaceColor.get();
+}
 
 SurfaceMesh* SurfaceMesh::setEdgeColor(glm::vec3 val) {
-  edgeColor = val;
-  requestRedraw();
-  return this;
+    edgeColor = val;
+    requestRedraw();
+    return this;
 }
-glm::vec3 SurfaceMesh::getEdgeColor() { return edgeColor.get(); }
+glm::vec3 SurfaceMesh::getEdgeColor() {
+    return edgeColor.get();
+}
 
 SurfaceMesh* SurfaceMesh::setMaterial(std::string m) {
-  material = m;
-  refresh(); // (serves the purpose of re-initializing everything, though this is a bit overkill)
-  requestRedraw();
-  return this;
+    material = m;
+    refresh(); // (serves the purpose of re-initializing everything, though this is a bit overkill)
+    requestRedraw();
+    return this;
 }
-std::string SurfaceMesh::getMaterial() { return material.get(); }
+std::string SurfaceMesh::getMaterial() {
+    return material.get();
+}
 
 SurfaceMesh* SurfaceMesh::setEdgeWidth(double newVal) {
-  edgeWidth = newVal;
-  refresh();
-  requestRedraw();
-  return this;
+    edgeWidth = newVal;
+    refresh();
+    requestRedraw();
+    return this;
 }
-double SurfaceMesh::getEdgeWidth() { return edgeWidth.get(); }
+double SurfaceMesh::getEdgeWidth() {
+    return edgeWidth.get();
+}
 
 SurfaceMesh* SurfaceMesh::setBackFacePolicy(BackFacePolicy newPolicy) {
-  backFacePolicy = newPolicy;
-  refresh();
-  requestRedraw();
-  return this;
+    backFacePolicy = newPolicy;
+    refresh();
+    requestRedraw();
+    return this;
 }
-BackFacePolicy SurfaceMesh::getBackFacePolicy() { return backFacePolicy.get(); }
+BackFacePolicy SurfaceMesh::getBackFacePolicy() {
+    return backFacePolicy.get();
+}
 
 // === Quantity adders
 
 
 SurfaceVertexColorQuantity* SurfaceMesh::addVertexColorQuantityImpl(std::string name,
                                                                     const std::vector<glm::vec3>& colors) {
-  SurfaceVertexColorQuantity* q = new SurfaceVertexColorQuantity(name, applyPermutation(colors, vertexPerm), *this);
-  addQuantity(q);
-  return q;
+    SurfaceVertexColorQuantity* q = new SurfaceVertexColorQuantity(name, applyPermutation(colors, vertexPerm), *this);
+    addQuantity(q);
+    return q;
 }
 
 SurfaceFaceColorQuantity* SurfaceMesh::addFaceColorQuantityImpl(std::string name,
                                                                 const std::vector<glm::vec3>& colors) {
-  SurfaceFaceColorQuantity* q = new SurfaceFaceColorQuantity(name, applyPermutation(colors, facePerm), *this);
-  addQuantity(q);
-  return q;
+    SurfaceFaceColorQuantity* q = new SurfaceFaceColorQuantity(name, applyPermutation(colors, facePerm), *this);
+    addQuantity(q);
+    return q;
 }
 
 SurfaceVertexScalarQuantity* SurfaceMesh::addVertexDistanceQuantityImpl(std::string name,
                                                                         const std::vector<double>& data) {
-  SurfaceVertexScalarQuantity* q =
-      new SurfaceVertexScalarQuantity(name, applyPermutation(data, vertexPerm), *this, DataType::MAGNITUDE);
+    SurfaceVertexScalarQuantity* q =
+        new SurfaceVertexScalarQuantity(name, applyPermutation(data, vertexPerm), *this, DataType::MAGNITUDE);
 
-  q->setIsolinesEnabled(true);
-  q->setIsolineWidth(0.02, true);
+    q->setIsolinesEnabled(true);
+    q->setIsolineWidth(0.02, true);
 
-  addQuantity(q);
-  return q;
+    addQuantity(q);
+    return q;
 }
 
 SurfaceVertexScalarQuantity* SurfaceMesh::addVertexSignedDistanceQuantityImpl(std::string name,
                                                                               const std::vector<double>& data) {
-  SurfaceVertexScalarQuantity* q =
-      new SurfaceVertexScalarQuantity(name, applyPermutation(data, vertexPerm), *this, DataType::SYMMETRIC);
+    SurfaceVertexScalarQuantity* q =
+        new SurfaceVertexScalarQuantity(name, applyPermutation(data, vertexPerm), *this, DataType::SYMMETRIC);
 
-  q->setIsolinesEnabled(true);
-  q->setIsolineWidth(0.02, true);
+    q->setIsolinesEnabled(true);
+    q->setIsolineWidth(0.02, true);
 
-  addQuantity(q);
-  return q;
+    addQuantity(q);
+    return q;
 }
 
 SurfaceCornerParameterizationQuantity*
 SurfaceMesh::addParameterizationQuantityImpl(std::string name, const std::vector<glm::vec2>& coords,
                                              ParamCoordsType type) {
-  SurfaceCornerParameterizationQuantity* q = new SurfaceCornerParameterizationQuantity(
-      name, applyPermutation(coords, cornerPerm), type, ParamVizStyle::CHECKER, *this);
-  addQuantity(q);
+    SurfaceCornerParameterizationQuantity* q = new SurfaceCornerParameterizationQuantity(
+        name, applyPermutation(coords, cornerPerm), type, ParamVizStyle::CHECKER, *this);
+    addQuantity(q);
 
-  return q;
+    return q;
 }
 
 SurfaceVertexParameterizationQuantity*
 SurfaceMesh::addVertexParameterizationQuantityImpl(std::string name, const std::vector<glm::vec2>& coords,
                                                    ParamCoordsType type) {
-  SurfaceVertexParameterizationQuantity* q = new SurfaceVertexParameterizationQuantity(
-      name, applyPermutation(coords, vertexPerm), type, ParamVizStyle::CHECKER, *this);
-  addQuantity(q);
+    SurfaceVertexParameterizationQuantity* q = new SurfaceVertexParameterizationQuantity(
+        name, applyPermutation(coords, vertexPerm), type, ParamVizStyle::CHECKER, *this);
+    addQuantity(q);
 
-  return q;
+    return q;
 }
 
 SurfaceVertexParameterizationQuantity*
 SurfaceMesh::addLocalParameterizationQuantityImpl(std::string name, const std::vector<glm::vec2>& coords,
                                                   ParamCoordsType type) {
-  SurfaceVertexParameterizationQuantity* q = new SurfaceVertexParameterizationQuantity(
-      name, applyPermutation(coords, vertexPerm), type, ParamVizStyle::LOCAL_CHECK, *this);
-  addQuantity(q);
+    SurfaceVertexParameterizationQuantity* q = new SurfaceVertexParameterizationQuantity(
+        name, applyPermutation(coords, vertexPerm), type, ParamVizStyle::LOCAL_CHECK, *this);
+    addQuantity(q);
 
-  return q;
+    return q;
 }
 
 
 SurfaceVertexCountQuantity* SurfaceMesh::addVertexCountQuantityImpl(std::string name,
                                                                     const std::vector<std::pair<size_t, int>>& values) {
 
-  SurfaceVertexCountQuantity* q = new SurfaceVertexCountQuantity(name, values, *this);
-  addQuantity(q);
-  return q;
+    SurfaceVertexCountQuantity* q = new SurfaceVertexCountQuantity(name, values, *this);
+    addQuantity(q);
+    return q;
 }
 
 SurfaceVertexIsolatedScalarQuantity*
 SurfaceMesh::addVertexIsolatedScalarQuantityImpl(std::string name,
                                                  const std::vector<std::pair<size_t, double>>& values) {
-  SurfaceVertexIsolatedScalarQuantity* q = new SurfaceVertexIsolatedScalarQuantity(name, values, *this);
-  addQuantity(q);
-  return q;
+    SurfaceVertexIsolatedScalarQuantity* q = new SurfaceVertexIsolatedScalarQuantity(name, values, *this);
+    addQuantity(q);
+    return q;
 }
 
 SurfaceFaceCountQuantity* SurfaceMesh::addFaceCountQuantityImpl(std::string name,
                                                                 const std::vector<std::pair<size_t, int>>& values) {
-  SurfaceFaceCountQuantity* q = new SurfaceFaceCountQuantity(name, values, *this);
-  addQuantity(q);
-  return q;
+    SurfaceFaceCountQuantity* q = new SurfaceFaceCountQuantity(name, values, *this);
+    addQuantity(q);
+    return q;
 }
 
 SurfaceGraphQuantity* SurfaceMesh::addSurfaceGraphQuantityImpl(std::string name, const std::vector<glm::vec3>& nodes,
                                                                const std::vector<std::array<size_t, 2>>& edges) {
-  SurfaceGraphQuantity* q = new SurfaceGraphQuantity(name, nodes, edges, *this);
-  addQuantity(q);
-  return q;
+    SurfaceGraphQuantity* q = new SurfaceGraphQuantity(name, nodes, edges, *this);
+    addQuantity(q);
+    return q;
 }
 
 
 SurfaceVertexScalarQuantity* SurfaceMesh::addVertexScalarQuantityImpl(std::string name, const std::vector<double>& data,
                                                                       DataType type) {
-  SurfaceVertexScalarQuantity* q =
-      new SurfaceVertexScalarQuantity(name, applyPermutation(data, vertexPerm), *this, type);
-  addQuantity(q);
-  return q;
+    SurfaceVertexScalarQuantity* q =
+        new SurfaceVertexScalarQuantity(name, applyPermutation(data, vertexPerm), *this, type);
+    addQuantity(q);
+    return q;
 }
 
 SurfaceFaceScalarQuantity* SurfaceMesh::addFaceScalarQuantityImpl(std::string name, const std::vector<double>& data,
                                                                   DataType type) {
-  SurfaceFaceScalarQuantity* q = new SurfaceFaceScalarQuantity(name, applyPermutation(data, facePerm), *this, type);
-  addQuantity(q);
-  return q;
+    SurfaceFaceScalarQuantity* q = new SurfaceFaceScalarQuantity(name, applyPermutation(data, facePerm), *this, type);
+    addQuantity(q);
+    return q;
 }
 
 
 SurfaceEdgeScalarQuantity* SurfaceMesh::addEdgeScalarQuantityImpl(std::string name, const std::vector<double>& data,
                                                                   DataType type) {
-  SurfaceEdgeScalarQuantity* q = new SurfaceEdgeScalarQuantity(name, applyPermutation(data, edgePerm), *this, type);
-  addQuantity(q);
-  return q;
+    SurfaceEdgeScalarQuantity* q = new SurfaceEdgeScalarQuantity(name, applyPermutation(data, edgePerm), *this, type);
+    addQuantity(q);
+    return q;
 }
 
 SurfaceHalfedgeScalarQuantity*
 SurfaceMesh::addHalfedgeScalarQuantityImpl(std::string name, const std::vector<double>& data, DataType type) {
-  SurfaceHalfedgeScalarQuantity* q =
-      new SurfaceHalfedgeScalarQuantity(name, applyPermutation(data, halfedgePerm), *this, type);
-  addQuantity(q);
-  return q;
+    SurfaceHalfedgeScalarQuantity* q =
+        new SurfaceHalfedgeScalarQuantity(name, applyPermutation(data, halfedgePerm), *this, type);
+    addQuantity(q);
+    return q;
+}
+
+SurfaceCornerScalarQuantity* SurfaceMesh::addCornerScalarQuantityImpl(std::string name, const std::vector<double>& data,
+                                                                      DataType type) {
+    SurfaceCornerScalarQuantity* q =
+        new SurfaceCornerScalarQuantity(name, applyPermutation(data, cornerPerm), *this, type);
+    addQuantity(q);
+    return q;
 }
 
 
 SurfaceVertexVectorQuantity* SurfaceMesh::addVertexVectorQuantityImpl(std::string name,
                                                                       const std::vector<glm::vec3>& vectors,
                                                                       VectorType vectorType) {
-  SurfaceVertexVectorQuantity* q =
-      new SurfaceVertexVectorQuantity(name, applyPermutation(vectors, vertexPerm), *this, vectorType);
-  addQuantity(q);
-  return q;
+    SurfaceVertexVectorQuantity* q =
+        new SurfaceVertexVectorQuantity(name, applyPermutation(vectors, vertexPerm), *this, vectorType);
+    addQuantity(q);
+    return q;
 }
 
 SurfaceFaceVectorQuantity*
 SurfaceMesh::addFaceVectorQuantityImpl(std::string name, const std::vector<glm::vec3>& vectors, VectorType vectorType) {
 
-  SurfaceFaceVectorQuantity* q =
-      new SurfaceFaceVectorQuantity(name, applyPermutation(vectors, facePerm), *this, vectorType);
-  addQuantity(q);
-  return q;
+    SurfaceFaceVectorQuantity* q =
+        new SurfaceFaceVectorQuantity(name, applyPermutation(vectors, facePerm), *this, vectorType);
+    addQuantity(q);
+    return q;
 }
 
 SurfaceFaceIntrinsicVectorQuantity*
 SurfaceMesh::addFaceIntrinsicVectorQuantityImpl(std::string name, const std::vector<glm::vec2>& vectors, int nSym,
                                                 VectorType vectorType) {
 
-  SurfaceFaceIntrinsicVectorQuantity* q =
-      new SurfaceFaceIntrinsicVectorQuantity(name, applyPermutation(vectors, facePerm), *this, nSym, vectorType);
-  addQuantity(q);
-  return q;
+    SurfaceFaceIntrinsicVectorQuantity* q =
+        new SurfaceFaceIntrinsicVectorQuantity(name, applyPermutation(vectors, facePerm), *this, nSym, vectorType);
+    addQuantity(q);
+    return q;
 }
 
 
 SurfaceVertexIntrinsicVectorQuantity*
 SurfaceMesh::addVertexIntrinsicVectorQuantityImpl(std::string name, const std::vector<glm::vec2>& vectors, int nSym,
                                                   VectorType vectorType) {
-  SurfaceVertexIntrinsicVectorQuantity* q =
-      new SurfaceVertexIntrinsicVectorQuantity(name, applyPermutation(vectors, vertexPerm), *this, nSym, vectorType);
-  addQuantity(q);
-  return q;
+    SurfaceVertexIntrinsicVectorQuantity* q =
+        new SurfaceVertexIntrinsicVectorQuantity(name, applyPermutation(vectors, vertexPerm), *this, nSym, vectorType);
+    addQuantity(q);
+    return q;
 }
 
 // Orientations is `true` if the canonical orientation of the edge points from the lower-indexed vertex to the
@@ -1337,61 +1398,61 @@ SurfaceMesh::addVertexIntrinsicVectorQuantityImpl(std::string name, const std::v
 SurfaceOneFormIntrinsicVectorQuantity*
 SurfaceMesh::addOneFormIntrinsicVectorQuantityImpl(std::string name, const std::vector<double>& data,
                                                    const std::vector<char>& orientations) {
-  SurfaceOneFormIntrinsicVectorQuantity* q = new SurfaceOneFormIntrinsicVectorQuantity(
-      name, applyPermutation(data, edgePerm), applyPermutation(orientations, edgePerm), *this);
-  addQuantity(q);
-  return q;
+    SurfaceOneFormIntrinsicVectorQuantity* q = new SurfaceOneFormIntrinsicVectorQuantity(
+        name, applyPermutation(data, edgePerm), applyPermutation(orientations, edgePerm), *this);
+    addQuantity(q);
+    return q;
 }
 
 
 void SurfaceMesh::setVertexTangentBasisXImpl(const std::vector<glm::vec3>& vectors) {
 
-  std::vector<glm::vec3> inputBasisX = applyPermutation(vectors, vertexPerm);
-  vertexTangentSpaces.resize(nVertices());
+    std::vector<glm::vec3> inputBasisX = applyPermutation(vectors, vertexPerm);
+    vertexTangentSpaces.resize(nVertices());
 
-  for (size_t iV = 0; iV < nVertices(); iV++) {
+    for (size_t iV = 0; iV < nVertices(); iV++) {
 
-    glm::vec3 basisX = inputBasisX[iV];
-    glm::vec3 normal = vertexNormals[iV];
+        glm::vec3 basisX = inputBasisX[iV];
+        glm::vec3 normal = vertexNormals[iV];
 
-    // Project in to tangent defined by our normals
-    basisX = glm::normalize(basisX - normal * glm::dot(normal, basisX));
+        // Project in to tangent defined by our normals
+        basisX = glm::normalize(basisX - normal * glm::dot(normal, basisX));
 
-    // Let basis Y complete the frame
-    glm::vec3 basisY = glm::cross(normal, basisX);
+        // Let basis Y complete the frame
+        glm::vec3 basisY = glm::cross(normal, basisX);
 
-    vertexTangentSpaces[iV][0] = basisX;
-    vertexTangentSpaces[iV][1] = basisY;
-  }
+        vertexTangentSpaces[iV][0] = basisX;
+        vertexTangentSpaces[iV][1] = basisY;
+    }
 
-  // Regenerate all data, in case stored data depends on tangent spaces.
-  // NOTE: This is overkill. We really only need to regenrate the handful of things which depend on tangent spaces.
-  refresh();
+    // Regenerate all data, in case stored data depends on tangent spaces.
+    // NOTE: This is overkill. We really only need to regenrate the handful of things which depend on tangent spaces.
+    refresh();
 }
 
 void SurfaceMesh::setFaceTangentBasisXImpl(const std::vector<glm::vec3>& vectors) {
 
-  std::vector<glm::vec3> inputBasisX = applyPermutation(vectors, facePerm);
-  faceTangentSpaces.resize(nFaces());
+    std::vector<glm::vec3> inputBasisX = applyPermutation(vectors, facePerm);
+    faceTangentSpaces.resize(nFaces());
 
-  for (size_t iF = 0; iF < nFaces(); iF++) {
+    for (size_t iF = 0; iF < nFaces(); iF++) {
 
-    glm::vec3 basisX = inputBasisX[iF];
-    glm::vec3 normal = faceNormals[iF];
+        glm::vec3 basisX = inputBasisX[iF];
+        glm::vec3 normal = faceNormals[iF];
 
-    // Project in to tangent defined by our normals
-    basisX = glm::normalize(basisX - normal * glm::dot(normal, basisX));
+        // Project in to tangent defined by our normals
+        basisX = glm::normalize(basisX - normal * glm::dot(normal, basisX));
 
-    // Let basis Y complete the frame
-    glm::vec3 basisY = glm::cross(normal, basisX);
+        // Let basis Y complete the frame
+        glm::vec3 basisY = glm::cross(normal, basisX);
 
-    faceTangentSpaces[iF][0] = basisX;
-    faceTangentSpaces[iF][1] = basisY;
-  }
+        faceTangentSpaces[iF][0] = basisX;
+        faceTangentSpaces[iF][1] = basisY;
+    }
 
-  // Regenerate all data, in case stored data depends on tangent spaces.
-  // NOTE: This is overkill. We really only need to regenrate the handful of things which depend on tangent spaces.
-  refresh();
+    // Regenerate all data, in case stored data depends on tangent spaces.
+    // NOTE: This is overkill. We really only need to regenrate the handful of things which depend on tangent spaces.
+    refresh();
 }
 
 
@@ -1401,5 +1462,6 @@ void SurfaceMeshQuantity::buildVertexInfoGUI(size_t vInd) {}
 void SurfaceMeshQuantity::buildFaceInfoGUI(size_t fInd) {}
 void SurfaceMeshQuantity::buildEdgeInfoGUI(size_t eInd) {}
 void SurfaceMeshQuantity::buildHalfedgeInfoGUI(size_t heInd) {}
+void SurfaceMeshQuantity::buildCornerInfoGUI(size_t cInd) {}
 
 } // namespace polyscope

--- a/src/surface_scalar_quantity.cpp
+++ b/src/surface_scalar_quantity.cpp
@@ -17,46 +17,44 @@ SurfaceScalarQuantity::SurfaceScalarQuantity(std::string name, SurfaceMesh& mesh
     : SurfaceMeshQuantity(name, mesh_, true), ScalarQuantity(*this, values_, dataType_), definedOn(definedOn_) {}
 
 void SurfaceScalarQuantity::draw() {
-    if (!isEnabled()) return;
+  if (!isEnabled()) return;
 
-    if (program == nullptr) {
-        createProgram();
-    }
+  if (program == nullptr) {
+    createProgram();
+  }
 
-    // Set uniforms
-    parent.setStructureUniforms(*program);
-    parent.setSurfaceMeshUniforms(*program);
-    setScalarUniforms(*program);
+  // Set uniforms
+  parent.setStructureUniforms(*program);
+  parent.setSurfaceMeshUniforms(*program);
+  setScalarUniforms(*program);
 
-    program->draw();
+  program->draw();
 }
 
 
 void SurfaceScalarQuantity::buildCustomUI() {
-    ImGui::SameLine();
+  ImGui::SameLine();
 
-    // == Options popup
-    if (ImGui::Button("Options")) {
-        ImGui::OpenPopup("OptionsPopup");
-    }
-    if (ImGui::BeginPopup("OptionsPopup")) {
+  // == Options popup
+  if (ImGui::Button("Options")) {
+    ImGui::OpenPopup("OptionsPopup");
+  }
+  if (ImGui::BeginPopup("OptionsPopup")) {
 
-        buildScalarOptionsUI();
+    buildScalarOptionsUI();
 
-        ImGui::EndPopup();
-    }
+    ImGui::EndPopup();
+  }
 
-    buildScalarUI();
+  buildScalarUI();
 }
 
 void SurfaceScalarQuantity::refresh() {
-    program.reset();
-    Quantity::refresh();
+  program.reset();
+  Quantity::refresh();
 }
 
-std::string SurfaceScalarQuantity::niceName() {
-    return name + " (" + definedOn + " scalar)";
-}
+std::string SurfaceScalarQuantity::niceName() { return name + " (" + definedOn + " scalar)"; }
 
 // ========================================================
 // ==========           Vertex Scalar            ==========
@@ -67,51 +65,50 @@ SurfaceVertexScalarQuantity::SurfaceVertexScalarQuantity(std::string name, const
     : SurfaceScalarQuantity(name, mesh_, "vertex", values_, dataType_)
 
 {
-    hist.buildHistogram(values, parent.vertexAreas); // rebuild to incorporate weights
+  hist.buildHistogram(values, parent.vertexAreas); // rebuild to incorporate weights
 }
 
 void SurfaceVertexScalarQuantity::createProgram() {
-    // Create the program to draw this quantity
-    program =
-        render::engine->requestShader("MESH", parent.addSurfaceMeshRules(addScalarRules({"MESH_PROPAGATE_VALUE"})));
+  // Create the program to draw this quantity
+  program = render::engine->requestShader("MESH", parent.addSurfaceMeshRules(addScalarRules({"MESH_PROPAGATE_VALUE"})));
 
-    // Fill color buffers
-    parent.fillGeometryBuffers(*program);
-    fillColorBuffers(*program);
-    render::engine->setMaterial(*program, parent.getMaterial());
+  // Fill color buffers
+  parent.fillGeometryBuffers(*program);
+  fillColorBuffers(*program);
+  render::engine->setMaterial(*program, parent.getMaterial());
 }
 
 
 void SurfaceVertexScalarQuantity::fillColorBuffers(render::ShaderProgram& p) {
-    std::vector<double> colorval;
-    colorval.reserve(3 * parent.nFacesTriangulation());
+  std::vector<double> colorval;
+  colorval.reserve(3 * parent.nFacesTriangulation());
 
-    for (size_t iF = 0; iF < parent.nFaces(); iF++) {
-        auto& face = parent.faces[iF];
-        size_t D = face.size();
+  for (size_t iF = 0; iF < parent.nFaces(); iF++) {
+    auto& face = parent.faces[iF];
+    size_t D = face.size();
 
-        // implicitly triangulate from root
-        size_t vRoot = face[0];
-        for (size_t j = 1; (j + 1) < D; j++) {
-            size_t vB = face[j];
-            size_t vC = face[(j + 1) % D];
+    // implicitly triangulate from root
+    size_t vRoot = face[0];
+    for (size_t j = 1; (j + 1) < D; j++) {
+      size_t vB = face[j];
+      size_t vC = face[(j + 1) % D];
 
-            colorval.push_back(values[vRoot]);
-            colorval.push_back(values[vB]);
-            colorval.push_back(values[vC]);
-        }
+      colorval.push_back(values[vRoot]);
+      colorval.push_back(values[vB]);
+      colorval.push_back(values[vC]);
     }
+  }
 
-    // Store data in buffers
-    p.setAttribute("a_value", colorval);
-    p.setTextureFromColormap("t_colormap", cMap.get());
+  // Store data in buffers
+  p.setAttribute("a_value", colorval);
+  p.setTextureFromColormap("t_colormap", cMap.get());
 }
 
 void SurfaceVertexScalarQuantity::buildVertexInfoGUI(size_t vInd) {
-    ImGui::TextUnformatted(name.c_str());
-    ImGui::NextColumn();
-    ImGui::Text("%g", values[vInd]);
-    ImGui::NextColumn();
+  ImGui::TextUnformatted(name.c_str());
+  ImGui::NextColumn();
+  ImGui::Text("%g", values[vInd]);
+  ImGui::NextColumn();
 }
 
 // ========================================================
@@ -123,43 +120,42 @@ SurfaceFaceScalarQuantity::SurfaceFaceScalarQuantity(std::string name, const std
     : SurfaceScalarQuantity(name, mesh_, "face", values_, dataType_)
 
 {
-    hist.buildHistogram(values, parent.faceAreas); // rebuild to incorporate weights
+  hist.buildHistogram(values, parent.faceAreas); // rebuild to incorporate weights
 }
 
 void SurfaceFaceScalarQuantity::createProgram() {
-    // Create the program to draw this quantity
-    program =
-        render::engine->requestShader("MESH", parent.addSurfaceMeshRules(addScalarRules({"MESH_PROPAGATE_VALUE"})));
+  // Create the program to draw this quantity
+  program = render::engine->requestShader("MESH", parent.addSurfaceMeshRules(addScalarRules({"MESH_PROPAGATE_VALUE"})));
 
-    // Fill color buffers
-    parent.fillGeometryBuffers(*program);
-    fillColorBuffers(*program);
-    render::engine->setMaterial(*program, parent.getMaterial());
+  // Fill color buffers
+  parent.fillGeometryBuffers(*program);
+  fillColorBuffers(*program);
+  render::engine->setMaterial(*program, parent.getMaterial());
 }
 
 void SurfaceFaceScalarQuantity::fillColorBuffers(render::ShaderProgram& p) {
-    std::vector<double> colorval;
-    colorval.reserve(3 * parent.nFacesTriangulation());
+  std::vector<double> colorval;
+  colorval.reserve(3 * parent.nFacesTriangulation());
 
-    for (size_t iF = 0; iF < parent.nFaces(); iF++) {
-        auto& face = parent.faces[iF];
-        size_t D = face.size();
-        size_t triDegree = std::max(0, static_cast<int>(D) - 2);
-        for (size_t j = 0; j < 3 * triDegree; j++) {
-            colorval.push_back(values[iF]);
-        }
+  for (size_t iF = 0; iF < parent.nFaces(); iF++) {
+    auto& face = parent.faces[iF];
+    size_t D = face.size();
+    size_t triDegree = std::max(0, static_cast<int>(D) - 2);
+    for (size_t j = 0; j < 3 * triDegree; j++) {
+      colorval.push_back(values[iF]);
     }
+  }
 
-    // Store data in buffers
-    p.setAttribute("a_value", colorval);
-    p.setTextureFromColormap("t_colormap", cMap.get());
+  // Store data in buffers
+  p.setAttribute("a_value", colorval);
+  p.setTextureFromColormap("t_colormap", cMap.get());
 }
 
 void SurfaceFaceScalarQuantity::buildFaceInfoGUI(size_t fInd) {
-    ImGui::TextUnformatted(name.c_str());
-    ImGui::NextColumn();
-    ImGui::Text("%g", values[fInd]);
-    ImGui::NextColumn();
+  ImGui::TextUnformatted(name.c_str());
+  ImGui::NextColumn();
+  ImGui::Text("%g", values[fInd]);
+  ImGui::NextColumn();
 }
 
 
@@ -172,65 +168,65 @@ SurfaceEdgeScalarQuantity::SurfaceEdgeScalarQuantity(std::string name, const std
     : SurfaceScalarQuantity(name, mesh_, "edge", values_, dataType_)
 
 {
-    hist.buildHistogram(values, parent.edgeLengths); // rebuild to incorporate weights
+  hist.buildHistogram(values, parent.edgeLengths); // rebuild to incorporate weights
 }
 
 void SurfaceEdgeScalarQuantity::createProgram() {
-    // Create the program to draw this quantity
-    program = render::engine->requestShader(
-        "MESH", parent.addSurfaceMeshRules(addScalarRules({"MESH_PROPAGATE_HALFEDGE_VALUE"})));
+  // Create the program to draw this quantity
+  program = render::engine->requestShader(
+      "MESH", parent.addSurfaceMeshRules(addScalarRules({"MESH_PROPAGATE_HALFEDGE_VALUE"})));
 
-    // Fill color buffers
-    parent.fillGeometryBuffers(*program);
-    fillColorBuffers(*program);
-    render::engine->setMaterial(*program, parent.getMaterial());
+  // Fill color buffers
+  parent.fillGeometryBuffers(*program);
+  fillColorBuffers(*program);
+  render::engine->setMaterial(*program, parent.getMaterial());
 }
 
 void SurfaceEdgeScalarQuantity::fillColorBuffers(render::ShaderProgram& p) {
-    std::vector<glm::vec3> colorval;
-    colorval.reserve(3 * parent.nFacesTriangulation());
+  std::vector<glm::vec3> colorval;
+  colorval.reserve(3 * parent.nFacesTriangulation());
 
-    // Fill buffers as usual, but at edges introduced by triangulation substitute the average value.
-    // TODO this still doesn't look too great on polygon meshes... perhaps compute an average value per edge?
-    for (size_t iF = 0; iF < parent.nFaces(); iF++) {
-        auto& face = parent.faces[iF];
-        size_t D = face.size();
+  // Fill buffers as usual, but at edges introduced by triangulation substitute the average value.
+  // TODO this still doesn't look too great on polygon meshes... perhaps compute an average value per edge?
+  for (size_t iF = 0; iF < parent.nFaces(); iF++) {
+    auto& face = parent.faces[iF];
+    size_t D = face.size();
 
-        // First, compute an average value for the face
-        double avgVal = 0.0;
-        for (size_t j = 0; j < D; j++) {
-            avgVal += values[parent.edgeIndices[iF][j]];
-        }
-        avgVal /= D;
-
-        // implicitly triangulate from root
-        for (size_t j = 1; (j + 1) < D; j++) {
-
-            glm::vec3 combinedValues = {avgVal, values[parent.edgeIndices[iF][j]], avgVal};
-
-            if (j == 1) {
-                combinedValues.x = values[parent.edgeIndices[iF][0]];
-            }
-            if (j + 2 == D) {
-                combinedValues.z = values[parent.edgeIndices[iF].back()];
-            }
-
-            for (size_t i = 0; i < 3; i++) {
-                colorval.push_back(combinedValues);
-            }
-        }
+    // First, compute an average value for the face
+    double avgVal = 0.0;
+    for (size_t j = 0; j < D; j++) {
+      avgVal += values[parent.edgeIndices[iF][j]];
     }
+    avgVal /= D;
 
-    // Store data in buffers
-    p.setAttribute("a_value3", colorval);
-    p.setTextureFromColormap("t_colormap", cMap.get());
+    // implicitly triangulate from root
+    for (size_t j = 1; (j + 1) < D; j++) {
+
+      glm::vec3 combinedValues = {avgVal, values[parent.edgeIndices[iF][j]], avgVal};
+
+      if (j == 1) {
+        combinedValues.x = values[parent.edgeIndices[iF][0]];
+      }
+      if (j + 2 == D) {
+        combinedValues.z = values[parent.edgeIndices[iF].back()];
+      }
+
+      for (size_t i = 0; i < 3; i++) {
+        colorval.push_back(combinedValues);
+      }
+    }
+  }
+
+  // Store data in buffers
+  p.setAttribute("a_value3", colorval);
+  p.setTextureFromColormap("t_colormap", cMap.get());
 }
 
 void SurfaceEdgeScalarQuantity::buildEdgeInfoGUI(size_t eInd) {
-    ImGui::TextUnformatted(name.c_str());
-    ImGui::NextColumn();
-    ImGui::Text("%g", values[eInd]);
-    ImGui::NextColumn();
+  ImGui::TextUnformatted(name.c_str());
+  ImGui::NextColumn();
+  ImGui::Text("%g", values[eInd]);
+  ImGui::NextColumn();
 }
 
 // ========================================================
@@ -242,82 +238,82 @@ SurfaceHalfedgeScalarQuantity::SurfaceHalfedgeScalarQuantity(std::string name, c
     : SurfaceScalarQuantity(name, mesh_, "halfedge", values_, dataType_)
 
 {
-    std::vector<double> weightsVec(parent.nHalfedges());
-    size_t iHe = 0;
-    for (size_t iF = 0; iF < parent.nFaces(); iF++) {
-        auto& face = parent.faces[iF];
-        size_t D = face.size();
-        for (size_t j = 0; j < D; j++) {
-            weightsVec[iHe] = parent.edgeLengths[parent.edgeIndices[iF][j]];
-            iHe++;
-        }
+  std::vector<double> weightsVec(parent.nHalfedges());
+  size_t iHe = 0;
+  for (size_t iF = 0; iF < parent.nFaces(); iF++) {
+    auto& face = parent.faces[iF];
+    size_t D = face.size();
+    for (size_t j = 0; j < D; j++) {
+      weightsVec[iHe] = parent.edgeLengths[parent.edgeIndices[iF][j]];
+      iHe++;
     }
-    hist.buildHistogram(values, weightsVec); // rebuild to incorporate weights
+  }
+  hist.buildHistogram(values, weightsVec); // rebuild to incorporate weights
 }
 
 void SurfaceHalfedgeScalarQuantity::createProgram() {
-    // Create the program to draw this quantity
-    program = render::engine->requestShader(
-        "MESH", parent.addSurfaceMeshRules(addScalarRules({"MESH_PROPAGATE_HALFEDGE_VALUE"})));
+  // Create the program to draw this quantity
+  program = render::engine->requestShader(
+      "MESH", parent.addSurfaceMeshRules(addScalarRules({"MESH_PROPAGATE_HALFEDGE_VALUE"})));
 
-    // Fill color buffers
-    parent.fillGeometryBuffers(*program);
-    fillColorBuffers(*program);
-    render::engine->setMaterial(*program, parent.getMaterial());
+  // Fill color buffers
+  parent.fillGeometryBuffers(*program);
+  fillColorBuffers(*program);
+  render::engine->setMaterial(*program, parent.getMaterial());
 }
 
 void SurfaceHalfedgeScalarQuantity::fillColorBuffers(render::ShaderProgram& p) {
-    std::vector<glm::vec3> colorval;
-    colorval.reserve(3 * parent.nFacesTriangulation());
+  std::vector<glm::vec3> colorval;
+  colorval.reserve(3 * parent.nFacesTriangulation());
 
-    // Fill buffers as usual, but at edges introduced by triangulation substitute the average value.
-    // TODO this still doesn't look too great on polygon meshes... perhaps compute an average value per edge?
-    size_t iHe = 0;
-    for (size_t iF = 0; iF < parent.nFaces(); iF++) {
-        auto& face = parent.faces[iF];
-        size_t D = face.size();
+  // Fill buffers as usual, but at edges introduced by triangulation substitute the average value.
+  // TODO this still doesn't look too great on polygon meshes... perhaps compute an average value per edge?
+  size_t iHe = 0;
+  for (size_t iF = 0; iF < parent.nFaces(); iF++) {
+    auto& face = parent.faces[iF];
+    size_t D = face.size();
 
-        // First, compute an average value for the face
-        double avgVal = 0.0;
-        for (size_t j = 0; j < D; j++) {
-            avgVal += values[iHe + j];
-        }
-        avgVal /= D;
-
-        // implicitly triangulate from root
-        for (size_t j = 1; (j + 1) < D; j++) {
-            glm::vec3 combinedValues = {avgVal, avgVal, avgVal};
-
-            if (j == 1) {
-                combinedValues[0] = values[iHe];
-                iHe++;
-            }
-
-            combinedValues[1] = values[iHe];
-            iHe++;
-
-            if (j + 2 == D) {
-                combinedValues[2] = values[iHe];
-                iHe++;
-            }
-
-            for (size_t i = 0; i < 3; i++) {
-                colorval.push_back(combinedValues);
-            }
-        }
+    // First, compute an average value for the face
+    double avgVal = 0.0;
+    for (size_t j = 0; j < D; j++) {
+      avgVal += values[iHe + j];
     }
+    avgVal /= D;
+
+    // implicitly triangulate from root
+    for (size_t j = 1; (j + 1) < D; j++) {
+      glm::vec3 combinedValues = {avgVal, avgVal, avgVal};
+
+      if (j == 1) {
+        combinedValues[0] = values[iHe];
+        iHe++;
+      }
+
+      combinedValues[1] = values[iHe];
+      iHe++;
+
+      if (j + 2 == D) {
+        combinedValues[2] = values[iHe];
+        iHe++;
+      }
+
+      for (size_t i = 0; i < 3; i++) {
+        colorval.push_back(combinedValues);
+      }
+    }
+  }
 
 
-    // Store data in buffers
-    p.setAttribute("a_value3", colorval);
-    p.setTextureFromColormap("t_colormap", cMap.get());
+  // Store data in buffers
+  p.setAttribute("a_value3", colorval);
+  p.setTextureFromColormap("t_colormap", cMap.get());
 }
 
 void SurfaceHalfedgeScalarQuantity::buildHalfedgeInfoGUI(size_t heInd) {
-    ImGui::TextUnformatted(name.c_str());
-    ImGui::NextColumn();
-    ImGui::Text("%g", values[heInd]);
-    ImGui::NextColumn();
+  ImGui::TextUnformatted(name.c_str());
+  ImGui::NextColumn();
+  ImGui::Text("%g", values[heInd]);
+  ImGui::NextColumn();
 }
 
 // ========================================================
@@ -329,61 +325,60 @@ SurfaceCornerScalarQuantity::SurfaceCornerScalarQuantity(std::string name, const
     : SurfaceScalarQuantity(name, mesh_, "corner", values_, dataType_)
 
 {
-    std::vector<double> cornerAreas;
-    for (size_t iF = 0; iF < parent.nFaces(); iF++) {
-        auto& face = parent.faces[iF];
-        size_t D = face.size();
-        double cornerArea = parent.faceAreas[iF] / (static_cast<double>(D));
-        for (size_t iC = 0; iC < D; iC++) {
-            cornerAreas.push_back(cornerArea);
-        }
+  std::vector<double> cornerAreas;
+  for (size_t iF = 0; iF < parent.nFaces(); iF++) {
+    auto& face = parent.faces[iF];
+    size_t D = face.size();
+    double cornerArea = parent.faceAreas[iF] / (static_cast<double>(D));
+    for (size_t iC = 0; iC < D; iC++) {
+      cornerAreas.push_back(cornerArea);
     }
+  }
 
-    hist.buildHistogram(values, cornerAreas); // rebuild to incorporate weights
+  hist.buildHistogram(values, cornerAreas); // rebuild to incorporate weights
 }
 
 void SurfaceCornerScalarQuantity::createProgram() {
-    // Create the program to draw this quantity
-    program =
-        render::engine->requestShader("MESH", parent.addSurfaceMeshRules(addScalarRules({"MESH_PROPAGATE_VALUE"})));
+  // Create the program to draw this quantity
+  program = render::engine->requestShader("MESH", parent.addSurfaceMeshRules(addScalarRules({"MESH_PROPAGATE_VALUE"})));
 
-    // Fill color buffers
-    parent.fillGeometryBuffers(*program);
-    fillColorBuffers(*program);
-    render::engine->setMaterial(*program, parent.getMaterial());
+  // Fill color buffers
+  parent.fillGeometryBuffers(*program);
+  fillColorBuffers(*program);
+  render::engine->setMaterial(*program, parent.getMaterial());
 }
 
 void SurfaceCornerScalarQuantity::fillColorBuffers(render::ShaderProgram& p) {
-    std::vector<double> colorval;
-    colorval.reserve(3 * parent.nFacesTriangulation());
+  std::vector<double> colorval;
+  colorval.reserve(3 * parent.nFacesTriangulation());
 
-    size_t cornerCount = 0;
-    for (size_t iF = 0; iF < parent.nFaces(); iF++) {
-        auto& face = parent.faces[iF];
-        size_t D = face.size();
+  size_t cornerCount = 0;
+  for (size_t iF = 0; iF < parent.nFaces(); iF++) {
+    auto& face = parent.faces[iF];
+    size_t D = face.size();
 
-        // implicitly triangulate from root
-        size_t cRoot = cornerCount;
-        for (size_t j = 1; (j + 1) < D; j++) {
-            size_t cB = cornerCount + j;
-            size_t cC = cornerCount + ((j + 1) % D);
-            colorval.push_back(values[cRoot]);
-            colorval.push_back(values[cB]);
-            colorval.push_back(values[cC]);
-        }
-        cornerCount += D;
+    // implicitly triangulate from root
+    size_t cRoot = cornerCount;
+    for (size_t j = 1; (j + 1) < D; j++) {
+      size_t cB = cornerCount + j;
+      size_t cC = cornerCount + ((j + 1) % D);
+      colorval.push_back(values[cRoot]);
+      colorval.push_back(values[cB]);
+      colorval.push_back(values[cC]);
     }
+    cornerCount += D;
+  }
 
-    // Store data in buffers
-    p.setAttribute("a_value", colorval);
-    p.setTextureFromColormap("t_colormap", cMap.get());
+  // Store data in buffers
+  p.setAttribute("a_value", colorval);
+  p.setTextureFromColormap("t_colormap", cMap.get());
 }
 
 void SurfaceCornerScalarQuantity::buildCornerInfoGUI(size_t cInd) {
-    ImGui::TextUnformatted(name.c_str());
-    ImGui::NextColumn();
-    ImGui::Text("%g", values[cInd]);
-    ImGui::NextColumn();
+  ImGui::TextUnformatted(name.c_str());
+  ImGui::NextColumn();
+  ImGui::Text("%g", values[cInd]);
+  ImGui::NextColumn();
 }
 
 } // namespace polyscope

--- a/src/surface_scalar_quantity.cpp
+++ b/src/surface_scalar_quantity.cpp
@@ -17,44 +17,46 @@ SurfaceScalarQuantity::SurfaceScalarQuantity(std::string name, SurfaceMesh& mesh
     : SurfaceMeshQuantity(name, mesh_, true), ScalarQuantity(*this, values_, dataType_), definedOn(definedOn_) {}
 
 void SurfaceScalarQuantity::draw() {
-  if (!isEnabled()) return;
+    if (!isEnabled()) return;
 
-  if (program == nullptr) {
-    createProgram();
-  }
+    if (program == nullptr) {
+        createProgram();
+    }
 
-  // Set uniforms
-  parent.setStructureUniforms(*program);
-  parent.setSurfaceMeshUniforms(*program);
-  setScalarUniforms(*program);
+    // Set uniforms
+    parent.setStructureUniforms(*program);
+    parent.setSurfaceMeshUniforms(*program);
+    setScalarUniforms(*program);
 
-  program->draw();
+    program->draw();
 }
 
 
 void SurfaceScalarQuantity::buildCustomUI() {
-  ImGui::SameLine();
+    ImGui::SameLine();
 
-  // == Options popup
-  if (ImGui::Button("Options")) {
-    ImGui::OpenPopup("OptionsPopup");
-  }
-  if (ImGui::BeginPopup("OptionsPopup")) {
+    // == Options popup
+    if (ImGui::Button("Options")) {
+        ImGui::OpenPopup("OptionsPopup");
+    }
+    if (ImGui::BeginPopup("OptionsPopup")) {
 
-    buildScalarOptionsUI();
+        buildScalarOptionsUI();
 
-    ImGui::EndPopup();
-  }
+        ImGui::EndPopup();
+    }
 
-  buildScalarUI();
+    buildScalarUI();
 }
 
 void SurfaceScalarQuantity::refresh() {
-  program.reset();
-  Quantity::refresh();
+    program.reset();
+    Quantity::refresh();
 }
 
-std::string SurfaceScalarQuantity::niceName() { return name + " (" + definedOn + " scalar)"; }
+std::string SurfaceScalarQuantity::niceName() {
+    return name + " (" + definedOn + " scalar)";
+}
 
 // ========================================================
 // ==========           Vertex Scalar            ==========
@@ -65,51 +67,51 @@ SurfaceVertexScalarQuantity::SurfaceVertexScalarQuantity(std::string name, const
     : SurfaceScalarQuantity(name, mesh_, "vertex", values_, dataType_)
 
 {
-  hist.buildHistogram(values, parent.vertexAreas); // rebuild to incorporate weights
+    hist.buildHistogram(values, parent.vertexAreas); // rebuild to incorporate weights
 }
 
 void SurfaceVertexScalarQuantity::createProgram() {
-  // Create the program to draw this quantity
-  program =
-      render::engine->requestShader("MESH", parent.addSurfaceMeshRules(addScalarRules({"MESH_PROPAGATE_VALUE"})));
+    // Create the program to draw this quantity
+    program =
+        render::engine->requestShader("MESH", parent.addSurfaceMeshRules(addScalarRules({"MESH_PROPAGATE_VALUE"})));
 
-  // Fill color buffers
-  parent.fillGeometryBuffers(*program);
-  fillColorBuffers(*program);
-  render::engine->setMaterial(*program, parent.getMaterial());
+    // Fill color buffers
+    parent.fillGeometryBuffers(*program);
+    fillColorBuffers(*program);
+    render::engine->setMaterial(*program, parent.getMaterial());
 }
 
 
 void SurfaceVertexScalarQuantity::fillColorBuffers(render::ShaderProgram& p) {
-  std::vector<double> colorval;
-  colorval.reserve(3 * parent.nFacesTriangulation());
+    std::vector<double> colorval;
+    colorval.reserve(3 * parent.nFacesTriangulation());
 
-  for (size_t iF = 0; iF < parent.nFaces(); iF++) {
-    auto& face = parent.faces[iF];
-    size_t D = face.size();
+    for (size_t iF = 0; iF < parent.nFaces(); iF++) {
+        auto& face = parent.faces[iF];
+        size_t D = face.size();
 
-    // implicitly triangulate from root
-    size_t vRoot = face[0];
-    for (size_t j = 1; (j + 1) < D; j++) {
-      size_t vB = face[j];
-      size_t vC = face[(j + 1) % D];
+        // implicitly triangulate from root
+        size_t vRoot = face[0];
+        for (size_t j = 1; (j + 1) < D; j++) {
+            size_t vB = face[j];
+            size_t vC = face[(j + 1) % D];
 
-      colorval.push_back(values[vRoot]);
-      colorval.push_back(values[vB]);
-      colorval.push_back(values[vC]);
+            colorval.push_back(values[vRoot]);
+            colorval.push_back(values[vB]);
+            colorval.push_back(values[vC]);
+        }
     }
-  }
 
-  // Store data in buffers
-  p.setAttribute("a_value", colorval);
-  p.setTextureFromColormap("t_colormap", cMap.get());
+    // Store data in buffers
+    p.setAttribute("a_value", colorval);
+    p.setTextureFromColormap("t_colormap", cMap.get());
 }
 
 void SurfaceVertexScalarQuantity::buildVertexInfoGUI(size_t vInd) {
-  ImGui::TextUnformatted(name.c_str());
-  ImGui::NextColumn();
-  ImGui::Text("%g", values[vInd]);
-  ImGui::NextColumn();
+    ImGui::TextUnformatted(name.c_str());
+    ImGui::NextColumn();
+    ImGui::Text("%g", values[vInd]);
+    ImGui::NextColumn();
 }
 
 // ========================================================
@@ -121,13 +123,13 @@ SurfaceFaceScalarQuantity::SurfaceFaceScalarQuantity(std::string name, const std
     : SurfaceScalarQuantity(name, mesh_, "face", values_, dataType_)
 
 {
-  hist.buildHistogram(values, parent.faceAreas); // rebuild to incorporate weights
+    hist.buildHistogram(values, parent.faceAreas); // rebuild to incorporate weights
 }
 
 void SurfaceFaceScalarQuantity::createProgram() {
-  // Create the program to draw this quantity
-  program =
-      render::engine->requestShader("MESH", parent.addSurfaceMeshRules(addScalarRules({"MESH_PROPAGATE_VALUE"})));
+    // Create the program to draw this quantity
+    program =
+        render::engine->requestShader("MESH", parent.addSurfaceMeshRules(addScalarRules({"MESH_PROPAGATE_VALUE"})));
 
     // Fill color buffers
     parent.fillGeometryBuffers(*program);
@@ -140,12 +142,12 @@ void SurfaceFaceScalarQuantity::fillColorBuffers(render::ShaderProgram& p) {
     colorval.reserve(3 * parent.nFacesTriangulation());
 
     for (size_t iF = 0; iF < parent.nFaces(); iF++) {
-      auto& face = parent.faces[iF];
-      size_t D = face.size();
-      size_t triDegree = std::max(0, static_cast<int>(D) - 2);
-      for (size_t j = 0; j < 3 * triDegree; j++) {
-        colorval.push_back(values[iF]);
-      }
+        auto& face = parent.faces[iF];
+        size_t D = face.size();
+        size_t triDegree = std::max(0, static_cast<int>(D) - 2);
+        for (size_t j = 0; j < 3 * triDegree; j++) {
+            colorval.push_back(values[iF]);
+        }
     }
 
     // Store data in buffers
@@ -191,32 +193,32 @@ void SurfaceEdgeScalarQuantity::fillColorBuffers(render::ShaderProgram& p) {
     // Fill buffers as usual, but at edges introduced by triangulation substitute the average value.
     // TODO this still doesn't look too great on polygon meshes... perhaps compute an average value per edge?
     for (size_t iF = 0; iF < parent.nFaces(); iF++) {
-      auto& face = parent.faces[iF];
-      size_t D = face.size();
+        auto& face = parent.faces[iF];
+        size_t D = face.size();
 
-      // First, compute an average value for the face
-      double avgVal = 0.0;
-      for (size_t j = 0; j < D; j++) {
-        avgVal += values[parent.edgeIndices[iF][j]];
-      }
-      avgVal /= D;
-
-      // implicitly triangulate from root
-      for (size_t j = 1; (j + 1) < D; j++) {
-
-        glm::vec3 combinedValues = {avgVal, values[parent.edgeIndices[iF][j]], avgVal};
-
-        if (j == 1) {
-          combinedValues.x = values[parent.edgeIndices[iF][0]];
+        // First, compute an average value for the face
+        double avgVal = 0.0;
+        for (size_t j = 0; j < D; j++) {
+            avgVal += values[parent.edgeIndices[iF][j]];
         }
-        if (j + 2 == D) {
-          combinedValues.z = values[parent.edgeIndices[iF].back()];
-        }
+        avgVal /= D;
 
-        for (size_t i = 0; i < 3; i++) {
-          colorval.push_back(combinedValues);
+        // implicitly triangulate from root
+        for (size_t j = 1; (j + 1) < D; j++) {
+
+            glm::vec3 combinedValues = {avgVal, values[parent.edgeIndices[iF][j]], avgVal};
+
+            if (j == 1) {
+                combinedValues.x = values[parent.edgeIndices[iF][0]];
+            }
+            if (j + 2 == D) {
+                combinedValues.z = values[parent.edgeIndices[iF].back()];
+            }
+
+            for (size_t i = 0; i < 3; i++) {
+                colorval.push_back(combinedValues);
+            }
         }
-      }
     }
 
     // Store data in buffers
@@ -243,12 +245,12 @@ SurfaceHalfedgeScalarQuantity::SurfaceHalfedgeScalarQuantity(std::string name, c
     std::vector<double> weightsVec(parent.nHalfedges());
     size_t iHe = 0;
     for (size_t iF = 0; iF < parent.nFaces(); iF++) {
-      auto& face = parent.faces[iF];
-      size_t D = face.size();
-      for (size_t j = 0; j < D; j++) {
-        weightsVec[iHe] = parent.edgeLengths[parent.edgeIndices[iF][j]];
-        iHe++;
-      }
+        auto& face = parent.faces[iF];
+        size_t D = face.size();
+        for (size_t j = 0; j < D; j++) {
+            weightsVec[iHe] = parent.edgeLengths[parent.edgeIndices[iF][j]];
+            iHe++;
+        }
     }
     hist.buildHistogram(values, weightsVec); // rebuild to incorporate weights
 }
@@ -272,37 +274,37 @@ void SurfaceHalfedgeScalarQuantity::fillColorBuffers(render::ShaderProgram& p) {
     // TODO this still doesn't look too great on polygon meshes... perhaps compute an average value per edge?
     size_t iHe = 0;
     for (size_t iF = 0; iF < parent.nFaces(); iF++) {
-      auto& face = parent.faces[iF];
-      size_t D = face.size();
+        auto& face = parent.faces[iF];
+        size_t D = face.size();
 
-      // First, compute an average value for the face
-      double avgVal = 0.0;
-      for (size_t j = 0; j < D; j++) {
-        avgVal += values[iHe + j];
-      }
-      avgVal /= D;
-
-      // implicitly triangulate from root
-      for (size_t j = 1; (j + 1) < D; j++) {
-        glm::vec3 combinedValues = {avgVal, avgVal, avgVal};
-
-        if (j == 1) {
-          combinedValues[0] = values[iHe];
-          iHe++;
+        // First, compute an average value for the face
+        double avgVal = 0.0;
+        for (size_t j = 0; j < D; j++) {
+            avgVal += values[iHe + j];
         }
+        avgVal /= D;
 
-        combinedValues[1] = values[iHe];
-        iHe++;
+        // implicitly triangulate from root
+        for (size_t j = 1; (j + 1) < D; j++) {
+            glm::vec3 combinedValues = {avgVal, avgVal, avgVal};
 
-        if (j + 2 == D) {
-          combinedValues[2] = values[iHe];
-          iHe++;
+            if (j == 1) {
+                combinedValues[0] = values[iHe];
+                iHe++;
+            }
+
+            combinedValues[1] = values[iHe];
+            iHe++;
+
+            if (j + 2 == D) {
+                combinedValues[2] = values[iHe];
+                iHe++;
+            }
+
+            for (size_t i = 0; i < 3; i++) {
+                colorval.push_back(combinedValues);
+            }
         }
-
-        for (size_t i = 0; i < 3; i++) {
-          colorval.push_back(combinedValues);
-        }
-      }
     }
 
 
@@ -315,6 +317,72 @@ void SurfaceHalfedgeScalarQuantity::buildHalfedgeInfoGUI(size_t heInd) {
     ImGui::TextUnformatted(name.c_str());
     ImGui::NextColumn();
     ImGui::Text("%g", values[heInd]);
+    ImGui::NextColumn();
+}
+
+// ========================================================
+// ==========          Corner Scalar           ==========
+// ========================================================
+
+SurfaceCornerScalarQuantity::SurfaceCornerScalarQuantity(std::string name, const std::vector<double>& values_,
+                                                         SurfaceMesh& mesh_, DataType dataType_)
+    : SurfaceScalarQuantity(name, mesh_, "corner", values_, dataType_)
+
+{
+    std::vector<double> cornerAreas;
+    for (size_t iF = 0; iF < parent.nFaces(); iF++) {
+        auto& face = parent.faces[iF];
+        size_t D = face.size();
+        double cornerArea = parent.faceAreas[iF] / (static_cast<double>(D));
+        for (size_t iC = 0; iC < D; iC++) {
+            cornerAreas.push_back(cornerArea);
+        }
+    }
+
+    hist.buildHistogram(values, cornerAreas); // rebuild to incorporate weights
+}
+
+void SurfaceCornerScalarQuantity::createProgram() {
+    // Create the program to draw this quantity
+    program =
+        render::engine->requestShader("MESH", parent.addSurfaceMeshRules(addScalarRules({"MESH_PROPAGATE_VALUE"})));
+
+    // Fill color buffers
+    parent.fillGeometryBuffers(*program);
+    fillColorBuffers(*program);
+    render::engine->setMaterial(*program, parent.getMaterial());
+}
+
+void SurfaceCornerScalarQuantity::fillColorBuffers(render::ShaderProgram& p) {
+    std::vector<double> colorval;
+    colorval.reserve(3 * parent.nFacesTriangulation());
+
+    size_t cornerCount = 0;
+    for (size_t iF = 0; iF < parent.nFaces(); iF++) {
+        auto& face = parent.faces[iF];
+        size_t D = face.size();
+
+        // implicitly triangulate from root
+        size_t cRoot = cornerCount;
+        for (size_t j = 1; (j + 1) < D; j++) {
+            size_t cB = cornerCount + j;
+            size_t cC = cornerCount + ((j + 1) % D);
+            colorval.push_back(values[cRoot]);
+            colorval.push_back(values[cB]);
+            colorval.push_back(values[cC]);
+        }
+        cornerCount += D;
+    }
+
+    // Store data in buffers
+    p.setAttribute("a_value", colorval);
+    p.setTextureFromColormap("t_colormap", cMap.get());
+}
+
+void SurfaceCornerScalarQuantity::buildCornerInfoGUI(size_t cInd) {
+    ImGui::TextUnformatted(name.c_str());
+    ImGui::NextColumn();
+    ImGui::Text("%g", values[cInd]);
     ImGui::NextColumn();
 }
 

--- a/src/volume_mesh.cpp
+++ b/src/volume_mesh.cpp
@@ -470,7 +470,7 @@ void VolumeMesh::preparePick() {
   std::vector<glm::vec3> normals;
   std::vector<glm::vec3> bcoord;
   std::vector<glm::vec3> edgeReal;
-  std::vector<std::array<glm::vec3, 3>> vertexColors, edgeColors, halfedgeColors;
+  std::vector<std::array<glm::vec3, 3>> vertexColors, edgeColors, halfedgeColors, cornerColors;
   std::vector<glm::vec3> faceColor;
   std::vector<glm::vec3> barycenters;
 
@@ -483,6 +483,7 @@ void VolumeMesh::preparePick() {
   vertexColors.resize(3 * nFacesTriangulation());
   edgeColors.resize(3 * nFacesTriangulation());
   halfedgeColors.resize(3 * nFacesTriangulation());
+  cornerColors.resize(3 * nFacesTriangulation());
   faceColor.resize(3 * nFacesTriangulation());
   normals.resize(3 * nFacesTriangulation());
   if (wantsBarycenters) {
@@ -552,6 +553,7 @@ void VolumeMesh::preparePick() {
           vertexColors[iData + k] = vColor;
           edgeColors[iData + k] = cellColorArr;
           halfedgeColors[iData + k] = cellColorArr;
+          cornerColors[iData + k] = vColor;
         }
 
         bcoord[iData + 0] = glm::vec3{1., 0., 0.};
@@ -589,6 +591,7 @@ void VolumeMesh::preparePick() {
   pickProgram->setAttribute<glm::vec3, 3>("a_vertexColors", vertexColors);
   pickProgram->setAttribute<glm::vec3, 3>("a_edgeColors", edgeColors);
   pickProgram->setAttribute<glm::vec3, 3>("a_halfedgeColors", halfedgeColors);
+  pickProgram->setAttribute<glm::vec3, 3>("a_cornerColors", cornerColors);
   pickProgram->setAttribute("a_faceColor", faceColor);
   if (wantsBarycenters) {
     pickProgram->setAttribute("a_cullPos", barycenters);

--- a/test/src/basics_test.cpp
+++ b/test/src/basics_test.cpp
@@ -374,6 +374,15 @@ TEST_F(PolyscopeTest, SurfaceMeshScalarHalfedge) {
   polyscope::removeAllStructures();
 }
 
+TEST_F(PolyscopeTest, SurfaceMeshScalarCorner) {
+  auto psMesh = registerTriangleMesh();
+  std::vector<double> cScalar(psMesh->nCorners(), 11.);
+  auto q5 = psMesh->addCornerScalarQuantity("cScalar", cScalar);
+  q5->setEnabled(true);
+  polyscope::show(3);
+  polyscope::removeAllStructures();
+}
+
 TEST_F(PolyscopeTest, SurfaceMeshDistance) {
   auto psMesh = registerTriangleMesh();
   std::vector<double> vScalar(psMesh->nVertices(), 7.);
@@ -1078,7 +1087,7 @@ TEST_F(PolyscopeTest, SlicePlaneTest) {
   polyscope::show(3);
   psPoints->setCullWholeElements(false);
   polyscope::show(3);
-  
+
   polyscope::show(3);
 
   // add another and rotate it


### PR DESCRIPTION
Add `addCornerScalarQuantity()` function, and expand the picker to include corners. A corner is picked if the user clicks within some radius of the corner's vertex (but further than the vertex's pick radius.) When a corner is picked, the corner info GUI pops up. 

So far, no support for other corner quantities beyond scalar.