### PR TITLE
Fix level set shading

### DIFF
--- a/src/render/opengl/shaders/volume_mesh_shaders.cpp
+++ b/src/render/opengl/shaders/volume_mesh_shaders.cpp
@@ -150,7 +150,7 @@ const ShaderStageSpecification SLICE_TETS_GEOM_SHADER = {
             // Emit the vertices as a triangle strip
             mat4 toScreen = u_projMatrix * u_modelView;
             for (int i = 0; i < n; i++){
-                a_normalToFrag = cross12;
+                a_normalToFrag = vec3(toScreen * vec4(cross12, 0.0));
                 a_barycoordToFrag = vec3(0, 0, 0);
                 a_barycoordToFrag[i % 3] = 1.0;
                 ${ GEOM_ASSIGNMENTS }$
@@ -341,8 +341,7 @@ const ShaderReplacementRule SLICE_TETS_VECTOR_COLOR(
           vec3 albedoColor = shadeValue;
         )"}},
     /* uniforms */
-    {
-    },
+    {},
     /* attributes */ {},
     /* textures */ {});
 

--- a/src/render/opengl/shaders/volume_mesh_shaders.cpp
+++ b/src/render/opengl/shaders/volume_mesh_shaders.cpp
@@ -138,8 +138,18 @@ const ShaderStageSpecification SLICE_TETS_GEOM_SHADER = {
                 }
             }
 
+            // compute gradient of d to orient our sliced faces
+            vec3 vN[4]; // tet face normal times volume
+            vN[0] = cross(p[2]-p[1], p[3]-p[1]);
+            vN[1] = cross(p[3]-p[0], p[2]-p[0]);
+            vN[2] = cross(p[1]-p[0], p[3]-p[0]);
+            vN[3] = cross(p[0]-p[1], p[2]-p[1]);
+
+            // actually gradient times tet volume, but since we only want the sign, that doesn't really matter
+            // TODO: fix for inverted tets?
+            vec3 grad = d[0] * vN[0] + d[1] * vN[1] + d[2] * vN[2] + d[3] * vN[3];
             vec3 cross12 = cross(q[1] - q[0], q[2] - q[0]);
-            if(dot(cross12, u_sliceVector) < 0){
+            if(dot(cross12, grad) < 0){
                 int temp = ordering[1];
                 ordering[1] = ordering[2];
                 ordering[2] = temp;

--- a/src/volume_mesh_scalar_quantity.cpp
+++ b/src/volume_mesh_scalar_quantity.cpp
@@ -186,7 +186,6 @@ void VolumeMeshVertexScalarQuantity::setLevelSetVisibleQuantity(std::string name
 
 void VolumeMeshVertexScalarQuantity::buildCustomUI() {
   VolumeMeshScalarQuantity::buildCustomUI();
-  /* TODO disabled for now
   if (ImGui::Checkbox("Level Set", &isDrawingLevelSet)) {
     setEnabledLevelSet(isDrawingLevelSet);
   }
@@ -205,7 +204,6 @@ void VolumeMeshVertexScalarQuantity::buildCustomUI() {
       ImGui::EndMenu();
     }
   }
-  */
 }
 
 void VolumeMeshVertexScalarQuantity::refresh() {


### PR DESCRIPTION
I found two minor bugs in polyscope's marching tets implementation.
1. Emitted faces were oriented using `u_sliceVector` rather than the gradient of the scalar function. This works fine for slicing along planes, but for arbitrary scalar functions `u_sliceVector` is completely independent from the function
2. Normals weren't transformed to screen space

I fixed these bugs and enabled level set visualization in the GUI