### PR TITLE
Make FPS camera navigation speed independent from frame rate

### DIFF
--- a/src/view.cpp
+++ b/src/view.cpp
@@ -289,7 +289,7 @@ void processKeyboardNavigation(ImGuiIO& io) {
       hasMovement = true;
     }
 
-    float movementScale = state::lengthScale * 0.02 * moveScale;
+    float movementScale = state::lengthScale * ImGui::GetIO().DeltaTime * moveScale;
     glm::mat4x4 camSpaceT = glm::translate(glm::mat4x4(1.0), movementScale * delta);
     viewMat = camSpaceT * viewMat;
   }


### PR DESCRIPTION
Use time elapsed since last frame to make navigation speed consistent at different frame rates when using the first-person camera navigation style.

Fixes:
- Camera barely moving when using keyboard controls for first-person camera navigation style at low fps.
- Camera moving at light speed when using keyboard controls for first-person camera navigation style at high fps.