### PR TITLE
Fix naming conflict and missing uniform in pick program

### DIFF
--- a/src/render/opengl/shaders/texture_draw_shaders.cpp
+++ b/src/render/opengl/shaders/texture_draw_shaders.cpp
@@ -181,8 +181,8 @@ R"(
     vec2 depthRange = vec2(gl_DepthRange.near, gl_DepthRange.far);
     vec3 viewRay = fragmentViewPosition(u_viewport, depthRange, u_invProjMatrix, gl_FragCoord);
     viewRay = normalize(viewRay);
-    vec3 viewPos =  viewRay * (-1./viewRay.z*depth);
-    float fragdepth = fragDepthFromView(u_projMatrix, depthRange, viewPos);
+    vec3 renderImageTextureDraw_viewPos = viewRay * (-1./viewRay.z*depth);
+    float fragdepth = fragDepthFromView(u_projMatrix, depthRange, renderImageTextureDraw_viewPos);
     gl_FragDepth = fragdepth;
 
     
@@ -263,8 +263,8 @@ R"(
     vec2 depthRange = vec2(gl_DepthRange.near, gl_DepthRange.far);
     vec3 viewRay = fragmentViewPosition(u_viewport, depthRange, u_invProjMatrix, gl_FragCoord);
     viewRay = normalize(viewRay);
-    vec3 viewPos =  viewRay * (-1./viewRay.z*depth);
-    float fragdepth = fragDepthFromView(u_projMatrix, depthRange, viewPos);
+    vec3 plainRawRenderImageTextureDraw_viewPos = viewRay * (-1./viewRay.z*depth);
+    float fragdepth = fragDepthFromView(u_projMatrix, depthRange, plainRawRenderImageTextureDraw_viewPos);
     gl_FragDepth = fragdepth;
 
     

--- a/src/render_image_quantity_base.cpp
+++ b/src/render_image_quantity_base.cpp
@@ -92,6 +92,7 @@ void RenderImageQuantityBase::drawPickDelayed() {
   glm::mat4 P = view::getCameraPerspectiveMatrix();
   glm::mat4 Pinv = glm::inverse(P);
 
+  parent.setStructureUniforms(*pickProgram);
   pickProgram->setUniform("u_projMatrix", glm::value_ptr(P));
   pickProgram->setUniform("u_invProjMatrix", glm::value_ptr(Pinv));
   pickProgram->setUniform("u_viewport", render::engine->getCurrentViewport());


### PR DESCRIPTION
This pull request resolve a crash triggered by the following reproducer (tested on Ubuntu 24.04):

```py
import numpy as np
import polyscope as ps

def main():
    ps.set_program_name("Polyscope slice plane crash reproducer")
    ps.set_use_prefs_file(False)
    ps.set_user_gui_is_on_right_side(False)
    ps.set_verbosity(1)
    ps.set_build_default_gui_panels(False)
    ps.set_ground_plane_mode("none")
    ps.set_window_resizable(True)
    ps.set_window_size(1024, 768)

    ps.init()

    # ----------

    # 1. Slice plane (even if disabled)
    plane = ps.add_scene_slice_plane()
    plane.set_active(True)

    # 2. Raw render image quantity
    ps.add_raw_color_alpha_render_image_quantity(
        "ray_traced_img",
        depth_values=np.full((10, 10), 0.5),
        color_values=np.full((10, 10, 4), 0.5, dtype=np.float32),
        enabled=True,
    )

    # 3. Process selection
    pick_result = ps.pick(screen_coords=(15, 15))
    print(f"{pick_result=}")

    ps.show()

if __name__ == "__main__":
    main()
```