### PR TITLE
Remove imgui_impl_opengl3 from polyscope.cpp

### DIFF
--- a/src/polyscope.cpp
+++ b/src/polyscope.cpp
@@ -20,8 +20,6 @@
 #include "nlohmann/json.hpp"
 using json = nlohmann::json;
 
-#include "backends/imgui_impl_opengl3.h"
-
 namespace polyscope {
 
 // Note: Storage for global members lives in state.cpp and options.cpp


### PR DESCRIPTION
This should cause a bug when building unit tests, since they don't rely on the opengl backend (due to `POLYSCOPE_BACKEND_OPENGL_MOCK_ENABLED`) and therefore shouldn't link to this particular imgui backend.

I'm not sure why cmake permits this, but this causes the build to break when using Bazel (which is the correct behaviour).