### PR TITLE
Fix custom indexing for edge picks

### DIFF
--- a/include/polyscope/pick.ipp
+++ b/include/polyscope/pick.ipp
@@ -24,11 +24,11 @@ inline glm::vec3 indToVec(size_t globalInd) {
   globalInd = globalInd >> bitsForPickPacking;
   uint64_t high = globalInd;
 
-  return 2500.f * glm::vec3{static_cast<double>(low) / factorF, static_cast<double>(med) / factorF,
-                            static_cast<double>(high) / factorF};
+  return glm::vec3{static_cast<double>(low) / factorF, static_cast<double>(med) / factorF,
+                   static_cast<double>(high) / factorF};
 }
 inline uint64_t vecToInd(glm::vec3 vec) {
-  vec /= 2500.f;
+
   uint64_t factor = 1 << bitsForPickPacking;
   double factorF = factor;
 

--- a/include/polyscope/pick.ipp
+++ b/include/polyscope/pick.ipp
@@ -24,11 +24,11 @@ inline glm::vec3 indToVec(size_t globalInd) {
   globalInd = globalInd >> bitsForPickPacking;
   uint64_t high = globalInd;
 
-  return glm::vec3{static_cast<double>(low) / factorF, static_cast<double>(med) / factorF,
-                   static_cast<double>(high) / factorF};
+  return 2500.f * glm::vec3{static_cast<double>(low) / factorF, static_cast<double>(med) / factorF,
+                            static_cast<double>(high) / factorF};
 }
 inline uint64_t vecToInd(glm::vec3 vec) {
-
+  vec /= 2500.f;
   uint64_t factor = 1 << bitsForPickPacking;
   double factorF = factor;
 

--- a/include/polyscope/surface_mesh.h
+++ b/include/polyscope/surface_mesh.h
@@ -219,8 +219,8 @@ public:
   size_t nEdges();                  // NOTE causes population of nEdgesCount
 
   size_t nCornersCount = 0; // = nHalfedges = sum face degree
-  size_t nCorners() const { return nCornersCount; }
-  size_t nHalfedges() const { return nCornersCount; }
+  size_t nCorners() const { return cornerDataSize == INVALID_IND ? nCornersCount : cornerDataSize; }
+  size_t nHalfedges() const { return halfedgeDataSize == INVALID_IND ? nCornersCount : halfedgeDataSize; }
 
   // = Mesh helpers
   void nestedFacesToFlat(const std::vector<std::vector<size_t>>& nestedInds);
@@ -333,7 +333,6 @@ private:
   bool edgesHaveBeenUsed = false;
   std::vector<uint32_t>
       halfedgeEdgeCorrespondence; // ugly hack used to save a pick buffer attr, filled out lazily w/ edge indices
-
 
   // Visualization settings
   PersistentValue<glm::vec3> surfaceColor;

--- a/include/polyscope/surface_mesh.ipp
+++ b/include/polyscope/surface_mesh.ipp
@@ -136,6 +136,8 @@ void SurfaceMesh::setEdgePermutation(const T& perm, size_t expectedSize) {
 
   // now that we have edge indexing, enable edge-related stuff
   markEdgesAsUsed();
+
+  triangleAllEdgeInds.recomputeIfPopulated();
 }
 
 template <class T>
@@ -163,6 +165,8 @@ void SurfaceMesh::setHalfedgePermutation(const T& perm, size_t expectedSize) {
   }
 
   markHalfedgesAsUsed();
+  triangleAllEdgeInds.recomputeIfPopulated();
+  triangleAllHalfedgeInds.recomputeIfPopulated();
 }
 
 template <class T>
@@ -190,6 +194,8 @@ void SurfaceMesh::setCornerPermutation(const T& perm, size_t expectedSize) {
   }
 
   markCornersAsUsed();
+  triangleAllEdgeInds.recomputeIfPopulated();
+  triangleAllCornerInds.recomputeIfPopulated();
 }
 
 

--- a/src/surface_mesh.cpp
+++ b/src/surface_mesh.cpp
@@ -1134,9 +1134,6 @@ void SurfaceMesh::buildFaceInfoGui(size_t fInd) {
 
 void SurfaceMesh::buildEdgeInfoGui(size_t eInd) {
   size_t displayInd = eInd;
-  if (edgePerm.size() > 0) {
-    // displayInd = edgePerm[eInd];
-  }
   ImGui::TextUnformatted(("Edge #" + std::to_string(displayInd)).c_str());
 
   ImGui::Spacing();
@@ -1157,9 +1154,6 @@ void SurfaceMesh::buildEdgeInfoGui(size_t eInd) {
 
 void SurfaceMesh::buildHalfedgeInfoGui(size_t heInd) {
   size_t displayInd = heInd;
-  if (halfedgePerm.size() > 0) {
-    // displayInd = halfedgePerm[heInd];
-  }
   ImGui::TextUnformatted(("Halfedge #" + std::to_string(displayInd)).c_str());
 
   ImGui::Spacing();

--- a/src/surface_mesh.cpp
+++ b/src/surface_mesh.cpp
@@ -195,6 +195,8 @@ void SurfaceMesh::computeTriangleAllEdgeInds() {
   triangleAllEdgeInds.data.resize(3 * 3 * nFacesTriangulation());
   halfedgeEdgeCorrespondence.resize(nHalfedges());
 
+  bool haveCustomHalfedgeIndex = !halfedgePerm.empty();
+
   // used to loop over edges
   std::unordered_map<std::pair<size_t, size_t>, size_t, polyscope::hash_combine::hash<std::pair<size_t, size_t>>>
       seenEdgeInds;
@@ -238,7 +240,10 @@ void SurfaceMesh::computeTriangleAllEdgeInds() {
         thisEdgeInd = seenEdgeInds[key];
       }
 
-      halfedgeEdgeCorrespondence[start + j] = thisEdgeInd;
+      size_t he = start + j;
+      if (haveCustomHalfedgeIndex) he = halfedgePerm[he];
+
+      halfedgeEdgeCorrespondence[he] = thisEdgeInd;
       thisTriInds[j] = thisEdgeInd;
     }
 
@@ -1130,7 +1135,7 @@ void SurfaceMesh::buildFaceInfoGui(size_t fInd) {
 void SurfaceMesh::buildEdgeInfoGui(size_t eInd) {
   size_t displayInd = eInd;
   if (edgePerm.size() > 0) {
-    displayInd = edgePerm[eInd];
+    // displayInd = edgePerm[eInd];
   }
   ImGui::TextUnformatted(("Edge #" + std::to_string(displayInd)).c_str());
 
@@ -1153,7 +1158,7 @@ void SurfaceMesh::buildEdgeInfoGui(size_t eInd) {
 void SurfaceMesh::buildHalfedgeInfoGui(size_t heInd) {
   size_t displayInd = heInd;
   if (halfedgePerm.size() > 0) {
-    displayInd = halfedgePerm[heInd];
+    // displayInd = halfedgePerm[heInd];
   }
   ImGui::TextUnformatted(("Halfedge #" + std::to_string(displayInd)).c_str());
 


### PR DESCRIPTION
Update picking logic to use custom indices when picking edges and halfedges.

I'm not totally sure if I got all of the `recomputeIfPopulated();` calls correct in `surface_mesh.ipp`: this code works for my use case, but it's possible that there are more arrays that should really be recomputed when the edge, halfedge, or corner permutations are set. Also, now the code calls `triangleAllEdgeInds.recomputeIfPopulated();` three times if the permutations are all set at once via `SurfaceMesh::setAllPermutations` is called.