### PR TITLE
Fix template initializer for setAllPermutations()

### DIFF
--- a/include/polyscope/surface_mesh.ipp
+++ b/include/polyscope/surface_mesh.ipp
@@ -175,7 +175,7 @@ template <class T>
 void SurfaceMesh::setAllPermutations(const std::array<std::pair<T, size_t>, 5>& perms) {
   // (kept for backward compatbility only)
   // forward to the 3-arg version, ignoring the unused ones
-  setAllPermutations(std::array<std::pair<T, size_t>, 2>{perms[2], perms[3], perms[4]});
+  setAllPermutations(std::array<std::pair<T, size_t>, 3>{perms[2], perms[3], perms[4]});
 }
 
 template <class T>


### PR DESCRIPTION
There was just a minor typo in `setAllPermuations()` in `include/surface_mesh.ipp`. One of the template arguments was meant to be 3 instead of 2.