### PR TITLE
Draft: New Feature - Groups, i.e. creating collections of structures in the UI for quickly showing - hiding layers / hierarchies of structures  

### DIFF
--- a/include/polyscope/group.h
+++ b/include/polyscope/group.h
@@ -27,6 +27,7 @@ public:
   void addChildGroup(Group* newChild);
   void addChildStructure(Structure* newChild);
   void removeChildGroup(Group* child);
+  void removeChildStructure(Structure* child);
   void unparent();
 
   bool isRootGroup();

--- a/include/polyscope/group.h
+++ b/include/polyscope/group.h
@@ -30,6 +30,7 @@ public:
   void unparent();
 
   bool isRootGroup();
+  Group* getTopLevelGrandparent();
 
   std::string niceName();
 

--- a/include/polyscope/group.h
+++ b/include/polyscope/group.h
@@ -7,9 +7,11 @@
 
 namespace polyscope {
 
-// A 'quantity' (in Polyscope terminology) is data which is associated with a structure; any structure might have many
-// quantities. For instance a mesh structure might have a scalar quantity associated with it, or a point cloud might
-// have a vector field quantity associated with it.
+// Groups track collections of structures (or other groups) which can be toggled together.
+//
+// Groups are non-owning. Any contained structures continue their normal lifetime unaffected
+// by the group. A structure can be in 0, 1, or multiple groups, and removing it from a group 
+// does not destroy the structure.
 
 class Group {
 public:

--- a/include/polyscope/group.h
+++ b/include/polyscope/group.h
@@ -10,7 +10,7 @@ namespace polyscope {
 // Groups track collections of structures (or other groups) which can be toggled together.
 //
 // Groups are non-owning. Any contained structures continue their normal lifetime unaffected
-// by the group. A structure can be in 0, 1, or multiple groups, and removing it from a group 
+// by the group. A structure can be in 0, 1, or multiple groups, and removing it from a group
 // does not destroy the structure.
 
 class Group {
@@ -19,8 +19,8 @@ public:
   ~Group();
 
   // Draw the ImGUI ui elements
-  void buildUI();       // draws the tree node and enabled checkbox, and calls
-                                // buildUI() for all children.
+  void buildUI(); // draws the tree node and enabled checkbox, and calls
+                  // buildUI() for all children.
 
   // Is the group being displayed (0 no, 1 some children, 2 all children)
   int isEnabled();
@@ -38,11 +38,10 @@ public:
   std::string niceName();
 
   // === Member variables ===
-  Group* parentGroup; // the parent group of this group (if null, this is a root group)
+  Group* parentGroup;     // the parent group of this group (if null, this is a root group)
   const std::string name; // a name for this group, which must be unique amongst groups on `parent`
   std::vector<Group*> childrenGroups;
   std::vector<Structure*> childrenStructures;
-
 };
 
 

--- a/include/polyscope/group.h
+++ b/include/polyscope/group.h
@@ -1,0 +1,45 @@
+// Copyright 2017-2019, Nicholas Sharp and the Polyscope contributors. http://polyscope.run.
+#pragma once
+
+#include "polyscope/structure.h"
+
+#include <string>
+
+namespace polyscope {
+
+// A 'quantity' (in Polyscope terminology) is data which is associated with a structure; any structure might have many
+// quantities. For instance a mesh structure might have a scalar quantity associated with it, or a point cloud might
+// have a vector field quantity associated with it.
+
+class Group {
+public:
+  Group(std::string name);
+  ~Group();
+
+  // Draw the ImGUI ui elements
+  void buildUI();       // draws the tree node and enabled checkbox, and calls
+                                // buildUI() for all children.
+
+  // Is the group being displayed (0 no, 1 some children, 2 all children)
+  int isEnabled();
+  Group* setEnabled(bool newEnabled);
+
+  void addChildGroup(Group* newChild);
+  void addChildStructure(Structure* newChild);
+  void removeChildGroup(Group* child);
+  void unparent();
+
+  bool isRootGroup();
+
+  std::string niceName();
+
+  // === Member variables ===
+  Group* parentGroup; // the parent group of this group (if null, this is a root group)
+  const std::string name; // a name for this group, which must be unique amongst groups on `parent`
+  std::vector<Group*> childrenGroups;
+  std::vector<Structure*> childrenStructures;
+
+};
+
+
+} // namespace polyscope

--- a/include/polyscope/polyscope.h
+++ b/include/polyscope/polyscope.h
@@ -96,11 +96,12 @@ Structure* getStructure(std::string type, std::string name = "");
 // True if such a structure exists
 bool hasStructure(std::string type, std::string name = "");
 
-// register a structure with polyscope
+// Group management - TODO: Daniel, add entries for documentation
 bool registerGroup(std::string name);
 bool setParentGroupOfGroup(std::string child, std::string parent);
 bool setParentGroupOfStructure(std::string typeName, std::string child, std::string parent);
 // De-register a group
+void setGroupEnabled(std::string name, bool enabled);
 void removeGroup(std::string name, bool errorIfAbsent = true);
 
 // De-register a structure, of any type. Also removes any quantities associated with the structure

--- a/include/polyscope/polyscope.h
+++ b/include/polyscope/polyscope.h
@@ -7,6 +7,7 @@
 #include "polyscope/screenshot.h"
 #include "polyscope/slice_plane.h"
 #include "polyscope/structure.h"
+#include "polyscope/group.h"
 #include "polyscope/utilities.h"
 #include "polyscope/widget.h"
 #include "polyscope/transformation_gizmo.h"
@@ -53,6 +54,9 @@ extern std::string backend;
 // lists of all structures in Polyscope, by category
 extern std::map<std::string, std::map<std::string, Structure*>> structures;
 
+// lists of all groups in Polyscope
+extern std::map<std::string, Group*> groups;
+
 // representative length scale for all registered structures
 extern float lengthScale;
 
@@ -91,6 +95,13 @@ Structure* getStructure(std::string type, std::string name = "");
 
 // True if such a structure exists
 bool hasStructure(std::string type, std::string name = "");
+
+// register a structure with polyscope
+bool registerGroup(std::string name);
+bool setParentGroupOfGroup(std::string child, std::string parent);
+bool setParentGroupOfStructure(std::string typeName, std::string child, std::string parent);
+// De-register a group
+void removeGroup(std::string name, bool errorIfAbsent = true);
 
 // De-register a structure, of any type. Also removes any quantities associated with the structure
 void removeStructure(Structure* structure, bool errorIfAbsent = true);

--- a/include/polyscope/polyscope.h
+++ b/include/polyscope/polyscope.h
@@ -13,6 +13,7 @@
 #include "polyscope/utilities.h"
 #include "polyscope/widget.h"
 
+
 #include <functional>
 #include <map>
 #include <set>
@@ -23,6 +24,7 @@ namespace polyscope {
 
 // forward declarations
 class Structure;
+class Group;
 
 // Initialize polyscope, including windowing system and openGL. Should be called exactly once at the beginning of a
 // program. If initialization fails in any way, an exception will be thrown.

--- a/include/polyscope/polyscope.h
+++ b/include/polyscope/polyscope.h
@@ -100,9 +100,11 @@ bool hasStructure(std::string type, std::string name = "");
 bool registerGroup(std::string name);
 bool setParentGroupOfGroup(std::string child, std::string parent);
 bool setParentGroupOfStructure(std::string typeName, std::string child, std::string parent);
+bool setParentGroupOfStructure(Structure* child, std::string parent);
 // De-register a group
 void setGroupEnabled(std::string name, bool enabled);
 void removeGroup(std::string name, bool errorIfAbsent = true);
+void removeAllGroups();
 
 // De-register a structure, of any type. Also removes any quantities associated with the structure
 void removeStructure(Structure* structure, bool errorIfAbsent = true);

--- a/include/polyscope/polyscope.h
+++ b/include/polyscope/polyscope.h
@@ -1,17 +1,17 @@
 // Copyright 2017-2019, Nicholas Sharp and the Polyscope contributors. http://polyscope.run.
 #pragma once
 
+#include "imgui.h"
+#include "polyscope/group.h"
 #include "polyscope/internal.h"
 #include "polyscope/messages.h"
 #include "polyscope/options.h"
 #include "polyscope/screenshot.h"
 #include "polyscope/slice_plane.h"
 #include "polyscope/structure.h"
-#include "polyscope/group.h"
+#include "polyscope/transformation_gizmo.h"
 #include "polyscope/utilities.h"
 #include "polyscope/widget.h"
-#include "polyscope/transformation_gizmo.h"
-#include "imgui.h"
 
 #include <functional>
 #include <map>
@@ -67,14 +67,12 @@ extern std::tuple<glm::vec3, glm::vec3> boundingBox;
 extern std::set<Widget*> widgets;
 extern std::vector<SlicePlane*> slicePlanes;
 
-// should we allow default trackball mouse camera interaction? 
+// should we allow default trackball mouse camera interaction?
 // Needs more interactions on when to turn this on/off
 extern bool doDefaultMouseInteraction;
 
 // a callback function used to render a "user" gui
 extern std::function<void()> userCallback;
-
-
 
 
 // representative center for all registered structures
@@ -96,7 +94,7 @@ Structure* getStructure(std::string type, std::string name = "");
 // True if such a structure exists
 bool hasStructure(std::string type, std::string name = "");
 
-// Group management - TODO: Daniel, add entries for documentation
+// Group management
 bool registerGroup(std::string name);
 bool setParentGroupOfGroup(std::string child, std::string parent);
 bool setParentGroupOfStructure(std::string typeName, std::string child, std::string parent);

--- a/include/polyscope/structure.h
+++ b/include/polyscope/structure.h
@@ -53,6 +53,8 @@ public:
   const std::string name; // should be unique amongst registered structures with this type
   std::string uniquePrefix();
 
+  std::string getName() { return name; }; // used by pybind to access the name property
+
   // = Length and bounding box
   // (returned in world coordinates, after the object transform is applied)
   std::tuple<glm::vec3, glm::vec3> boundingBox(); // get axis-aligned bounding box

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,7 @@ SET(SRCS
   internal.cpp
   state.cpp
   structure.cpp
+  group.cpp
   utilities.cpp
   view.cpp
   screenshot.cpp
@@ -215,6 +216,7 @@ SET(HEADERS
   ${INCLUDE_ROOT}/curve_network_vector_quantity.h
   ${INCLUDE_ROOT}/disjoint_sets.h
   ${INCLUDE_ROOT}/file_helpers.h
+  ${INCLUDE_ROOT}/group.h
   ${INCLUDE_ROOT}/histogram.h
   ${INCLUDE_ROOT}/image_scalar_artist.h
   ${INCLUDE_ROOT}/imgui_config.h

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -45,7 +45,10 @@ Group::~Group(){
   for (Group* child : childrenGroups) {
     child->parentGroup = nullptr;
   }
-  // remove onselves from parent
+  // clear vectors
+  childrenGroups.clear();
+  childrenStructures.clear();
+  // remove oneself from parent
   if (parentGroup != nullptr) {
     parentGroup->removeChildGroup(this);
   }
@@ -95,10 +98,23 @@ void Group::removeChildGroup(Group* child) {
 }
 
 void Group::addChildGroup(Group* newChild) {
-  // TODO: check cycles
-  // TODO: if child is already in a group, remove it from that group
+  // TODO: Daniel - check for cycles
+  if (getTopLevelGrandparent() == newChild) {
+    polyscope::error("Attempted to make group " + newChild->name + " a child of " + name + ", but this would create a cycle (group " + name + " is already a descendant of " + newChild->name + ")");
+    return;
+  }
+  // if child is already in a group, remove it from that group
+  newChild->unparent();
   newChild->parentGroup = this;
   childrenGroups.push_back(newChild);
+}
+
+Group* Group::getTopLevelGrandparent() {
+  Group* current = this;
+  while (current->parentGroup != nullptr) {
+    current = current->parentGroup;
+  }
+  return current;
 }
 
 void Group::addChildStructure(Structure* newChild) {
@@ -106,7 +122,6 @@ void Group::addChildStructure(Structure* newChild) {
 }
 
 int Group::isEnabled() {
-  // TODO: fix enabling / disabling behavior
   bool any_children_enabled = false;
   bool any_children_disabled = false;
   // check all structure children

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -1,45 +1,38 @@
 // Copyright 2017-2019, Nicholas Sharp and the Polyscope contributors. http://polyscope.run.
+#include "polyscope/group.h"
 #include "imgui.h"
 #include "polyscope/polyscope.h"
-#include "polyscope/group.h"
 
 #include "imgui_internal.h"
 
 namespace {
-    bool CheckboxTristate(const char* label, int* v_tristate)
-    {
-        bool ret;
-        if (*v_tristate == -1)
-        {
-            ImGui::PushItemFlag(ImGuiItemFlags_MixedValue, true);
-            bool b = false;
-            ret = ImGui::Checkbox(label, &b);
-            if (ret)
-                *v_tristate = 1;
-            ImGui::PopItemFlag();
-        }
-        else
-        {
-            bool b = (*v_tristate != 0);
-            ret = ImGui::Checkbox(label, &b);
-            if (ret)
-                *v_tristate = (int)b;
-        }
-        return ret;
-    }
-};
+bool CheckboxTristate(const char* label, int* v_tristate) {
+  bool ret;
+  if (*v_tristate == -1) {
+    ImGui::PushItemFlag(ImGuiItemFlags_MixedValue, true);
+    bool b = false;
+    ret = ImGui::Checkbox(label, &b);
+    if (ret) *v_tristate = 1;
+    ImGui::PopItemFlag();
+  } else {
+    bool b = (*v_tristate != 0);
+    ret = ImGui::Checkbox(label, &b);
+    if (ret) *v_tristate = (int)b;
+  }
+  return ret;
+}
+}; // namespace
 
 
 namespace polyscope {
 
-Group::Group(std::string name_)
-    : name(name_) {
+Group::Group(std::string name_) : name(name_) {
   childrenGroups = std::vector<Group*>();
   childrenStructures = std::vector<Structure*>();
   parentGroup = nullptr;
 }
 
-Group::~Group(){
+Group::~Group() {
   // unparent all children
   for (Group* child : childrenGroups) {
     child->parentGroup = nullptr;
@@ -70,7 +63,7 @@ void Group::buildUI() {
     } else {
       if (CheckboxTristate("Enabled", &enabledLocal)) {
         setEnabled(enabledLocal);
-      }  
+      }
     }
 
     // Call children buildUI
@@ -81,7 +74,7 @@ void Group::buildUI() {
     for (Structure* child : childrenStructures) {
       child->buildUI();
     }
-    
+
     ImGui::TreePop();
   }
 }
@@ -96,7 +89,9 @@ void Group::unparent() {
 void Group::addChildGroup(Group* newChild) {
   // TODO: Daniel - check for cycles
   if (getTopLevelGrandparent() == newChild) {
-    polyscope::error("Attempted to make group " + newChild->name + " a child of " + name + ", but this would create a cycle (group " + name + " is already a descendant of " + newChild->name + ")");
+    polyscope::error("Attempted to make group " + newChild->name + " a child of " + name +
+                     ", but this would create a cycle (group " + name + " is already a descendant of " +
+                     newChild->name + ")");
     return;
   }
   // if child is already in a group, remove it from that group
@@ -105,9 +100,7 @@ void Group::addChildGroup(Group* newChild) {
   childrenGroups.push_back(newChild);
 }
 
-void Group::addChildStructure(Structure* newChild) {
-  childrenStructures.push_back(newChild);
-}
+void Group::addChildStructure(Structure* newChild) { childrenStructures.push_back(newChild); }
 
 void Group::removeChildGroup(Group* child) {
   auto it = std::find(childrenGroups.begin(), childrenGroups.end(), child);
@@ -133,7 +126,7 @@ Group* Group::getTopLevelGrandparent() {
 }
 
 int Group::isEnabled() {
-  // return values: 
+  // return values:
   // 0: all children disabled
   // 1: all children enabled
   // -1: some children enabled, some disabled
@@ -193,12 +186,8 @@ Group* Group::setEnabled(bool newEnabled) {
   return this;
 }
 
-bool Group::isRootGroup() {
-  return parentGroup == nullptr;
-}
+bool Group::isRootGroup() { return parentGroup == nullptr; }
 
-std::string Group::niceName() {
-  return name;
-}
+std::string Group::niceName() { return name; }
 
 } // namespace polyscope

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -5,8 +5,7 @@
 
 #include "imgui_internal.h"
 
-namespace ImGui
-{
+namespace {
     bool CheckboxTristate(const char* label, int* v_tristate)
     {
         bool ret;
@@ -69,7 +68,7 @@ void Group::buildUI() {
       // no children, add greyed out text
       ImGui::TextDisabled("no child structures");
     } else {
-      if (ImGui::CheckboxTristate("Enabled", &enabledLocal)) {
+      if (CheckboxTristate("Enabled", &enabledLocal)) {
         setEnabled(enabledLocal);
       }  
     }

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -53,13 +53,18 @@ Group::~Group(){
 
 void Group::buildUI() {
 
+  // Set this treenode to open if there's children
+  if (childrenGroups.size() > 0 || childrenStructures.size() > 0) {
+    ImGui::SetNextTreeNodeOpen(true, ImGuiCond_Once);
+  }
+
   if (ImGui::TreeNode(niceName().c_str())) {
 
     // Enabled checkbox
     int enabledLocal = isEnabled();
     if (ImGui::CheckboxTristate("Enabled", &enabledLocal)) {
       setEnabled(enabledLocal);
-    }
+    }  
 
     // Call children buildUI
     for (Group* child : childrenGroups) {

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -161,8 +161,6 @@ int Group::isEnabled() {
       any_children_enabled = true;
       any_children_disabled = true;
     } else if (child->isEnabled() == -2) {
-      any_children_enabled = false;
-      any_children_disabled = false;
     } else { // huh?
       polyscope::error("Unexpected return value from Group::isEnabled()");
     }

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -72,12 +72,45 @@ void Group::addChildStructure(Structure* newChild) {
 }
 
 int Group::isEnabled() {
-  // TODO
-  return 2;
+  // TODO: fix enabling / disabling behavior
+  bool any_children_enabled = false;
+  bool any_children_disabled = false;
+  // check all structure children
+  for (Structure* child : childrenStructures) {
+    if (child->isEnabled()) {
+      any_children_enabled = true;
+    } else {
+      any_children_disabled = true;
+    }
+  }
+  // check all group children
+  for (Group* child : childrenGroups) {
+    if (child->isEnabled() != 0) {
+      any_children_enabled = true;
+    } else {
+      any_children_disabled = true;
+    }
+  }
+
+  int result = 0;
+  if (any_children_enabled) {
+    result = 1;
+    if (!any_children_disabled) {
+      result = 2;
+    }
+  }
+  return result;
 }
 
 Group* Group::setEnabled(bool newEnabled) {
-  // TODO
+  // set all structure children to enabled
+  for (Structure* child : childrenStructures) {
+    child->setEnabled(newEnabled);
+  }
+  // set all group children to enabled
+  for (Group* child : childrenGroups) {
+    child->setEnabled(newEnabled);
+  }
   return this;
 }
 

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -1,0 +1,92 @@
+// Copyright 2017-2019, Nicholas Sharp and the Polyscope contributors. http://polyscope.run.
+#include "imgui.h"
+#include "polyscope/polyscope.h"
+#include "polyscope/group.h"
+
+namespace polyscope {
+
+Group::Group(std::string name_)
+    : name(name_) {
+  childrenGroups = std::vector<Group*>();
+  childrenStructures = std::vector<Structure*>();
+  parentGroup = nullptr;
+}
+
+Group::~Group(){
+  // unparent all children
+  for (Group* child : childrenGroups) {
+    child->parentGroup = nullptr;
+  }
+  // remove onselves from parent
+  if (parentGroup != nullptr) {
+    parentGroup->removeChildGroup(this);
+  }
+};
+
+void Group::buildUI() {
+
+  if (ImGui::TreeNode(niceName().c_str())) {
+
+    // Enabled checkbox
+    bool enabledLocal = isEnabled();
+    ImGui::Checkbox("Enabled", &enabledLocal);
+    setEnabled(enabledLocal);
+
+    // Call children buildUI
+    for (Group* child : childrenGroups) {
+      child->buildUI();
+    }
+
+    for (Structure* child : childrenStructures) {
+      child->buildUI();
+    }
+    
+    ImGui::TreePop();
+  }
+}
+
+void Group::unparent() {
+  if (parentGroup != nullptr) {
+    parentGroup->removeChildGroup(this);
+  }
+  parentGroup = nullptr; // redundant, but explicit
+}
+
+void Group::removeChildGroup(Group* child) {
+  auto it = std::find(childrenGroups.begin(), childrenGroups.end(), child);
+  if (it != childrenGroups.end()) {
+    (*it)->parentGroup = nullptr; // mark child as not having a parent anymore
+    childrenGroups.erase(it);
+  }
+}
+
+void Group::addChildGroup(Group* newChild) {
+  // TODO: check cycles
+  // TODO: if child is already in a group, remove it from that group
+  newChild->parentGroup = this;
+  childrenGroups.push_back(newChild);
+}
+
+void Group::addChildStructure(Structure* newChild) {
+  childrenStructures.push_back(newChild);
+}
+
+int Group::isEnabled() {
+  // TODO
+  return 2;
+}
+
+Group* Group::setEnabled(bool newEnabled) {
+  // TODO
+  return this;
+}
+
+bool Group::isRootGroup() {
+  return parentGroup == nullptr;
+}
+
+std::string Group::niceName() {
+  return name;
+}
+
+} // namespace polyscope

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -839,13 +839,12 @@ bool setParentGroupOfStructure(std::string typeName, std::string child, std::str
   // check if parent exists
   bool parentExists = state::groups.find(parent) != state::groups.end();
   if (!parentExists) {
-    polyscope::error("Attempted to set parent of curve network " + child + " to " + parent +
+    polyscope::error("Attempted to set parent of " + typeName + " " + child + " to " + parent +
                      ", but no group with that name exists");
     return false;
   }
 
   // Make sure a map for the type exists
-  // std::string typeName = "Curve Network";
   if (state::structures.find(typeName) == state::structures.end()) {
     state::structures[typeName] = std::map<std::string, Structure*>();
   }
@@ -854,8 +853,8 @@ bool setParentGroupOfStructure(std::string typeName, std::string child, std::str
   // check if child exists
   bool childExists = sMap.find(child) != sMap.end();
   if (!childExists) {
-    polyscope::error("Attempted to set parent of curve network " + child +
-                     ", but no curve network with that name exists");
+    polyscope::error("Attempted to set parent of " + typeName + " " + child + ", but no " + typeName +
+                     "with that name exists");
     return false;
   }
 

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -155,9 +155,7 @@ void checkInitialized() {
   }
 }
 
-bool isInitialized() {
-  return state::initialized;
-}
+bool isInitialized() { return state::initialized; }
 
 void pushContext(std::function<void()> callbackFunction, bool drawDefaultUI) {
 
@@ -218,10 +216,7 @@ void popContext() {
   contextStack.pop_back();
 }
 
-ImGuiContext* getCurrentContext()
-{
-  return contextStack.empty() ? nullptr : contextStack.back().context;
-}
+ImGuiContext* getCurrentContext() { return contextStack.empty() ? nullptr : contextStack.back().context; }
 
 void requestRedraw() { redrawNextFrame = true; }
 bool redrawRequested() { return redrawNextFrame; }
@@ -573,7 +568,7 @@ void buildStructureGui() {
 
   // only show groups if there are any
   if (state::groups.size() > 0) {
-    if(ImGui::CollapsingHeader("Groups", ImGuiTreeNodeFlags_DefaultOpen)) {
+    if (ImGui::CollapsingHeader("Groups", ImGuiTreeNodeFlags_DefaultOpen)) {
       for (auto x : state::groups) {
         if (x.second->isRootGroup()) {
           x.second->buildUI();
@@ -859,7 +854,8 @@ bool setParentGroupOfStructure(std::string typeName, std::string child, std::str
   // check if child exists
   bool childExists = sMap.find(child) != sMap.end();
   if (!childExists) {
-    polyscope::error("Attempted to set parent of curve network " + child + ", but no curve network with that name exists");
+    polyscope::error("Attempted to set parent of curve network " + child +
+                     ", but no curve network with that name exists");
     return false;
   }
 

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -566,6 +566,14 @@ void buildStructureGui() {
 
   ImGui::Begin("Structures", &showStructureWindow);
 
+  if(ImGui::CollapsingHeader("Groups", ImGuiTreeNodeFlags_DefaultOpen)) {
+    for (auto x : state::groups) {
+      if (x.second->isRootGroup()) {
+        x.second->buildUI();
+      }
+    }
+  }
+
   for (auto catMapEntry : state::structures) {
     std::string catName = catMapEntry.first;
 
@@ -590,14 +598,6 @@ void buildStructureGui() {
     }
 
     ImGui::PopID();
-  }
-
-  if(ImGui::CollapsingHeader("Groups")) {
-    for (auto x : state::groups) {
-      if (x.second->isRootGroup()) {
-        x.second->buildUI();
-      }
-    }
   }
 
   leftWindowsWidth = ImGui::GetWindowWidth();

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -944,6 +944,18 @@ bool hasStructure(std::string type, std::string name) {
   return sMap.find(name) != sMap.end();
 }
 
+void setGroupEnabled(std::string name, bool enabled) {
+  // Check if group exists
+  if (state::groups.find(name) == state::groups.end()) {
+    error("No group with name " + name + " registered");
+    return;
+  }
+
+  // Group exists, set it
+  state::groups[name]->setEnabled(enabled);
+  return;
+}
+
 void removeGroup(std::string name, bool errorIfAbsent) {
   // Check if group exists
   if (state::groups.find(name) == state::groups.end()) {

--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -566,10 +566,13 @@ void buildStructureGui() {
 
   ImGui::Begin("Structures", &showStructureWindow);
 
-  if(ImGui::CollapsingHeader("Groups", ImGuiTreeNodeFlags_DefaultOpen)) {
-    for (auto x : state::groups) {
-      if (x.second->isRootGroup()) {
-        x.second->buildUI();
+  // only show groups if there are any
+  if (state::groups.size() > 0) {
+    if(ImGui::CollapsingHeader("Groups", ImGuiTreeNodeFlags_DefaultOpen)) {
+      for (auto x : state::groups) {
+        if (x.second->isRootGroup()) {
+          x.second->buildUI();
+        }
       }
     }
   }
@@ -860,6 +863,10 @@ bool setParentGroupOfStructure(std::string typeName, std::string child, std::str
   return true;
 }
 
+bool setParentGroupOfStructure(Structure* child, std::string parent) {
+  return setParentGroupOfStructure(child->typeName(), child->name, parent);
+}
+
 bool registerStructure(Structure* s, bool replaceIfPresent) {
 
   // Make sure a map for the type exists
@@ -972,6 +979,13 @@ void removeGroup(std::string name, bool errorIfAbsent) {
   return;
 }
 
+void removeAllGroups() {
+  for (auto& g : state::groups) {
+    delete g.second;
+  }
+  state::groups.clear();
+}
+
 void removeStructure(std::string type, std::string name, bool errorIfAbsent) {
 
   // If there are no structures of that type it is an automatic fail
@@ -993,6 +1007,10 @@ void removeStructure(std::string type, std::string name, bool errorIfAbsent) {
 
   // Structure exists, remove it
   Structure* s = sMap[name];
+  // remove it from all existing groups
+  for (auto& g : state::groups) {
+    g.second->removeChildStructure(s);
+  }
   pick::resetSelectionIfStructure(s);
   sMap.erase(s->name);
   delete s;

--- a/src/state.cpp
+++ b/src/state.cpp
@@ -11,6 +11,7 @@ float lengthScale = 1.0;
 std::tuple<glm::vec3, glm::vec3> boundingBox =
     std::tuple<glm::vec3, glm::vec3>{glm::vec3{-1., -1., -1.}, glm::vec3{1., 1., 1.}};
 std::map<std::string, std::map<std::string, Structure*>> structures;
+std::map<std::string, Group*> groups;
 std::function<void()> userCallback = nullptr;
 bool doDefaultMouseInteraction = true;
 

--- a/test/src/basics_test.cpp
+++ b/test/src/basics_test.cpp
@@ -931,6 +931,213 @@ TEST_F(PolyscopeTest, VolumeMeshInspect) {
   polyscope::removeLastSceneSlicePlane();
 }
 
+// ============================================================
+// =============== Group tests
+// ============================================================
+
+TEST_F(PolyscopeTest, RegisterGroupTest) {
+  polyscope::registerGroup("test_group");
+  polyscope::show(3);
+
+  polyscope::removeAllGroups();
+}
+
+TEST_F(PolyscopeTest, AddStructuresToGroupTest) {
+  std::string cloudName = "test_point_cloud";
+  std::string curveName = "test_curve_network";
+  std::string meshName = "test_triangle_mesh";
+  // Add a point cloud structure
+  auto psCloud = registerPointCloud(cloudName);
+  // Add a curve network structure
+  auto psCurve = registerCurveNetwork(curveName);
+  // Add a triangle mesh structure
+  auto psMesh = registerTriangleMesh(meshName);
+  polyscope::registerGroup("test_group");
+  polyscope::setParentGroupOfStructure(psCloud, "test_group");
+  polyscope::setParentGroupOfStructure(psCurve, "test_group");
+  polyscope::setParentGroupOfStructure(psMesh, "test_group");
+  polyscope::show(3);
+
+  polyscope::removeAllGroups();
+  polyscope::removeAllStructures();
+}
+
+TEST_F(PolyscopeTest, AddGroupsToGroupTest) {
+  polyscope::registerGroup("test_group");
+  polyscope::registerGroup("child_test_group_1");
+  polyscope::registerGroup("child_test_group_2");
+  polyscope::setParentGroupOfGroup("child_test_group_1", "test_group");
+  polyscope::setParentGroupOfGroup("child_test_group_2", "test_group");
+  polyscope::show(3);
+
+  polyscope::removeAllGroups();
+}
+
+TEST_F(PolyscopeTest, AddStructuresAndGroupsToGroupTest) {
+  std::string cloudName = "test_point_cloud";
+  std::string curveName = "test_curve_network";
+  std::string meshName = "test_triangle_mesh";
+  auto psCloud1 = registerPointCloud(cloudName + "1");
+  auto psCloud2 = registerPointCloud(cloudName + "2");
+  auto psCloud3 = registerPointCloud(cloudName + "3");
+  auto psCurve1 = registerCurveNetwork(curveName + "1");
+  auto psCurve2 = registerCurveNetwork(curveName + "2");
+  auto psCurve3 = registerCurveNetwork(curveName + "3");
+  auto psMesh1 = registerTriangleMesh(meshName + "1");
+  auto psMesh2 = registerTriangleMesh(meshName + "2");
+  auto psMesh3 = registerTriangleMesh(meshName + "3");
+  polyscope::registerGroup("test_group");
+  polyscope::registerGroup("points_group");
+  polyscope::registerGroup("curves_group");
+  polyscope::registerGroup("meshes_group");
+  polyscope::setParentGroupOfStructure(psCloud1, "points_group");
+  polyscope::setParentGroupOfStructure(psCloud2, "points_group");
+  polyscope::setParentGroupOfStructure(psCloud3, "points_group");
+  polyscope::setParentGroupOfStructure(psCurve1, "curves_group");
+  polyscope::setParentGroupOfStructure(psCurve2, "curves_group");
+  polyscope::setParentGroupOfStructure(psCurve3, "curves_group");
+  polyscope::setParentGroupOfStructure(psMesh1, "meshes_group");
+  polyscope::setParentGroupOfStructure(psMesh2, "meshes_group");
+  polyscope::setParentGroupOfStructure(psMesh3, "meshes_group");
+  polyscope::setParentGroupOfGroup("points_group", "test_group");
+  polyscope::setParentGroupOfGroup("curves_group", "test_group");
+  polyscope::setParentGroupOfGroup("meshes_group", "test_group");
+  polyscope::show(3);
+
+  polyscope::removeAllGroups();
+  polyscope::removeAllStructures();
+}
+
+TEST_F(PolyscopeTest, RemoveStructureButLeaveItInGroupTest) {
+  std::string cloudName = "test_point_cloud";
+  std::string curveName = "test_curve_network";
+  std::string meshName = "test_triangle_mesh";
+  // Add a point cloud structure
+  auto psCloud = registerPointCloud(cloudName);
+  // Add a curve network structure
+  auto psCurve = registerCurveNetwork(curveName);
+  // Add a triangle mesh structure
+  auto psMesh = registerTriangleMesh(meshName);
+  polyscope::registerGroup("test_group");
+  polyscope::setParentGroupOfStructure(psCloud, "test_group");
+  polyscope::setParentGroupOfStructure(psCurve, "test_group");
+  polyscope::setParentGroupOfStructure(psMesh, "test_group");
+  polyscope::removeStructure(cloudName);
+  polyscope::show(3);
+
+  polyscope::removeAllGroups();
+  polyscope::removeAllStructures();
+}
+
+TEST_F(PolyscopeTest, TestDisableGroup) {
+  std::string cloudName = "test_point_cloud";
+  std::string curveName = "test_curve_network";
+  std::string meshName = "test_triangle_mesh";
+  // Add a point cloud structure
+  auto psCloud = registerPointCloud(cloudName);
+  // Add a curve network structure
+  auto psCurve = registerCurveNetwork(curveName);
+  // Add a triangle mesh structure
+  auto psMesh = registerTriangleMesh(meshName);
+  polyscope::registerGroup("test_group");
+  polyscope::setParentGroupOfStructure(psCloud, "test_group");
+  polyscope::setParentGroupOfStructure(psCurve, "test_group");
+  polyscope::setParentGroupOfStructure(psMesh, "test_group");
+  polyscope::setGroupEnabled("test_group", false);
+  polyscope::show(3);
+
+  polyscope::removeAllGroups();
+  polyscope::removeAllStructures();
+}
+
+TEST_F(PolyscopeTest, TestDisableSubgroup) {
+  std::string cloudName = "test_point_cloud";
+  std::string curveName = "test_curve_network";
+  std::string meshName = "test_triangle_mesh";
+  auto psCloud1 = registerPointCloud(cloudName + "1");
+  auto psCloud2 = registerPointCloud(cloudName + "2");
+  auto psCloud3 = registerPointCloud(cloudName + "3");
+  auto psCurve1 = registerCurveNetwork(curveName + "1");
+  auto psCurve2 = registerCurveNetwork(curveName + "2");
+  auto psCurve3 = registerCurveNetwork(curveName + "3");
+  auto psMesh1 = registerTriangleMesh(meshName + "1");
+  auto psMesh2 = registerTriangleMesh(meshName + "2");
+  auto psMesh3 = registerTriangleMesh(meshName + "3");
+  polyscope::registerGroup("test_group");
+  polyscope::registerGroup("points_group");
+  polyscope::registerGroup("curves_group");
+  polyscope::registerGroup("meshes_group");
+  polyscope::setParentGroupOfStructure(psCloud1, "points_group");
+  polyscope::setParentGroupOfStructure(psCloud2, "points_group");
+  polyscope::setParentGroupOfStructure(psCloud3, "points_group");
+  polyscope::setParentGroupOfStructure(psCurve1, "curves_group");
+  polyscope::setParentGroupOfStructure(psCurve2, "curves_group");
+  polyscope::setParentGroupOfStructure(psCurve3, "curves_group");
+  polyscope::setParentGroupOfStructure(psMesh1, "meshes_group");
+  polyscope::setParentGroupOfStructure(psMesh2, "meshes_group");
+  polyscope::setParentGroupOfStructure(psMesh3, "meshes_group");
+  polyscope::setParentGroupOfGroup("points_group", "test_group");
+  polyscope::setParentGroupOfGroup("curves_group", "test_group");
+  polyscope::setParentGroupOfGroup("meshes_group", "test_group");
+  polyscope::setGroupEnabled("meshes_group", false);
+  polyscope::show(3);
+
+  polyscope::removeAllGroups();
+  polyscope::removeAllStructures();
+}
+
+TEST_F(PolyscopeTest, TestRemoveSubgroup) {
+  // both remaining groups should remain and be root groups
+  auto psCurve1 = registerCurveNetwork("test_curve");
+  polyscope::registerGroup("test_group");
+  polyscope::registerGroup("test_child_group");
+  polyscope::registerGroup("test_grandchild_group");
+  polyscope::setParentGroupOfGroup("test_child_group", "test_group");
+  polyscope::setParentGroupOfGroup("test_grandchild_group", "test_child_group");
+  polyscope::setParentGroupOfStructure(psCurve1, "test_grandchild_group");
+  polyscope::removeGroup("test_child_group");
+  polyscope::show(3);
+
+  polyscope::removeAllGroups();
+  polyscope::removeAllStructures();
+}
+
+TEST_F(PolyscopeTest, TestRepeatAddAndRemoveGroup) {
+  auto psCurve1 = registerCurveNetwork("test_curve");
+  polyscope::registerGroup("test_group");
+  for (int i = 0; i < 10; i++) {
+    polyscope::registerGroup("test_child_group");
+    polyscope::setParentGroupOfGroup("test_child_group", "test_group");
+    polyscope::setParentGroupOfStructure(psCurve1, "test_child_group");
+    if (i != 9) {
+    polyscope::removeGroup("test_child_group");
+    }
+  }
+  polyscope::show(3);
+
+  polyscope::removeAllGroups();
+  polyscope::removeAllStructures();
+}
+
+TEST_F(PolyscopeTest, TestDeletedGroupReferenceError) {
+  // don't run this because we can't catch UI errors
+  if (true) return;
+  polyscope::registerGroup("test_group");
+  polyscope::registerGroup("test_child_group");
+  polyscope::removeGroup("test_group");
+  // this should throw an error (but not segfault)
+  polyscope::setParentGroupOfGroup("test_child_group", "test_group");
+}
+
+TEST_F(PolyscopeTest, TestGroupCycleError) {
+  // don't run this because we can't catch UI errors
+  if (true) return;
+  polyscope::registerGroup("test_group");
+  polyscope::registerGroup("test_child_group");
+  polyscope::setParentGroupOfGroup("test_child_group", "test_group");
+  // this should throw an error (but not segfault)
+  polyscope::setParentGroupOfGroup("test_group", "test_child_group");
+}
 
 // ============================================================
 // =============== Ground plane tests

--- a/test/src/basics_test.cpp
+++ b/test/src/basics_test.cpp
@@ -1119,6 +1119,56 @@ TEST_F(PolyscopeTest, TestRepeatAddAndRemoveGroup) {
   polyscope::removeAllStructures();
 }
 
+TEST_F(PolyscopeTest, TestDocsExample) {
+  // make a point cloud
+  std::vector<glm::vec3> points;
+  for (size_t i = 0; i < 3000; i++) {
+    points.push_back(
+        glm::vec3{polyscope::randomUnit() - .5,
+                  polyscope::randomUnit() - .5,
+                  polyscope::randomUnit() - .5});
+  }
+  polyscope::PointCloud* psCloud = polyscope::registerPointCloud("my cloud", points);
+  psCloud->setPointRadius(0.02);
+  psCloud->setPointRenderMode(polyscope::PointRenderMode::Quad);
+
+  // make a curve network
+  std::vector<glm::vec3> nodes;
+  std::vector<std::array<size_t, 2>> edges;
+  nodes = {
+  {1, 0, 0},
+  {0, 1, 0},
+  {0, 0, 1},
+  {0, 0, 0},
+  };
+  edges = {
+  {1, 3},
+  {3, 0},
+  {1, 0},
+  {0, 2}
+  };
+  polyscope::CurveNetwork* psCurve = polyscope::registerCurveNetwork("my network", nodes, edges);
+
+  // group them together
+  std::string groupName = "my group";
+  polyscope::registerGroup(groupName);
+  polyscope::setParentGroupOfStructure(psCloud, groupName);
+  polyscope::setParentGroupOfStructure(psCurve, groupName);
+
+  // put that group in another group
+  std::string parentGroupName = "my parent group";
+  std::string emptyGroupName = "my empty group";
+  polyscope::registerGroup(parentGroupName);
+  polyscope::registerGroup(emptyGroupName);
+  polyscope::setParentGroupOfGroup(groupName, parentGroupName);
+  polyscope::setParentGroupOfGroup(emptyGroupName, parentGroupName);
+
+  polyscope::show(3);
+
+  polyscope::removeAllGroups();
+  polyscope::removeAllStructures();
+}
+
 TEST_F(PolyscopeTest, TestDeletedGroupReferenceError) {
   // don't run this because we can't catch UI errors
   if (true) return;


### PR DESCRIPTION
Hi, I'm a huge fan of Polyscope! I use it all the time for debugging / visualizing.

One feature I've been sorely needing is a way to group structures into hierarchies which can then be quickly enabled / disabled (as can be done in e.g. Unity, RHINO, etc). After reading the contribution guide, I went ahead and made a quick prototype implementation (and matching python bindings, tested with a really basic test script)

**This is a Draft of a PR**: before I put in more polishing work to ensure this fits the guidelines (unit tests, documentation update, etc..), I wanted to quickly check whether this is at all a feature others would find useful, and more importantly whether you agree that it belongs in polyscope.

Quick overview of what this does:

- Groups can have a single parent (another group), but several children (both groups and structures) - implemented in groups.cpp and groups.h
- Groups show up in the UI, in their own node under Structures
- Groups can be enabled / disabled by clicking on the checkbox, which enables / disables all their child structures and groups.
- For a quick functionality check, I've updated the python bindings (https://github.com/danieldugas/polyscope-py/tree/feature/structure_groups) and created a temporary build-and-test script.

![Screenshot from 2023-02-20 11-37-04](https://user-images.githubusercontent.com/1926730/220118649-065af3f1-77fa-432a-a920-5a0cbc3b3b8a.png)


If you do greenlight this, there's still a few things which need to be done (by me - although if any volunteers show up, help is always appreciated):
- Agreeing on the final API
- Documentation (both C++ and python)
- Unit tests
- Cleanup (test.py, run_build_and_test.sh)
- Also make and merge a PR on the polyscope-py repo
- Other required changes from your side