### PR TITLE
Varied node radius for CurveNetwork.

### DIFF
--- a/include/polyscope/curve_network.h
+++ b/include/polyscope/curve_network.h
@@ -133,10 +133,6 @@ public:
   void setNodeRadiusQuantity(std::string name, bool autoScale = true);
   void clearNodeRadiusQuantity();
 
-  // void setEdgeRadiusQuantity(CurveNetworkEdgeScalarQuantity* quantity, bool autoScale = true);
-  // void setEdgeRadiusQuantity(std::string name, bool autoScale = true);
-  // void clearEdgeRadiusQuantity();
-
   // set the radius of the points
   CurveNetwork* setRadius(float newVal, bool isRelative = true);
   float getRadius();
@@ -150,8 +146,6 @@ private:
   // === Visualization parameters
   PersistentValue<glm::vec3> color;
   PersistentValue<ScaledValue<float>> radius;
-  // PersistentValue<ScaledValue<float>> nodeRadius;
-  // PersistentValue<ScaledValue<float>> edgeRadius;
   PersistentValue<std::string> material;
 
 

--- a/include/polyscope/curve_network.h
+++ b/include/polyscope/curve_network.h
@@ -132,9 +132,6 @@ public:
   void setNodeRadiusQuantity(CurveNetworkNodeScalarQuantity* quantity, bool autoScale = true);
   void setNodeRadiusQuantity(std::string name, bool autoScale = true);
   void clearNodeRadiusQuantity();
-  // void setNodeRadiusQuantity(CurveNetworkNodeScalarQuantity* quantity, bool autoScale = true);
-  // void setNodeRadiusQuantity(std::string name, bool autoScale = true);
-  // void clearNodeRadiusQuantity();
 
   // void setEdgeRadiusQuantity(CurveNetworkEdgeScalarQuantity* quantity, bool autoScale = true);
   // void setEdgeRadiusQuantity(std::string name, bool autoScale = true);
@@ -143,12 +140,6 @@ public:
   // set the radius of the points
   CurveNetwork* setRadius(float newVal, bool isRelative = true);
   float getRadius();
-
-  // CurveNetwork* setNodeRadius(float newVal, bool isRelative = true);
-  // float getNodeRadius();
-
-  // CurveNetwork* setEdgeRadius(float newVal, bool isRelative = true);
-  // float getEdgeRadius();
 
   // Material
   CurveNetwork* setMaterial(std::string name);

--- a/include/polyscope/curve_network.h
+++ b/include/polyscope/curve_network.h
@@ -124,9 +124,31 @@ public:
   CurveNetwork* setColor(glm::vec3 newVal);
   glm::vec3 getColor();
 
+
+  // === Set radius from a scalar quantity
+  // effect is multiplicative with pointRadius
+  // negative values are always clamped to 0
+  // if autoScale==true, values are rescaled such that the largest has size pointRadius
+  void setNodeRadiusQuantity(CurveNetworkNodeScalarQuantity* quantity, bool autoScale = true);
+  void setNodeRadiusQuantity(std::string name, bool autoScale = true);
+  void clearNodeRadiusQuantity();
+  // void setNodeRadiusQuantity(CurveNetworkNodeScalarQuantity* quantity, bool autoScale = true);
+  // void setNodeRadiusQuantity(std::string name, bool autoScale = true);
+  // void clearNodeRadiusQuantity();
+
+  // void setEdgeRadiusQuantity(CurveNetworkEdgeScalarQuantity* quantity, bool autoScale = true);
+  // void setEdgeRadiusQuantity(std::string name, bool autoScale = true);
+  // void clearEdgeRadiusQuantity();
+
   // set the radius of the points
   CurveNetwork* setRadius(float newVal, bool isRelative = true);
   float getRadius();
+
+  // CurveNetwork* setNodeRadius(float newVal, bool isRelative = true);
+  // float getNodeRadius();
+
+  // CurveNetwork* setEdgeRadius(float newVal, bool isRelative = true);
+  // float getEdgeRadius();
 
   // Material
   CurveNetwork* setMaterial(std::string name);
@@ -137,6 +159,8 @@ private:
   // === Visualization parameters
   PersistentValue<glm::vec3> color;
   PersistentValue<ScaledValue<float>> radius;
+  // PersistentValue<ScaledValue<float>> nodeRadius;
+  // PersistentValue<ScaledValue<float>> edgeRadius;
   PersistentValue<std::string> material;
 
 
@@ -168,6 +192,15 @@ private:
   CurveNetworkNodeVectorQuantity* addNodeVectorQuantityImpl(std::string name, const std::vector<glm::vec3>& vectors, VectorType vectorType);
   CurveNetworkEdgeVectorQuantity* addEdgeVectorQuantityImpl(std::string name, const std::vector<glm::vec3>& vectors, VectorType vectorType);
   // clang-format on
+
+  // Manage varying node, edge size
+  std::string nodeRadiusQuantityName = ""; // e empty string means none
+  bool nodeRadiusQuantityAutoscale = true;
+  std::vector<double> resolveNodeRadiusQuantity(); // helper
+
+  // std::string edgeRadiusQuantityName = ""; // e empty string means none
+  // bool edgeRadiusQuantityAutoscale = true;
+  // std::vector<double> resolveEdgeRadiusQuantity(); // helper
 };
 
 

--- a/include/polyscope/curve_network.h
+++ b/include/polyscope/curve_network.h
@@ -182,10 +182,6 @@ private:
   std::string nodeRadiusQuantityName = ""; // e empty string means none
   bool nodeRadiusQuantityAutoscale = true;
   std::vector<double> resolveNodeRadiusQuantity(); // helper
-
-  // std::string edgeRadiusQuantityName = ""; // e empty string means none
-  // bool edgeRadiusQuantityAutoscale = true;
-  // std::vector<double> resolveEdgeRadiusQuantity(); // helper
 };
 
 

--- a/include/polyscope/render/opengl/shaders/cylinder_shaders.h
+++ b/include/polyscope/render/opengl/shaders/cylinder_shaders.h
@@ -18,6 +18,7 @@ extern const ShaderReplacementRule CYLINDER_PROPAGATE_COLOR;
 extern const ShaderReplacementRule CYLINDER_PROPAGATE_BLEND_COLOR;
 extern const ShaderReplacementRule CYLINDER_PROPAGATE_PICK;
 extern const ShaderReplacementRule CYLINDER_CULLPOS_FROM_MID;
+extern const ShaderReplacementRule CYLINDER_VARIABLE_SIZE;
 
 
 } // namespace backend_openGL3_glfw

--- a/src/curve_network.cpp
+++ b/src/curve_network.cpp
@@ -61,7 +61,6 @@ void CurveNetwork::setCurveNetworkNodeUniforms(render::ShaderProgram& p) {
   } else {
     p.setUniform("u_pointRadius", getRadius());
   }
-  // p.setUniform("u_pointRadius", getRadius());
 }
 
 void CurveNetwork::setCurveNetworkEdgeUniforms(render::ShaderProgram& p) {
@@ -70,8 +69,6 @@ void CurveNetwork::setCurveNetworkEdgeUniforms(render::ShaderProgram& p) {
   p.setUniform("u_invProjMatrix", glm::value_ptr(Pinv));
   p.setUniform("u_viewport", render::engine->getCurrentViewport());
   p.setUniform("u_radius", getRadius());
-  // p.setUniform("u_tipRadius", getRadius());
-  // p.setUniform("u_tailRadius", getRadius());
 }
 
 void CurveNetwork::draw() {
@@ -431,24 +428,6 @@ void CurveNetwork::clearNodeRadiusQuantity() {
   refresh();
 };
 
-// void CurveNetwork::setEdgeRadiusQuantity(CurveNetworkEdgeScalarQuantity* quantity, bool autoScale) {
-//   setEdgeRadiusQuantity(quantity->name, autoScale);
-// }
-//
-// void CurveNetwork::setEdgeRadiusQuantity(std::string name, bool autoScale) {
-//   edgeRadiusQuantityName = name;
-//   edgeRadiusQuantityAutoscale = autoScale;
-//
-//   resolveEdgeRadiusQuantity(); // do it once, just so we fail fast if it doesn't exist
-//
-//   refresh(); // TODO this is a bit overkill
-// }
-//
-// void CurveNetwork::clearEdgeRadiusQuantity() {
-//   edgeRadiusQuantityName = "";
-//   refresh();
-// }
-
 CurveNetwork* CurveNetwork::setRadius(float newVal, bool isRelative) {
   radius = ScaledValue<float>(newVal, isRelative);
   polyscope::requestRedraw();
@@ -560,43 +539,5 @@ std::vector<double> CurveNetwork::resolveNodeRadiusQuantity() {
 
   return sizes;
 }
-
-// std::vector<double> CurveNetwork::resolveEdgeRadiusQuantity() {
-//   CurveNetworkScalarQuantity* sizeScalarQ = nullptr;
-//   CurveNetworkQuantity* sizeQ = getQuantity(nodeRadiusQuantityName);
-//   if (sizeQ != nullptr) {
-//     sizeScalarQ = dynamic_cast<CurveNetworkScalarQuantity*>(sizeQ);
-//     if (sizeScalarQ == nullptr) {
-//       polyscope::error("Cannot populate point size from quantity [" + name + "], it is not a scalar quantity");
-//     }
-//   } else {
-//     polyscope::error("Cannot populate point size from quantity [" + name + "], it does not exist");
-//   }
-//
-//   std::vector<double> sizes;
-//   if (sizeScalarQ == nullptr || sizeScalarQ->values.size() != nEdges()) {
-//     // we failed to resolve above; populate with dummy data so we can continue processing
-//     std::vector<double> ones(nEdges(), 1.);
-//     sizes = ones;
-//     polyscope::error("quantity # != edge #");
-//   } else {
-//     sizes = sizeScalarQ->values;
-//   }
-//
-//   // clamp to nonnegative and autoscale (if requested)
-//   double max = 0;
-//   for (double& x : sizes) {
-//     if (!(x > 0)) x = 0; // ensure all nonnegative
-//     max = std::fmax(max, x);
-//   }
-//   if (max == 0) max = 1e-6;
-//   if (nodeRadiusQuantityAutoscale) {
-//     for (double& x : sizes) {
-//       x /= max;
-//     }
-//   }
-//
-//   return sizes;
-// }
 
 } // namespace polyscope

--- a/src/curve_network.cpp
+++ b/src/curve_network.cpp
@@ -56,7 +56,12 @@ void CurveNetwork::setCurveNetworkNodeUniforms(render::ShaderProgram& p) {
   glm::mat4 Pinv = glm::inverse(P);
   p.setUniform("u_invProjMatrix", glm::value_ptr(Pinv));
   p.setUniform("u_viewport", render::engine->getCurrentViewport());
-  p.setUniform("u_pointRadius", getRadius());
+  if (nodeRadiusQuantityName != "" && nodeRadiusQuantityAutoscale) {
+    p.setUniform("u_pointRadius", 1.); // u_pointRadius in sphere shader
+  } else {
+    p.setUniform("u_pointRadius", getRadius());
+  }
+  // p.setUniform("u_pointRadius", getRadius());
 }
 
 void CurveNetwork::setCurveNetworkEdgeUniforms(render::ShaderProgram& p) {
@@ -64,7 +69,7 @@ void CurveNetwork::setCurveNetworkEdgeUniforms(render::ShaderProgram& p) {
   glm::mat4 Pinv = glm::inverse(P);
   p.setUniform("u_invProjMatrix", glm::value_ptr(Pinv));
   p.setUniform("u_viewport", render::engine->getCurrentViewport());
-  p.setUniform("u_radius", getRadius());
+  p.setUniform("u_radius", getRadius()); // u_radius in cylinder shader
 }
 
 void CurveNetwork::draw() {
@@ -124,6 +129,9 @@ void CurveNetwork::drawPick() {
 
 std::vector<std::string> CurveNetwork::addCurveNetworkNodeRules(std::vector<std::string> initRules) {
   initRules = addStructureRules(initRules);
+  if (nodeRadiusQuantityName != "") {
+    initRules.push_back("SPHERE_VARIABLE_SIZE");
+  }
   if (wantsCullPosition()) {
     initRules.push_back("SPHERE_CULLPOS_FROM_CENTER");
   }
@@ -223,6 +231,12 @@ void CurveNetwork::preparePick() {
 
 void CurveNetwork::fillNodeGeometryBuffers(render::ShaderProgram& program) {
   program.setAttribute("a_position", nodes);
+
+  if (nodeRadiusQuantityName != "") {
+    // Resolve the quantity
+    std::vector<double> nodeRadiusQuantityVals = resolveNodeRadiusQuantity();
+    program.setAttribute("a_pointRadius", nodeRadiusQuantityVals);
+  }
 }
 
 void CurveNetwork::fillEdgeGeometryBuffers(render::ShaderProgram& program) {
@@ -371,12 +385,61 @@ CurveNetwork* CurveNetwork::setColor(glm::vec3 newVal) {
 }
 glm::vec3 CurveNetwork::getColor() { return color.get(); }
 
+void CurveNetwork::setNodeRadiusQuantity(CurveNetworkNodeScalarQuantity* quantity, bool autoScale) {
+  setNodeRadiusQuantity(quantity->name, autoScale);
+}
+void CurveNetwork::setNodeRadiusQuantity(std::string name, bool autoScale) {
+  nodeRadiusQuantityName = name;
+  nodeRadiusQuantityAutoscale = autoScale;
+
+  resolveNodeRadiusQuantity(); // do it once, just so we fail fast if it doesn't exist
+
+  refresh(); // TODO this is a bit overkill
+}
+void CurveNetwork::clearNodeRadiusQuantity() {
+  nodeRadiusQuantityName = "";
+  refresh();
+};
+// void CurveNetwork::setEdgeRadiusQuantity(CurveNetworkEdgeScalarQuantity* quantity, bool autoScale) {
+//   setEdgeRadiusQuantity(quantity->name, autoScale);
+// }
+//
+// void CurveNetwork::setEdgeRadiusQuantity(std::string name, bool autoScale) {
+//   edgeRadiusQuantityName = name;
+//   edgeRadiusQuantityAutoscale = autoScale;
+//
+//   resolveEdgeRadiusQuantity(); // do it once, just so we fail fast if it doesn't exist
+//
+//   refresh(); // TODO this is a bit overkill
+// }
+//
+// void CurveNetwork::clearEdgeRadiusQuantity() {
+//   edgeRadiusQuantityName = "";
+//   refresh();
+// }
+
 CurveNetwork* CurveNetwork::setRadius(float newVal, bool isRelative) {
   radius = ScaledValue<float>(newVal, isRelative);
+  // nodeRadius = ScaledValue<float>(newVal, isRelative);
+  // edgeRadius = ScaledValue<float>(newVal, isRelative);
   polyscope::requestRedraw();
   return this;
 }
-float CurveNetwork::getRadius() { return radius.get().asAbsolute(); }
+float CurveNetwork::getRadius() { return radius.get().asAbsolute(); } // TODO: what should we return?
+
+// CurveNetwork* CurveNetwork::setNodeRadius(float newVal, bool isRelative) {
+//   nodeRadius = ScaledValue<float>(newVal, isRelative);
+//   polyscope::requestRedraw();
+//   return this;
+// }
+// float CurveNetwork::getNodeRadius() { return nodeRadius.get().asAbsolute(); }
+//
+// CurveNetwork* CurveNetwork::setEdgeRadius(float newVal, bool isRelative) {
+//   edgeRadius = ScaledValue<float>(newVal, isRelative);
+//   polyscope::requestRedraw();
+//   return this;
+// }
+// float CurveNetwork::getEdgeRadius() { return edgeRadius.get().asAbsolute(); }
 
 CurveNetwork* CurveNetwork::setMaterial(std::string m) {
   material = m;
@@ -445,5 +508,80 @@ CurveNetworkEdgeVectorQuantity* CurveNetwork::addEdgeVectorQuantityImpl(std::str
   return q;
 }
 
+std::vector<double> CurveNetwork::resolveNodeRadiusQuantity() {
+  CurveNetworkScalarQuantity* sizeScalarQ = nullptr;
+  CurveNetworkQuantity* sizeQ = getQuantity(nodeRadiusQuantityName);
+  if (sizeQ != nullptr) {
+    sizeScalarQ = dynamic_cast<CurveNetworkScalarQuantity*>(sizeQ);
+    if (sizeScalarQ == nullptr) {
+      polyscope::error("Cannot populate point size from quantity [" + name + "], it is not a scalar quantity");
+    }
+  } else {
+    polyscope::error("Cannot populate point size from quantity [" + name + "], it does not exist");
+  }
+
+  std::vector<double> sizes;
+  if (sizeScalarQ == nullptr || sizeScalarQ->values.size() != nNodes()) {
+    // we failed to resolve above; populate with dummy data so we can continue processing
+    std::vector<double> ones(nNodes(), 1.);
+    sizes = ones;
+    polyscope::error("quantity # != node #");
+  } else {
+    sizes = sizeScalarQ->values;
+  }
+
+  // clamp to nonnegative and autoscale (if requested)
+  double max = 0;
+  for (double& x : sizes) {
+    if (!(x > 0)) x = 0; // ensure all nonnegative
+    max = std::fmax(max, x);
+  }
+  if (max == 0) max = 1e-6;
+  if (nodeRadiusQuantityAutoscale) {
+    for (double& x : sizes) {
+      x /= max;
+    }
+  }
+
+  return sizes;
+}
+
+// std::vector<double> CurveNetwork::resolveEdgeRadiusQuantity() {
+//   CurveNetworkScalarQuantity* sizeScalarQ = nullptr;
+//   CurveNetworkQuantity* sizeQ = getQuantity(nodeRadiusQuantityName);
+//   if (sizeQ != nullptr) {
+//     sizeScalarQ = dynamic_cast<CurveNetworkScalarQuantity*>(sizeQ);
+//     if (sizeScalarQ == nullptr) {
+//       polyscope::error("Cannot populate point size from quantity [" + name + "], it is not a scalar quantity");
+//     }
+//   } else {
+//     polyscope::error("Cannot populate point size from quantity [" + name + "], it does not exist");
+//   }
+//
+//   std::vector<double> sizes;
+//   if (sizeScalarQ == nullptr || sizeScalarQ->values.size() != nEdges()) {
+//     // we failed to resolve above; populate with dummy data so we can continue processing
+//     std::vector<double> ones(nEdges(), 1.);
+//     sizes = ones;
+//     polyscope::error("quantity # != edge #");
+//   } else {
+//     sizes = sizeScalarQ->values;
+//   }
+//
+//   // clamp to nonnegative and autoscale (if requested)
+//   double max = 0;
+//   for (double& x : sizes) {
+//     if (!(x > 0)) x = 0; // ensure all nonnegative
+//     max = std::fmax(max, x);
+//   }
+//   if (max == 0) max = 1e-6;
+//   if (nodeRadiusQuantityAutoscale) {
+//     for (double& x : sizes) {
+//       x /= max;
+//     }
+//   }
+//
+//   return sizes;
+// }
 
 } // namespace polyscope

--- a/src/curve_network.cpp
+++ b/src/curve_network.cpp
@@ -420,26 +420,10 @@ void CurveNetwork::clearNodeRadiusQuantity() {
 
 CurveNetwork* CurveNetwork::setRadius(float newVal, bool isRelative) {
   radius = ScaledValue<float>(newVal, isRelative);
-  // nodeRadius = ScaledValue<float>(newVal, isRelative);
-  // edgeRadius = ScaledValue<float>(newVal, isRelative);
   polyscope::requestRedraw();
   return this;
 }
 float CurveNetwork::getRadius() { return radius.get().asAbsolute(); } // TODO: what should we return?
-
-// CurveNetwork* CurveNetwork::setNodeRadius(float newVal, bool isRelative) {
-//   nodeRadius = ScaledValue<float>(newVal, isRelative);
-//   polyscope::requestRedraw();
-//   return this;
-// }
-// float CurveNetwork::getNodeRadius() { return nodeRadius.get().asAbsolute(); }
-//
-// CurveNetwork* CurveNetwork::setEdgeRadius(float newVal, bool isRelative) {
-//   edgeRadius = ScaledValue<float>(newVal, isRelative);
-//   polyscope::requestRedraw();
-//   return this;
-// }
-// float CurveNetwork::getEdgeRadius() { return edgeRadius.get().asAbsolute(); }
 
 CurveNetwork* CurveNetwork::setMaterial(std::string m) {
   material = m;

--- a/src/curve_network_scalar_quantity.cpp
+++ b/src/curve_network_scalar_quantity.cpp
@@ -79,8 +79,8 @@ void CurveNetworkNodeScalarQuantity::createProgram() {
       "RAYCAST_CYLINDER", addScalarRules(parent.addCurveNetworkEdgeRules({"CYLINDER_PROPAGATE_BLEND_VALUE"})));
 
   // Fill geometry buffers
-  parent.fillEdgeGeometryBuffers(*edgeProgram);
   parent.fillNodeGeometryBuffers(*nodeProgram);
+  parent.fillEdgeGeometryBuffers(*edgeProgram);
 
   { // Fill node color buffers
     nodeProgram->setAttribute("a_value", values);

--- a/src/render/mock_opengl/mock_gl_engine.cpp
+++ b/src/render/mock_opengl/mock_gl_engine.cpp
@@ -1456,6 +1456,7 @@ void MockGLEngine::populateDefaultShadersAndRules() {
   registeredShaderRules.insert({"CYLINDER_PROPAGATE_BLEND_COLOR", CYLINDER_PROPAGATE_BLEND_COLOR});
   registeredShaderRules.insert({"CYLINDER_PROPAGATE_PICK", CYLINDER_PROPAGATE_PICK});
   registeredShaderRules.insert({"CYLINDER_CULLPOS_FROM_MID", CYLINDER_CULLPOS_FROM_MID});
+  registeredShaderRules.insert({"CYLINDER_VARIABLE_SIZE", CYLINDER_VARIABLE_SIZE});
 
   // marching tets things
   registeredShaderRules.insert({"SLICE_TETS_BASECOLOR_SHADE", SLICE_TETS_BASECOLOR_SHADE});

--- a/src/render/opengl/gl_engine.cpp
+++ b/src/render/opengl/gl_engine.cpp
@@ -2144,6 +2144,7 @@ void GLEngine::populateDefaultShadersAndRules() {
   registeredShaderRules.insert({"CYLINDER_PROPAGATE_BLEND_COLOR", CYLINDER_PROPAGATE_BLEND_COLOR});
   registeredShaderRules.insert({"CYLINDER_PROPAGATE_PICK", CYLINDER_PROPAGATE_PICK});
   registeredShaderRules.insert({"CYLINDER_CULLPOS_FROM_MID", CYLINDER_CULLPOS_FROM_MID});
+  registeredShaderRules.insert({"CYLINDER_VARIABLE_SIZE", CYLINDER_VARIABLE_SIZE});
 
   // marching tets things
   registeredShaderRules.insert({"SLICE_TETS_BASECOLOR_SHADE", SLICE_TETS_BASECOLOR_SHADE});

--- a/src/render/opengl/shaders/common.cpp
+++ b/src/render/opengl/shaders/common.cpp
@@ -197,7 +197,7 @@ bool rayDiskIntersection(vec3 rayStart, vec3 rayDir, vec3 planePos, vec3 planeDi
   return true;
 }
 
-bool rayCylinderIntersection(vec3 rayStart, vec3 rayDir, vec3 cylTail, vec3 cylTip, float cylRad, out float tHit, out vec3 pHit, out vec3 nHit) {
+bool rayCylinderIntersection(vec3 rayStart, vec3 rayDir, vec3 cylTail, vec3 cylTip, float cylTipRad, float cylTailRad, out float tHit, out vec3 pHit, out vec3 nHit) {
     
     rayDir = normalize(rayDir);
     float cylLen = max(length(cylTip - cylTail), 1e-6);
@@ -209,7 +209,7 @@ bool rayCylinderIntersection(vec3 rayStart, vec3 rayDir, vec3 cylTail, vec3 cylT
     vec3 pVec = o - dot(o, cylDir)*cylDir;
     float a = length2(qVec);
     float b = 2.0 * dot(qVec, pVec);
-    float c = length2(pVec) - cylRad*cylRad;
+    float c = length2(pVec) - cylTipRad*cylTailRad; // not sure about here. What are we doing in this section? Need comment for the root-solving.
     float disc = b*b - 4*a*c;
     if(disc < 0){
       tHit = LARGE_FLOAT();
@@ -240,7 +240,7 @@ bool rayCylinderIntersection(vec3 rayStart, vec3 rayDir, vec3 cylTail, vec3 cylT
     float tHitTail;
     vec3 pHitTail;
     vec3 nHitTail;
-    rayDiskIntersection(rayStart, rayDir, cylTail, -cylDir, cylRad, tHitTail, pHitTail, nHitTail);
+    rayDiskIntersection(rayStart, rayDir, cylTail, -cylDir, cylTipRad, tHitTail, pHitTail, nHitTail);
     if(tHitTail < tHit) {
       tHit = tHitTail;
       pHit = pHitTail;
@@ -251,7 +251,7 @@ bool rayCylinderIntersection(vec3 rayStart, vec3 rayDir, vec3 cylTail, vec3 cylT
     float tHitTip;
     vec3 pHitTip;
     vec3 nHitTip;
-    rayDiskIntersection(rayStart, rayDir, cylTip, cylDir, cylRad, tHitTip, pHitTip, nHitTip);
+    rayDiskIntersection(rayStart, rayDir, cylTip, cylDir, cylTailRad, tHitTip, pHitTip, nHitTip);
     if(tHitTip < tHit) {
       tHit = tHitTip;
       pHit = pHitTip;

--- a/src/render/opengl/shaders/cylinder_shaders.cpp
+++ b/src/render/opengl/shaders/cylinder_shaders.cpp
@@ -71,8 +71,6 @@ R"(
         in vec4 position_tip[];
         uniform mat4 u_projMatrix;
         uniform float u_radius;
-        //uniform float u_tipRadius;
-        //uniform float u_tailRadius;
         out vec3 tipView;
         out vec3 tailView;
 
@@ -159,8 +157,6 @@ R"(
         uniform mat4 u_invProjMatrix;
         uniform vec4 u_viewport;
         uniform float u_radius;
-        //uniform float u_tipRadius;
-        //uniform float u_tailRadius;
         in vec3 tailView;
         in vec3 tipView;
         layout(location = 0) out vec4 outputF;

--- a/test/src/basics_test.cpp
+++ b/test/src/basics_test.cpp
@@ -679,6 +679,37 @@ TEST_F(PolyscopeTest, CurveNetworkScalarEdge) {
   polyscope::removeAllStructures();
 }
 
+TEST_F(PolyscopeTest, CurveNetworkScalarRadius) {
+  auto psCurve = registerCurveNetwork();
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> dis(0.1, 10);
+
+  std::vector<double> vScalar(psCurve->nNodes(), 0.1);
+  std::vector<double> vScalar2(psCurve->nNodes(), 0.1);
+  std::generate(vScalar.begin(), vScalar.end(), [&]() { return dis(gen); });
+  std::generate(vScalar2.begin(), vScalar2.end(), [&]() { return dis(gen); });
+
+  auto q1 = psCurve->addNodeScalarQuantity("vScalar", vScalar);
+  auto q2 = psCurve->addNodeScalarQuantity("vScalar2", vScalar2);
+  q1->setEnabled(true);
+
+  psCurve->setNodeRadiusQuantity(q1);
+  polyscope::show(3);
+
+  psCurve->setNodeRadiusQuantity("vScalar2");
+  polyscope::show(3);
+
+  psCurve->setNodeRadiusQuantity("vScalar2", false); // no autoscaling
+  polyscope::show(3);
+
+  psCurve->clearNodeRadiusQuantity();
+  polyscope::show(3);
+
+  polyscope::removeAllStructures();
+}
+
 TEST_F(PolyscopeTest, CurveNetworkVertexVector) {
   auto psCurve = registerCurveNetwork();
   std::vector<glm::vec3> vals(psCurve->nNodes(), {1., 2., 3.});
@@ -1078,7 +1109,7 @@ TEST_F(PolyscopeTest, SlicePlaneTest) {
   polyscope::show(3);
   psPoints->setCullWholeElements(false);
   polyscope::show(3);
-  
+
   polyscope::show(3);
 
   // add another and rotate it


### PR DESCRIPTION
Coming back to this issue from last year: https://github.com/nmwsharp/polyscope/issues/139

I copied the same approach from PointCloud and add a function to allow varying the node radius of `CurveNetwork`.
The radius can be set using:
```cpp
      polyscope::getCurveNetwork(name_crv)
          ->addNodeScalarQuantity("nodeR", varyingR);
      polyscope::getCurveNetwork(name_crv)
          ->setNodeRadiusQuantity("nodeR");
```
However, the edges currently cannot be set correctly. 
Based on the discussion, I think it is good to blend the curve radius to the radius of two nodes, instead of managing two sets of radii (node + edge) -- it makes things cleaner.

However, this requires a new "truncated cone" shader so that the two radii of the cylinder on the two ends can be different.
My openGL knowledge is a bit limited, can have difficulty doing that.

The current effect is shown below:
![image](https://user-images.githubusercontent.com/1921878/180957272-4bf34f11-c091-4fd4-9312-1ab85e22b119.png)


P.S. 
The PR contains some commented PR (what I started by allowing also managing edge radius, but later decide not to). Please feel free to use it or delete it.