### PR TITLE
Make Widget destructor virtual

### DIFF
--- a/include/polyscope/widget.h
+++ b/include/polyscope/widget.h
@@ -10,7 +10,7 @@ class Widget {
 
 public:
   Widget();
-  ~Widget();
+  virtual ~Widget();
 
   // No copy constructor/assignment
   Widget(const Widget&) = delete;


### PR DESCRIPTION
[Issue](https://github.com/nmwsharp/polyscope/issues/221)
Makes the base class(Widget) destructor virtual so the derived class destructors are also called.