### PR TITLE
Warn color range clamping

### DIFF
--- a/include/polyscope/utilities.h
+++ b/include/polyscope/utilities.h
@@ -103,6 +103,9 @@ inline std::string to_string(const glm::vec3& v) {
 }
 inline std::string to_string_short(const glm::vec3& v) { return str_printf("<%1.3f, %1.3f, %1.3f>", v[0], v[1], v[2]); }
 
+// Warn when provided color ranges are not [0, 1], so they will be clamped in shader
+void checkColorRanges(const std::vector<glm::vec3>& colors);
+
 // === Index management
 const size_t INVALID_IND = std::numeric_limits<size_t>::max();
 const uint32_t INVALID_IND_32 = std::numeric_limits<uint32_t>::max();

--- a/src/curve_network.cpp
+++ b/src/curve_network.cpp
@@ -513,6 +513,7 @@ void CurveNetworkQuantity::buildEdgeInfoGUI(size_t edgeInd) {}
 CurveNetworkNodeColorQuantity* CurveNetwork::addNodeColorQuantityImpl(std::string name,
                                                                       const std::vector<glm::vec3>& colors) {
   checkForQuantityWithNameAndDeleteOrError(name);
+  checkColorRanges(colors);
   CurveNetworkNodeColorQuantity* q = new CurveNetworkNodeColorQuantity(name, colors, *this);
   addQuantity(q);
   return q;
@@ -521,6 +522,7 @@ CurveNetworkNodeColorQuantity* CurveNetwork::addNodeColorQuantityImpl(std::strin
 CurveNetworkEdgeColorQuantity* CurveNetwork::addEdgeColorQuantityImpl(std::string name,
                                                                       const std::vector<glm::vec3>& colors) {
   checkForQuantityWithNameAndDeleteOrError(name);
+  checkColorRanges(colors);
   CurveNetworkEdgeColorQuantity* q = new CurveNetworkEdgeColorQuantity(name, colors, *this);
   addQuantity(q);
   return q;

--- a/src/point_cloud.cpp
+++ b/src/point_cloud.cpp
@@ -436,6 +436,7 @@ void PointCloudQuantity::buildInfoGUI(size_t pointInd) {}
 
 PointCloudColorQuantity* PointCloud::addColorQuantityImpl(std::string name, const std::vector<glm::vec3>& colors) {
   checkForQuantityWithNameAndDeleteOrError(name);
+  checkColorRanges(colors);
   PointCloudColorQuantity* q = new PointCloudColorQuantity(name, colors, *this);
   addQuantity(q);
   return q;

--- a/src/surface_mesh.cpp
+++ b/src/surface_mesh.cpp
@@ -1577,6 +1577,7 @@ MeshShadeStyle SurfaceMesh::getShadeStyle() { return shadeStyle.get(); }
 SurfaceVertexColorQuantity* SurfaceMesh::addVertexColorQuantityImpl(std::string name,
                                                                     const std::vector<glm::vec3>& colors) {
   checkForQuantityWithNameAndDeleteOrError(name);
+  checkColorRanges(colors);
   SurfaceVertexColorQuantity* q = new SurfaceVertexColorQuantity(name, *this, colors);
   addQuantity(q);
   return q;
@@ -1585,6 +1586,7 @@ SurfaceVertexColorQuantity* SurfaceMesh::addVertexColorQuantityImpl(std::string 
 SurfaceFaceColorQuantity* SurfaceMesh::addFaceColorQuantityImpl(std::string name,
                                                                 const std::vector<glm::vec3>& colors) {
   checkForQuantityWithNameAndDeleteOrError(name);
+  checkColorRanges(colors);
   SurfaceFaceColorQuantity* q = new SurfaceFaceColorQuantity(name, *this, colors);
   addQuantity(q);
   return q;
@@ -1594,6 +1596,7 @@ SurfaceTextureColorQuantity*
 SurfaceMesh::addTextureColorQuantityImpl(std::string name, SurfaceParameterizationQuantity& param, size_t dimX,
                                          size_t dimY, const std::vector<glm::vec3>& colors, ImageOrigin imageOrigin) {
   checkForQuantityWithNameAndDeleteOrError(name);
+  checkColorRanges(colors);
   SurfaceTextureColorQuantity* q = new SurfaceTextureColorQuantity(name, *this, param, dimX, dimY, colors, imageOrigin);
   addQuantity(q);
   return q;

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -126,6 +126,7 @@ void checkColorRanges(const std::vector<glm::vec3>& colors) {
     for (float c : color){
       if(c<0.0 || c>1.0){
         warning("Colors should be in range [0, 1], will be clamped");
+        return;
       }
     }
   }

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -121,6 +121,16 @@ std::string prettyPrintCount(size_t count) {
   }
 }
 
+void checkColorRanges(const std::vector<glm::vec3>& colors) {
+  for (glm::vec3 color : colors){
+    for (float c : color){
+      if(c<0.0 || c>1.0){
+        warning("Colors should be in range [0, 1], will be clamped");
+      }
+    }
+  }
+}
+
 void ImGuiHelperMarker(const char* text) {
   ImGui::TextDisabled("(?)");
   if (ImGui::IsItemHovered()) {

--- a/src/volume_mesh.cpp
+++ b/src/volume_mesh.cpp
@@ -1017,6 +1017,7 @@ double VolumeMesh::getEdgeWidth() { return edgeWidth.get(); }
 VolumeMeshVertexColorQuantity* VolumeMesh::addVertexColorQuantityImpl(std::string name,
                                                                       const std::vector<glm::vec3>& colors) {
   checkForQuantityWithNameAndDeleteOrError(name);
+  checkColorRanges(colors);
   VolumeMeshVertexColorQuantity* q = new VolumeMeshVertexColorQuantity(name, *this, colors);
   addQuantity(q);
   return q;
@@ -1025,6 +1026,7 @@ VolumeMeshVertexColorQuantity* VolumeMesh::addVertexColorQuantityImpl(std::strin
 VolumeMeshCellColorQuantity* VolumeMesh::addCellColorQuantityImpl(std::string name,
                                                                   const std::vector<glm::vec3>& colors) {
   checkForQuantityWithNameAndDeleteOrError(name);
+  checkColorRanges(colors);
   VolumeMeshCellColorQuantity* q = new VolumeMeshCellColorQuantity(name, *this, colors);
   addQuantity(q);
   return q;


### PR DESCRIPTION
I encountered the problem described in #102 since I did not read the documentation carefully and I think that a warning should be shown when values are clamped, otherwise the results are not those expected (for surface meshes vertex coloring I get flat color faces instead of color gradients centered on the vertex).

I implemented an utility function to show a warning.
I am a novice of this library, so I am not sure I did everything correctly.
Also the code is not tested, but it is pretty easy.