### PR TITLE
alias return type to workaround cuda error

### DIFF
--- a/include/polyscope/scalar_quantity.h
+++ b/include/polyscope/scalar_quantity.h
@@ -11,6 +11,8 @@
 #include "polyscope/scaled_value.h"
 #include "polyscope/standardize_data_array.h"
 
+#include <utility>
+
 namespace polyscope {
 
 // Encapsulates logic which is common to all scalar quantities
@@ -50,10 +52,11 @@ public:
   std::string getColorMap();
 
   // Data limits mapped in to colormap
-  QuantityT* setMapRange(std::pair<double, double> val);
-  std::pair<double, double> getMapRange();
+  using ScalarRange = std::pair<double, double>;
+  QuantityT* setMapRange(ScalarRange val);
+  ScalarRange getMapRange();
   QuantityT* resetMapRange(); // reset to full range
-  std::pair<double, double> getDataRange();
+  ScalarRange getDataRange();
 
   // Color bar options (it is always displayed inline in the structures panel)
   QuantityT* setOnscreenColorbarEnabled(bool newEnabled);

--- a/include/polyscope/scalar_quantity.ipp
+++ b/include/polyscope/scalar_quantity.ipp
@@ -354,7 +354,7 @@ glm::vec2 ScalarQuantity<QuantityT>::getOnscreenColorbarLocation() {
 }
 
 template <typename QuantityT>
-QuantityT* ScalarQuantity<QuantityT>::setMapRange(std::pair<double, double> val) {
+QuantityT* ScalarQuantity<QuantityT>::setMapRange(ScalarRange val) {
   vizRangeMin = val.first;
   vizRangeMax = val.second;
   colorBar.colormapRange = std::pair<float, float>(vizRangeMin.get(), vizRangeMax.get());
@@ -362,11 +362,11 @@ QuantityT* ScalarQuantity<QuantityT>::setMapRange(std::pair<double, double> val)
   return &quantity;
 }
 template <typename QuantityT>
-std::pair<double, double> ScalarQuantity<QuantityT>::getMapRange() {
-  return std::pair<float, float>(vizRangeMin.get(), vizRangeMax.get());
+typename ScalarQuantity<QuantityT>::ScalarRange ScalarQuantity<QuantityT>::getMapRange() {
+  return ScalarRange(vizRangeMin.get(), vizRangeMax.get());
 }
 template <typename QuantityT>
-std::pair<double, double> ScalarQuantity<QuantityT>::getDataRange() {
+typename ScalarQuantity<QuantityT>::ScalarRange ScalarQuantity<QuantityT>::getDataRange() {
   return dataRange;
 }
 


### PR DESCRIPTION
If this file is included under CUDA 12.8 (and some others), we get an error like:

```
include/polyscope/scalar_quantity.ipp:365:1: error: no declaration matches ‘std::pair<__remove_cv(double), __remove_cv(double)> polyscope::ScalarQuantity<QuantityT>::getMapRange()’
  365 | std::pair<double, double> ScalarQuantity<QuantityT>::getMapRange() {
```

This seems to be a buggy interaction between some nvcc and host compiler versions. Aliasing the type works around the error.