### PR TITLE
Add the ability to have a slicing plane for one structure only

### DIFF
--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -92,22 +92,34 @@ void Structure::buildUI() {
 
       // Toggle whether slice planes apply
       if (ImGui::BeginMenu("Slice planes")) {
+        if (ImGui::Button("Add slice plane")) {
+          openSlicePlaneMenu = true;
+          addSlicePlane();
+        }
+        if (ImGui::Button("...for this structure only")) {
+          openSlicePlaneMenu = true;
+          SlicePlane* plane = addSlicePlane(std::string("Slice plane of ") + this->name);
+          /* Set all structures to ignore this plane, except for this one in particular! */
+          for (auto const& supermap: state::structures) {
+            for (auto const& map: supermap.second) {
+              map.second->setIgnoreSlicePlane(plane->name, supermap.first != this->typeName() or map.first != this->name);
+            }
+          }
+        }
+        ImGui::Separator();
+        ImGui::TextUnformatted("Applies to this structure:");
+        ImGui::Indent(20);
         if (state::slicePlanes.empty()) {
           // if there are none, show a helpful message
-          if (ImGui::Button("Add slice plane")) {
-            openSlicePlaneMenu = true;
-            addSlicePlane();
-          }
+          ImGui::TextWrapped("< none >");
         } else {
           // otherwise, show toggles for each
-          ImGui::TextUnformatted("Applies to this structure:");
-          ImGui::Indent(20);
           for (std::unique_ptr<SlicePlane>& s : state::slicePlanes) {
             bool ignorePlane = getIgnoreSlicePlane(s->name);
             if (ImGui::MenuItem(s->name.c_str(), NULL, !ignorePlane)) setIgnoreSlicePlane(s->name, !ignorePlane);
           }
-          ImGui::Indent(-20);
         }
+        ImGui::Indent(-20);
         ImGui::TextUnformatted("");
         ImGui::Separator();
         ImGui::TextUnformatted("Note: Manage slice planes in");

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -98,7 +98,7 @@ void Structure::buildUI() {
         }
         if (ImGui::Button("...for this structure only")) {
           openSlicePlaneMenu = true;
-          SlicePlane* plane = addSlicePlane(std::string("Slice plane of ") + this->name);
+          SlicePlane* plane = addSlicePlane();
           /* Set all structures to ignore this plane, except for this one in particular! */
           for (auto const& supermap: state::structures) {
             for (auto const& map: supermap.second) {

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -102,7 +102,7 @@ void Structure::buildUI() {
           /* Set all structures to ignore this plane, except for this one in particular! */
           for (auto const& supermap: state::structures) {
             for (auto const& map: supermap.second) {
-              map.second->setIgnoreSlicePlane(plane->name, supermap.first != this->typeName() or map.first != this->name);
+              map.second->setIgnoreSlicePlane(plane->name, (supermap.first != this->typeName() || map.first != this->name));
             }
           }
         }

--- a/src/structure.cpp
+++ b/src/structure.cpp
@@ -92,6 +92,8 @@ void Structure::buildUI() {
 
       // Toggle whether slice planes apply
       if (ImGui::BeginMenu("Slice planes")) {
+        /* We want to keep the menu open, as we might toggle on/off many slice planes at once. */
+        ImGui::PushItemFlag(ImGuiItemFlags_AutoClosePopups, false);
         if (ImGui::Button("Add slice plane")) {
           openSlicePlaneMenu = true;
           addSlicePlane();
@@ -125,6 +127,7 @@ void Structure::buildUI() {
         ImGui::TextUnformatted("Note: Manage slice planes in");
         ImGui::TextUnformatted("      View --> Slice Planes.");
 
+        ImGui::PopItemFlag();
         ImGui::EndMenu();
       }
 


### PR DESCRIPTION
I end up uploading tons of structures grouped into groups to `polyscope` at once, and analyze them later. When I want to hide a certain part of *one* structure, I can create a slicing plane and manually disable its effect on all structures I want to see whole, but this is time-consuming.

This PR adds the ability to add a slicing plane for one structure only, through that structure's `Options` > `Slice planes` menu in the `Structures` window. It does not change anything about the "global" slicing plane controls in `View` > `Slice Planes`.

Additionally, the buttons to add slice planes (both globally and per-structure) are now always visible in that structure's menu. I can thus quickly add structure-specific slicing planes at will even when some are already enabled.