### PR TITLE
updating CMakeLists for better robustness, when a "glad" and "glfw" are also used by other libraries

### DIFF
--- a/deps/glad/src/CMakeLists.txt
+++ b/deps/glad/src/CMakeLists.txt
@@ -1,10 +1,12 @@
 cmake_minimum_required(VERSION 3.1)
 
 # Create a library for the viewer code
-add_library(
-    glad
-    glad.c
-    )
+if (NOT TARGET glad)
+  add_library(
+      glad
+      glad.c
+      )
+endif()
 
 # Are we building a shared library?
 get_target_property(library_type glad TYPE)


### PR DESCRIPTION
Hi Nick,

Thanks for the great work. These updates are fixing the situation when someone want to compile two visualizers at the same project both using "glad" and "glfw", (e.g., both libigl viewer and polyscope). It does not happen everyday, but I think better robustness is a good idea. The fixes are necessary when using this template (https://github.com/libigl/libigl-example-project) together with polyscope.

Thanks,
Crane