### PR TITLE
use `std::vector::data()` when setting GL data

### DIFF
--- a/src/render/opengl/gl_engine.cpp
+++ b/src/render/opengl/gl_engine.cpp
@@ -264,7 +264,7 @@ void GLAttributeBuffer::setData_helper(const std::vector<T>& data) {
 
   // do the actual copy
   dataSize = data.size();
-  glBufferSubData(getTarget(), 0, dataSize * sizeof(T), &data[0]);
+  glBufferSubData(getTarget(), 0, dataSize * sizeof(T), data.data());
 
   checkGLError();
 }


### PR DESCRIPTION
MSVC in Debug will throw "vector subscript out of range" error when calling `std::vector::operator[]` on empty vector. This will fail unit tests. Instead use `std::vector::data()` to retrieve data pointer.