### PR TITLE
Add exception to register functions if polyscope is not initialized

### DIFF
--- a/include/polyscope/curve_network.ipp
+++ b/include/polyscope/curve_network.ipp
@@ -7,6 +7,8 @@ namespace polyscope {
 // Shorthand to add a curve network to polyscope
 template <class P, class E>
 CurveNetwork* registerCurveNetwork(std::string name, const P& nodes, const E& edges) {
+  checkInitialized();
+  
   CurveNetwork* s = new CurveNetwork(name, standardizeVectorArray<glm::vec3, 3>(nodes),
                                      standardizeVectorArray<std::array<size_t, 2>, 2>(edges));
   bool success = registerStructure(s);
@@ -17,6 +19,8 @@ CurveNetwork* registerCurveNetwork(std::string name, const P& nodes, const E& ed
 }
 template <class P, class E>
 CurveNetwork* registerCurveNetwork2D(std::string name, const P& nodes, const E& edges) {
+  checkInitialized();
+  
   std::vector<glm::vec3> points3D(standardizeVectorArray<glm::vec3, 2>(nodes));
   for (auto& v : points3D) {
     v.z = 0.;
@@ -33,6 +37,7 @@ CurveNetwork* registerCurveNetwork2D(std::string name, const P& nodes, const E& 
 // Shorthand to add curve from a line of points
 template <class P>
 CurveNetwork* registerCurveNetworkLine(std::string name, const P& nodes) {
+  checkInitialized();
 
   std::vector<std::array<size_t, 2>> edges;
   size_t N = adaptorF_size(nodes);
@@ -49,6 +54,7 @@ CurveNetwork* registerCurveNetworkLine(std::string name, const P& nodes) {
 }
 template <class P>
 CurveNetwork* registerCurveNetworkLine2D(std::string name, const P& nodes) {
+  checkInitialized();
 
   std::vector<std::array<size_t, 2>> edges;
   size_t N = adaptorF_size(nodes);
@@ -71,6 +77,7 @@ CurveNetwork* registerCurveNetworkLine2D(std::string name, const P& nodes) {
 // Shorthand to add curve from a loop of points
 template <class P>
 CurveNetwork* registerCurveNetworkLoop(std::string name, const P& nodes) {
+  checkInitialized();
 
   std::vector<std::array<size_t, 2>> edges;
   size_t N = adaptorF_size(nodes);
@@ -87,6 +94,7 @@ CurveNetwork* registerCurveNetworkLoop(std::string name, const P& nodes) {
 }
 template <class P>
 CurveNetwork* registerCurveNetworkLoop2D(std::string name, const P& nodes) {
+  checkInitialized();
 
   std::vector<std::array<size_t, 2>> edges;
   size_t N = adaptorF_size(nodes);

--- a/include/polyscope/point_cloud.ipp
+++ b/include/polyscope/point_cloud.ipp
@@ -7,6 +7,8 @@ namespace polyscope {
 // Shorthand to add a point cloud to polyscope
 template <class T>
 PointCloud* registerPointCloud(std::string name, const T& points) {
+  checkInitialized();
+
   PointCloud* s = new PointCloud(name, standardizeVectorArray<glm::vec3, 3>(points));
   bool success = registerStructure(s);
   if (!success) {
@@ -16,6 +18,8 @@ PointCloud* registerPointCloud(std::string name, const T& points) {
 }
 template <class T>
 PointCloud* registerPointCloud2D(std::string name, const T& points) {
+  checkInitialized();
+  
   std::vector<glm::vec3> points3D(standardizeVectorArray<glm::vec3, 2>(points));
   for (auto& v : points3D) {
     v.z = 0.;

--- a/include/polyscope/polyscope.h
+++ b/include/polyscope/polyscope.h
@@ -28,6 +28,9 @@ class Structure;
 // The backend string sets which rendering backend to use. If "", a reasonable default backend will be chosen.
 void init(std::string backend = "");
 
+// Check that polyscope has been initialized. If not, an exception is thrown to prevent further problems.
+void checkInitialized();
+
 // Give control to the polyscope GUI. Blocks until the user returns control via
 // the GUI, possibly by exiting the window.
 void show(size_t forFrames = std::numeric_limits<size_t>::max());

--- a/include/polyscope/polyscope.h
+++ b/include/polyscope/polyscope.h
@@ -31,6 +31,9 @@ void init(std::string backend = "");
 // Check that polyscope has been initialized. If not, an exception is thrown to prevent further problems.
 void checkInitialized();
 
+// Returns a bool indicating whether or not polyscope has been initialized
+bool isInitialized();
+
 // Give control to the polyscope GUI. Blocks until the user returns control via
 // the GUI, possibly by exiting the window.
 void show(size_t forFrames = std::numeric_limits<size_t>::max());

--- a/include/polyscope/surface_mesh.ipp
+++ b/include/polyscope/surface_mesh.ipp
@@ -4,6 +4,8 @@ namespace polyscope {
 // Shorthand to add a mesh to polyscope
 template <class V, class F>
 SurfaceMesh* registerSurfaceMesh(std::string name, const V& vertexPositions, const F& faceIndices) {
+  checkInitialized();
+  
   SurfaceMesh* s = new SurfaceMesh(name, standardizeVectorArray<glm::vec3, 3>(vertexPositions),
                                    standardizeNestedList<size_t, F>(faceIndices));
   bool success = registerStructure(s);
@@ -15,6 +17,7 @@ SurfaceMesh* registerSurfaceMesh(std::string name, const V& vertexPositions, con
 }
 template <class V, class F>
 SurfaceMesh* registerSurfaceMesh2D(std::string name, const V& vertexPositions, const F& faceIndices) {
+  checkInitialized();
 
   std::vector<glm::vec3> positions3D = standardizeVectorArray<glm::vec3, 2>(vertexPositions);
   for (auto& v : positions3D) {
@@ -34,6 +37,8 @@ SurfaceMesh* registerSurfaceMesh2D(std::string name, const V& vertexPositions, c
 template <class V, class F, class P>
 SurfaceMesh* registerSurfaceMesh(std::string name, const V& vertexPositions, const F& faceIndices,
                                  const std::array<std::pair<P, size_t>, 5>& perms) {
+  checkInitialized();
+  
   SurfaceMesh* s = registerSurfaceMesh(name, vertexPositions, faceIndices);
 
   if (s) {

--- a/include/polyscope/volume_mesh.ipp
+++ b/include/polyscope/volume_mesh.ipp
@@ -5,6 +5,7 @@ namespace polyscope {
 
 template <class V, class F>
 VolumeMesh* registerTetMesh(std::string name, const V& vertexPositions, const F& tetIndices) {
+  checkInitialized();
 
   // Standardize the array, and pad out extra indices with -1 for our representation
   std::vector<std::array<int64_t, 8>> tetIndsArr = standardizeVectorArray<std::array<int64_t, 8>, 4>(tetIndices);
@@ -27,6 +28,8 @@ VolumeMesh* registerTetMesh(std::string name, const V& vertexPositions, const F&
 
 template <class V, class F>
 VolumeMesh* registerHexMesh(std::string name, const V& vertexPositions, const F& faceIndices) {
+  checkInitialized();
+  
   VolumeMesh* s = new VolumeMesh(name, standardizeVectorArray<glm::vec3, 3>(vertexPositions),
                                  standardizeVectorArray<std::array<int64_t, 8>, 8>(faceIndices));
 
@@ -40,6 +43,8 @@ VolumeMesh* registerHexMesh(std::string name, const V& vertexPositions, const F&
 
 template <class V, class F>
 VolumeMesh* registerVolumeMesh(std::string name, const V& vertexPositions, const F& faceIndices) {
+  checkInitialized();
+  
   VolumeMesh* s = new VolumeMesh(name, standardizeVectorArray<glm::vec3, 3>(vertexPositions),
                                  standardizeVectorArray<std::array<int64_t, 8>, 8>(faceIndices));
 
@@ -53,6 +58,7 @@ VolumeMesh* registerVolumeMesh(std::string name, const V& vertexPositions, const
 
 template <class V, class Ft, class Fh>
 VolumeMesh* registerTetHexMesh(std::string name, const V& vertexPositions, const Ft& tetIndices, const Fh& hexIndices) {
+  checkInitialized();
 
   // Standardize the array, and pad out extra indices with -1 for our representation
   std::vector<std::array<int64_t, 8>> tetIndsArr = standardizeVectorArray<std::array<int64_t, 8>, 4>(tetIndices);

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -120,7 +120,7 @@ void writePrefsFile() {
 // === Core global functions
 
 void init(std::string backend) {
-  if (state::initialized) {
+  if (isInitialized()) {
     if (backend != state::backend) {
       throw std::runtime_error("re-initializing with different backend is not supported");
     }
@@ -153,6 +153,10 @@ void checkInitialized() {
   if (!state::initialized) {
     throw std::runtime_error("Polyscope has not been initialized");
   }
+}
+
+bool isInitialized() {
+  return state::initialized;
 }
 
 void pushContext(std::function<void()> callbackFunction, bool drawDefaultUI) {

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -149,6 +149,12 @@ void init(std::string backend) {
   state::doDefaultMouseInteraction = true;
 }
 
+void checkInitialized() {
+  if (!state::initialized) {
+    throw std::runtime_error("Polyscope has not been initialized");
+  }
+}
+
 void pushContext(std::function<void()> callbackFunction, bool drawDefaultUI) {
 
   // Create a new context and push it on to the stack


### PR DESCRIPTION
Previously if a register function was called and polyscope was not initialized you would get a seg fault. Adding this check now gives you a useful exception that tells you that polyscope needs to be initialized.