### PR TITLE
fix: Apply FOV from previously-saved JSON files

### DIFF
--- a/src/view.cpp
+++ b/src/view.cpp
@@ -1070,7 +1070,7 @@ void setViewFromJson(std::string jsonData, bool flyTo) {
     // NOTE: it's important that we do this after the mode/dir settings, as this
     // lets us do our flight
     bool viewChanged = false;
-    if (j.find("fov") == j.end()) {
+    if (j.find("fov") != j.end()) {
       newFov = j["fov"];
       viewChanged = true;
     }

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -1088,7 +1088,7 @@ void setViewFromJson(std::string jsonData, bool flyTo) {
     }
     if (viewChanged) {
       if (flyTo) {
-        startFlightTo(newViewMat, fov);
+        startFlightTo(newViewMat, newFov);
       } else {
         setCameraViewMatrix(newViewMat);
         fov = newFov;


### PR DESCRIPTION
It really bothered me that my FOV (and thus, the zoom) was not applied when loading a previously saved view JSON file. Found it was a typo in the deserialization :)

It should work for both the C++ and python functions, as long as polyscope-py gets a bump in its dependencies.