### PR TITLE
Show texture map using parameterization

### DIFF
--- a/include/polyscope/parameterization_quantity.h
+++ b/include/polyscope/parameterization_quantity.h
@@ -32,8 +32,9 @@ public:
   // Wrapper around the actual buffer of scalar data stored in the class.
   // Interaction with the data (updating it on CPU or GPU side, accessing it, etc) happens through this wrapper.
   render::ManagedBuffer<glm::vec2> coords;
-
   const ParamCoordsType coordsType;
+
+  std::shared_ptr<render::TextureBuffer> texture;
 
   // === Get/set visualization parameters
 
@@ -63,6 +64,10 @@ public:
   QuantityT* setAltDarkness(double newVal);
   double getAltDarkness();
 
+  // Texture
+  QuantityT* setTexture(unsigned int sizeX, unsigned int sizeY, const std::vector<unsigned char>& textureData,
+                        TextureFormat format = TextureFormat::RGB32F);
+
   // === Helpers for rendering
   std::vector<std::string> addParameterizationRules(std::vector<std::string> rules);
   void fillParameterizationBuffers(render::ShaderProgram& p);
@@ -71,6 +76,7 @@ public:
 protected:
   // Raw storage for the data. You should only interact with this via the managed buffer above
   std::vector<glm::vec2> coordsData;
+  std::vector<unsigned char> textureData;
 
   // === Visualization parameters
 

--- a/include/polyscope/parameterization_quantity.h
+++ b/include/polyscope/parameterization_quantity.h
@@ -66,7 +66,7 @@ public:
 
   // Texture
   QuantityT* setTexture(unsigned int sizeX, unsigned int sizeY, const std::vector<unsigned char>& textureData,
-                        TextureFormat format = TextureFormat::RGB32F);
+                        TextureFormat format = TextureFormat::RGB32F, FilterMode filterMode = FilterMode::Linear);
 
   // === Helpers for rendering
   std::vector<std::string> addParameterizationRules(std::vector<std::string> rules);

--- a/include/polyscope/parameterization_quantity.ipp
+++ b/include/polyscope/parameterization_quantity.ipp
@@ -174,7 +174,7 @@ void ParameterizationQuantity<QuantityT>::fillParameterizationBuffers(render::Sh
 template <typename QuantityT>
 void ParameterizationQuantity<QuantityT>::setParameterizationUniforms(render::ShaderProgram& p) {
 
-  // Interpretatin of modulo parameter depends on data type
+  // Interpretation of modulo parameter depends on data type
   switch (coordsType) {
   case ParamCoordsType::UNIT:
     p.setUniform("u_modLen", getCheckerSize());
@@ -297,6 +297,7 @@ QuantityT* ParameterizationQuantity<QuantityT>::setTexture(unsigned int sizeX, u
                                                            TextureFormat format) {
   textureData = textureData_;
   texture = render::engine->generateTextureBuffer(format, sizeX, sizeY, textureData.data());
+  texture->setFilterMode(FilterMode::Linear);
   return &quantity;
 }
 

--- a/include/polyscope/parameterization_quantity.ipp
+++ b/include/polyscope/parameterization_quantity.ipp
@@ -298,6 +298,7 @@ QuantityT* ParameterizationQuantity<QuantityT>::setTexture(unsigned int sizeX, u
   textureData = textureData_;
   texture = render::engine->generateTextureBuffer(format, sizeX, sizeY, textureData.data());
   texture->setFilterMode(FilterMode::Linear);
+  // texture->setFilterMode(FilterMode::Nearest);
   return &quantity;
 }
 

--- a/include/polyscope/parameterization_quantity.ipp
+++ b/include/polyscope/parameterization_quantity.ipp
@@ -294,11 +294,10 @@ double ParameterizationQuantity<QuantityT>::getAltDarkness() {
 template <typename QuantityT>
 QuantityT* ParameterizationQuantity<QuantityT>::setTexture(unsigned int sizeX, unsigned int sizeY,
                                                            const std::vector<unsigned char>& textureData_,
-                                                           TextureFormat format) {
+                                                           TextureFormat format, FilterMode filterMode) {
   textureData = textureData_;
   texture = render::engine->generateTextureBuffer(format, sizeX, sizeY, textureData.data());
-  texture->setFilterMode(FilterMode::Linear);
-  // texture->setFilterMode(FilterMode::Nearest);
+  texture->setFilterMode(filterMode);
   return &quantity;
 }
 

--- a/include/polyscope/render/opengl/shaders/rules.h
+++ b/include/polyscope/render/opengl/shaders/rules.h
@@ -27,6 +27,7 @@ extern const ShaderReplacementRule SHADE_CHECKER_VALUE2;        // generate a tw
 extern const ShaderReplacementRule SHADEVALUE_MAG_VALUE2;       // generate a shadeValue from the magnitude of shadeValue2
 extern const ShaderReplacementRule ISOLINE_STRIPE_VALUECOLOR;   // modulate albedoColor based on shadeValue
 extern const ShaderReplacementRule CHECKER_VALUE2COLOR;         // modulate albedoColor based on shadeValue2
+  extern const ShaderReplacementRule SHADE_TEXTURE_VALUE2;      // use image texture
 
 // Positions, culling, etc
 extern const ShaderReplacementRule GENERATE_VIEW_POS;          // computes viewPos, position in viewspace for fragment

--- a/include/polyscope/surface_mesh.ipp
+++ b/include/polyscope/surface_mesh.ipp
@@ -37,6 +37,13 @@ SurfaceMesh* registerSurfaceMesh2D(std::string name, const V& vertexPositions, c
 
   return registerSurfaceMesh(name, positions3D, faceIndices);
 }
+template <class V, class F, class P>
+SurfaceMesh* registerSurfaceMesh(std::string name, const V& vertexPositions, const F& faceIndices,
+                                 const std::array<std::pair<P, size_t>, 5>& perms) {
+  SurfaceMesh* s = registerSurfaceMesh(name, vertexPositions, faceIndices);
+  s->setAllPermutations(perms);
+  return s;
+}
 
 template <class V>
 void SurfaceMesh::updateVertexPositions(const V& newPositions) {

--- a/include/polyscope/surface_mesh.ipp
+++ b/include/polyscope/surface_mesh.ipp
@@ -37,13 +37,6 @@ SurfaceMesh* registerSurfaceMesh2D(std::string name, const V& vertexPositions, c
 
   return registerSurfaceMesh(name, positions3D, faceIndices);
 }
-template <class V, class F, class P>
-SurfaceMesh* registerSurfaceMesh(std::string name, const V& vertexPositions, const F& faceIndices,
-                                 const std::array<std::pair<P, size_t>, 5>& perms) {
-  SurfaceMesh* s = registerSurfaceMesh(name, vertexPositions, faceIndices);
-  s->setAllPermutations(perms);
-  return s;
-}
 
 template <class V>
 void SurfaceMesh::updateVertexPositions(const V& newPositions) {
@@ -182,7 +175,7 @@ template <class T>
 void SurfaceMesh::setAllPermutations(const std::array<std::pair<T, size_t>, 5>& perms) {
   // (kept for backward compatbility only)
   // forward to the 3-arg version, ignoring the unused ones
-  setAllPermutations(std::array<std::pair<T, size_t>, 3>{perms[2], perms[3], perms[4]});
+  setAllPermutations(std::array<std::pair<T, size_t>, 2>{perms[2], perms[3], perms[4]});
 }
 
 template <class T>

--- a/include/polyscope/surface_mesh.ipp
+++ b/include/polyscope/surface_mesh.ipp
@@ -182,7 +182,7 @@ template <class T>
 void SurfaceMesh::setAllPermutations(const std::array<std::pair<T, size_t>, 5>& perms) {
   // (kept for backward compatbility only)
   // forward to the 3-arg version, ignoring the unused ones
-  setAllPermutations(std::array<std::pair<T, size_t>, 2>{perms[2], perms[3], perms[4]});
+  setAllPermutations(std::array<std::pair<T, size_t>, 3>{perms[2], perms[3], perms[4]});
 }
 
 template <class T>

--- a/include/polyscope/types.h
+++ b/include/polyscope/types.h
@@ -24,8 +24,8 @@ enum class VolumeCellType { TET = 0, HEX };
 enum class ImplicitRenderMode { SphereMarch, FixedStep };
 enum class ImageOrigin { LowerLeft, UpperLeft };
 
-enum class ParamCoordsType { UNIT = 0, WORLD };                         // UNIT -> [0,1], WORLD -> length-valued
-enum class ParamVizStyle { CHECKER = 0, GRID, LOCAL_CHECK, LOCAL_RAD }; // TODO add "UV" with test UV map
+enum class ParamCoordsType { UNIT = 0, WORLD }; // UNIT -> [0,1], WORLD -> length-valued
+enum class ParamVizStyle { CHECKER = 0, GRID, LOCAL_CHECK, LOCAL_RAD, TEXTURE }; // TODO add "UV" with test UV map
 
 // What is the meaningful range of these values?
 // Used to set meaningful colormaps

--- a/src/render/mock_opengl/mock_gl_engine.cpp
+++ b/src/render/mock_opengl/mock_gl_engine.cpp
@@ -1929,6 +1929,7 @@ void MockGLEngine::populateDefaultShadersAndRules() {
   registerShaderRule("SHADEVALUE_MAG_VALUE2", SHADEVALUE_MAG_VALUE2);
   registerShaderRule("ISOLINE_STRIPE_VALUECOLOR", ISOLINE_STRIPE_VALUECOLOR);
   registerShaderRule("CHECKER_VALUE2COLOR", CHECKER_VALUE2COLOR);
+  registerShaderRule("SHADE_TEXTURE_VALUE2", SHADE_TEXTURE_VALUE2);
  
   // Texture and image things
   registerShaderRule("TEXTURE_ORIGIN_UPPERLEFT", TEXTURE_ORIGIN_UPPERLEFT);

--- a/src/render/opengl/gl_engine.cpp
+++ b/src/render/opengl/gl_engine.cpp
@@ -1143,7 +1143,16 @@ void GLCompiledProgram::compileGLProgram(const std::vector<ShaderStageSpecificat
       checkGLError();
     } catch (...) {
       std::cout << "GLError() after shader compilation! Program text:" << std::endl;
-      std::cout << s.src.c_str() << std::endl;
+      // std::cout << s.src.c_str() << std::endl;
+
+      // process shader line-by-line to print line numbers:
+      std::stringstream ss(s.src);
+      std::string line;
+      size_t lineNo = 0;
+      while (std::getline(ss, line, '\n')) {
+        std::cout << std::setw(4) << lineNo << ": " << line << std::endl;
+        lineNo++;
+      }
       throw;
     }
 
@@ -2707,6 +2716,7 @@ void GLEngine::populateDefaultShadersAndRules() {
   registerShaderRule("SHADEVALUE_MAG_VALUE2", SHADEVALUE_MAG_VALUE2);
   registerShaderRule("ISOLINE_STRIPE_VALUECOLOR", ISOLINE_STRIPE_VALUECOLOR);
   registerShaderRule("CHECKER_VALUE2COLOR", CHECKER_VALUE2COLOR);
+  registerShaderRule("SHADE_TEXTURE_VALUE2", SHADE_TEXTURE_VALUE2);
  
   // Texture and image things
   registerShaderRule("TEXTURE_ORIGIN_UPPERLEFT", TEXTURE_ORIGIN_UPPERLEFT);

--- a/src/render/opengl/shaders/rules.cpp
+++ b/src/render/opengl/shaders/rules.cpp
@@ -272,6 +272,26 @@ const ShaderReplacementRule CHECKER_VALUE2COLOR (
     /* textures */ {}
 );
 
+const ShaderReplacementRule SHADE_TEXTURE_VALUE2 (
+    /* rule name */ "CHECKER_TEXTURE_VALUE2",
+    { /* replacement sources */
+      {"FRAG_DECLARATIONS", R"(
+          uniform float u_modLen;
+          uniform sampler2D t_tex;
+        )"},
+      {"GENERATE_SHADE_COLOR", R"(
+        vec3 albedoColor = texture(t_tex, shadeValue2 * u_modLen).rgb;
+      )"}
+    },
+    /* uniforms */ {
+       {"u_modLen", RenderDataType::Float},
+    },
+    /* attributes */ {},
+    /* textures */ {
+       {"t_tex", 2},
+    }
+);
+
 
 const ShaderReplacementRule GENERATE_VIEW_POS (
     /* rule name */ "GENERATE_VIEW_POS",


### PR DESCRIPTION
This adds a new parameterization visualization style which uses polyscope's existing texture mapping utilities to texture surface meshes using to the given parameterization.

(There's also a small modification to `gl_engine.cpp` to provide line numbers for shaders which fail to compile, which makes it easier to debug them)