### PR TITLE
add function to retrieve imgui context

### DIFF
--- a/include/polyscope/polyscope.h
+++ b/include/polyscope/polyscope.h
@@ -126,6 +126,11 @@ bool redrawRequested();
 void pushContext(std::function<void()> callbackFunction, bool drawDefaultUI = true);
 void popContext();
 
+// Get current ImGui context
+// When linking to Polyscope as a shared library, we must set the current context
+// explicitly before making calls to ImGui in host application
+ImGuiContext* getCurrentContext();
+
 // These helpers are called internally by Polyscope to render and build the UI.
 // Normally, applications should not need to call them, but in advanced settings when making custom UIs, they may be
 // useful to manually build pieces of the interface.

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -218,9 +218,6 @@ void popContext() {
   contextStack.pop_back();
 }
 
-// Get current ImGui context
-// When linking to Polyscope as a shared library, we must set the current context
-// explicitly before making calls to ImGui in host application
 ImGuiContext* getCurrentContext()
 {
   return contextStack.empty() ? nullptr : contextStack.back().context;

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -218,6 +218,14 @@ void popContext() {
   contextStack.pop_back();
 }
 
+// Get current ImGui context
+// When linking to Polyscope as a shared library, we must set the current context
+// explicitly before making calls to ImGui in host application
+ImGuiContext* getCurrentContext()
+{
+  return contextStack.empty() ? nullptr : contextStack.back().context;
+}
+
 void requestRedraw() { redrawNextFrame = true; }
 bool redrawRequested() { return redrawNextFrame; }
 


### PR DESCRIPTION
When linking to polyscore as a shared library it is necessary to set the current ImGui context explicitly in userCallback prior to making ant calls to ImGui. (see: https://github.com/ocornut/imgui/issues/2292)