### PR TITLE
Fix attribute name in volume_grid_scalar_quantity

### DIFF
--- a/src/volume_grid_scalar_quantity.cpp
+++ b/src/volume_grid_scalar_quantity.cpp
@@ -153,13 +153,15 @@ void VolumeGridScalarQuantity::createIsosurfaceProgram() {
   isosurfaceProgram = render::engine->requestShader("INDEXED_MESH", parent.addStructureRules({"SHADE_BASECOLOR"}));
 
   // Populate the program buffers with the extracted mesh
-  isosurfaceProgram->setAttribute("a_position", mesh.vertices);
-  isosurfaceProgram->setAttribute("a_normal", mesh.normals);
+  isosurfaceProgram->setAttribute("a_vertexPositions", mesh.vertices);
+  isosurfaceProgram->setAttribute("a_vertexNormals", mesh.normals);
   isosurfaceProgram->setIndex(mesh.indices);
 
   // Fill out some barycoords
   // TODO: extract barycoords from surface mesh shader to rule so we don't have to add a useless quantity
-  isosurfaceProgram->setAttribute("a_barycoord", mesh.normals); // unused
+  if (isosurfaceProgram->hasAttribute("a_barycoord")) {
+    isosurfaceProgram->setAttribute("a_barycoord", mesh.normals); // unused
+  }
 
   render::engine->setMaterial(*isosurfaceProgram, parent.getMaterial());
 }


### PR DESCRIPTION
The concerned code does not seem to be in the public API yet, but it already displays something cool and relevant with the proposed fix.

![screenshot_000000](https://github.com/nmwsharp/polyscope/assets/9134757/93f4d8a0-634a-4e28-bac7-f3d98d4ef948)
![screenshot_000004](https://github.com/nmwsharp/polyscope/assets/9134757/007a9816-07fa-4948-817e-2ef7f93059f2)
